### PR TITLE
refactor: replace console with logger

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useEffect, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { useLogger } from '@/utils/logger';
 
 interface ProtectedRouteProps {
   children: ReactNode;
@@ -17,12 +18,13 @@ export function ProtectedRoute({
   const { user, profile, loading } = useAuth();
   const location = useLocation();
   const [shouldRedirect, setShouldRedirect] = useState(false);
+  const logger = useLogger('ProtectedRoute');
 
   useEffect(() => {
     // Only set redirect state once when loading is complete and we have the final auth state
     if (!loading) {
       const needsRedirect = !user || !profile;
-      console.log('[ProtectedRoute] Auth check:', { user: !!user, profile: !!profile, needsRedirect, pathname: location.pathname });
+      logger.debug('Auth check', { user: !!user, profile: !!profile, needsRedirect, pathname: location.pathname });
       setShouldRedirect(needsRedirect);
     }
   }, [loading, user, profile, location.pathname]);

--- a/src/components/forms/DashboardForm.tsx
+++ b/src/components/forms/DashboardForm.tsx
@@ -15,6 +15,7 @@ import { EnhancedTooltip } from "@/components/common/EnhancedTooltip";
 import { useCalculatePrice, useSavePricing } from "@/hooks/usePricing";
 import { useAutomaticPricingUpdate } from "@/hooks/useAutomaticPricingUpdate";
 import { PRICING_CONFIG } from "@/lib/config";
+import { useLogger } from "@/utils/logger";
 import { 
   DndContext, 
   closestCenter, 
@@ -231,6 +232,7 @@ const SortableCard = ({ result, index }: SortableCardProps) => {
 
 export const DashboardForm = () => {
   const { toast } = useToast();
+  const logger = useLogger('DashboardForm');
   const [selectedProductId, setSelectedProductId] = useState<string>("");
   const [selectedMarketplaces, setSelectedMarketplaces] = useState<string[]>([]);
   const [sortBy, setSortBy] = useState<SortOption>("margem_percentual");
@@ -340,7 +342,7 @@ export const DashboardForm = () => {
             });
           }
         } catch (error) {
-          console.error(`Erro ao recalcular marketplace ${marketplaceId}:`, error);
+          logger.error(`Erro ao recalcular marketplace ${marketplaceId}`, error);
         }
       });
 
@@ -351,7 +353,7 @@ export const DashboardForm = () => {
         description: `Preços recalculados com as configurações mais atuais para ${marketplaceIds.length} marketplace(s)`,
       });
     } catch (error) {
-      console.error('Erro durante recálculo automático:', error);
+      logger.error('Erro durante recálculo automático', error);
     } finally {
       setIsRecalculating(false);
     }
@@ -414,7 +416,7 @@ export const DashboardForm = () => {
             };
           }
         } catch (error) {
-          console.error('Erro ao calcular margem real:', error);
+          logger.error('Erro ao calcular margem real', error);
         }
       }
       

--- a/src/components/forms/PricingForm.tsx
+++ b/src/components/forms/PricingForm.tsx
@@ -11,6 +11,7 @@ import { useMarketplaces } from "@/hooks/useMarketplaces";
 import { useCalculatePrice, useCalculateMargemReal, useSavePricing } from "@/hooks/usePricing";
 import { PricingFormData } from "@/types/pricing";
 import { formatarMoeda, formatarPercentual } from "@/utils/pricing";
+import { useLogger } from "@/utils/logger";
 
 interface PricingResult {
   custo_total: number;
@@ -36,6 +37,7 @@ interface MargemRealResult {
 
 export const PricingForm = () => {
   const { toast } = useToast();
+  const logger = useLogger('PricingForm');
   const [formData, setFormData] = useState<PricingFormData>({
     product_id: "",
     marketplace_id: "",
@@ -124,7 +126,7 @@ export const PricingForm = () => {
               setMargemRealResult(margemResult as MargemRealResult);
             }
           } catch (error) {
-            console.error('Erro ao calcular margem real:', error);
+            logger.error('Erro ao calcular margem real', error);
           }
         }
         
@@ -138,7 +140,7 @@ export const PricingForm = () => {
         });
       }
     } catch (error) {
-      console.error('Erro ao calcular preço:', error);
+      logger.error('Erro ao calcular preço', error);
       toast({
         title: "Erro",
         description: "Erro ao calcular preço. Tente novamente.",
@@ -166,7 +168,7 @@ export const PricingForm = () => {
         margem_percentual: pricingResult.margem_percentual
       });
     } catch (error) {
-      console.error('Erro ao salvar precificação:', error);
+      logger.error('Erro ao salvar precificação', error);
     }
   };
 

--- a/src/hooks/useAutomaticPricingUpdate.ts
+++ b/src/hooks/useAutomaticPricingUpdate.ts
@@ -38,7 +38,7 @@ export function useAutomaticPricingUpdate() {
       });
       
     } catch (error) {
-      console.error('Erro no recálculo automático:', error);
+      logger.error('Erro no recálculo automático', 'useAutomaticPricingUpdate', error);
       toast({
         title: "Erro na atualização",
         description: "Falha ao recalcular precificações automaticamente",

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,15 +1,17 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { useLogger } from "@/utils/logger";
 
 const NotFound = () => {
   const location = useLocation();
+  const logger = useLogger('NotFound');
 
   useEffect(() => {
-    console.error(
-      "404 Error: User attempted to access non-existent route:",
-      location.pathname
+    logger.error(
+      'User attempted to access non-existent route',
+      { path: location.pathname }
     );
-  }, [location.pathname]);
+  }, [location.pathname, logger]);
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-100">

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,6 +1,7 @@
 import { supabase } from "@/integrations/supabase/client";
 import { BaseService } from "./base";
 import { Profile } from "@/types/auth";
+import { logger } from "@/utils/logger";
 
 export class AuthService extends BaseService<Profile> {
   constructor() {
@@ -47,7 +48,7 @@ export class AuthService extends BaseService<Profile> {
       .single();
 
     if (error) {
-      console.error('Error fetching profile:', error);
+      logger.error('Error fetching profile', 'AuthService', error);
       return null;
     }
 

--- a/src/services/pricing.ts
+++ b/src/services/pricing.ts
@@ -149,7 +149,7 @@ export class PricingService extends BaseService<SavedPricingType> {
           logger.debug(`Precificação atualizada: ${pricing.products?.name} - ${pricing.marketplaces?.name}`, 'PricingService');
           
         } catch (error) {
-          console.error(`Erro ao recalcular precificação para produto ${pricing.product_id}:`, error);
+          logger.error(`Erro ao recalcular precificação para produto ${pricing.product_id}`, 'PricingService', error);
           errorCount++;
         }
       }
@@ -158,7 +158,7 @@ export class PricingService extends BaseService<SavedPricingType> {
       return { updated: updatedCount, errors: errorCount };
       
     } catch (error) {
-      console.error('Erro geral no recálculo automático:', error);
+      logger.error('Erro geral no recálculo automático', 'PricingService', error);
       throw new Error('Falha no recálculo automático das precificações');
     }
   }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,5 @@
+import { logger } from '@/utils/logger';
+
 export class ValidationError extends Error {
   constructor(message: string) {
     super(message);
@@ -58,9 +60,8 @@ export function handleSupabaseError(error: any): string {
  * Log de erro para desenvolvimento
  */
 export function logError(error: Error, context?: string): void {
-  console.error(`[${context || 'ERROR'}]:`, {
+  logger.error(error.message, context || 'ERROR', {
     name: error.name,
-    message: error.message,
     stack: error.stack,
     timestamp: new Date().toISOString(),
   });


### PR DESCRIPTION
## Summary
- switch auth components to use structured logger
- channel auth utilities through logger instead of console
- remove remaining console statements across codebase

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 59 problems (46 errors, 13 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688e57c7d7448329b1809bf2c425a798