### PR TITLE
refactor: strengthen typings

### DIFF
--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -15,7 +15,7 @@ import { LoadingSpinner } from "./LoadingSpinner";
 export interface Column<T> {
   key: keyof T | string;
   header: string;
-  render?: (value: any, item: T) => React.ReactNode;
+  render?: (value: unknown, item: T) => React.ReactNode;
   className?: string;
 }
 

--- a/src/components/forms/FixedFeeRuleForm.tsx
+++ b/src/components/forms/FixedFeeRuleForm.tsx
@@ -50,7 +50,15 @@ const RULE_TYPES = [
 ];
 
 export const FixedFeeRuleForm = () => {
-  const [formData, setFormData] = useState({
+  interface FixedFeeRuleFormData {
+    marketplace_id: string;
+    rule_type: string;
+    range_min: string;
+    range_max: string;
+    value: string;
+  }
+
+  const [formData, setFormData] = useState<FixedFeeRuleFormData>({
     marketplace_id: "",
     rule_type: "",
     range_min: "",
@@ -91,7 +99,7 @@ export const FixedFeeRuleForm = () => {
   });
 
   const createMutation = useMutation({
-    mutationFn: async (data: any) => {
+    mutationFn: async (data: FixedFeeRuleFormData) => {
       const { error } = await supabase
         .from("marketplace_fixed_fee_rules")
         .insert([{
@@ -126,7 +134,7 @@ export const FixedFeeRuleForm = () => {
   });
 
   const updateMutation = useMutation({
-    mutationFn: async ({ id, data }: { id: string; data: any }) => {
+    mutationFn: async ({ id, data }: { id: string; data: FixedFeeRuleFormData }) => {
       const { error } = await supabase
         .from("marketplace_fixed_fee_rules")
         .update({

--- a/src/components/forms/ShippingRuleForm.tsx
+++ b/src/components/forms/ShippingRuleForm.tsx
@@ -38,7 +38,14 @@ interface Marketplace {
 }
 
 export const ShippingRuleForm = () => {
-  const [formData, setFormData] = useState({
+  interface ShippingRuleFormData {
+    product_id: string;
+    marketplace_id: string;
+    shipping_cost: string;
+    free_shipping_threshold: string;
+  }
+
+  const [formData, setFormData] = useState<ShippingRuleFormData>({
     product_id: "",
     marketplace_id: "",
     shipping_cost: "",
@@ -92,7 +99,7 @@ export const ShippingRuleForm = () => {
   });
 
   const upsertMutation = useMutation({
-    mutationFn: async (data: any) => {
+    mutationFn: async (data: ShippingRuleFormData & { id?: string }) => {
       const { error } = await supabase
         .from("shipping_rules")
         .upsert({

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -7,8 +7,8 @@ export interface SubscriptionPlan {
   price_yearly?: number;
   stripe_price_id_monthly?: string;
   stripe_price_id_yearly?: string;
-  features: any; // JSONB
-  limits: any; // JSONB
+  features: PlanFeatures; // JSONB
+  limits: UsageLimits; // JSONB
   is_active: boolean;
   sort_order: number;
   created_at: string;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,14 +1,14 @@
 /**
  * Valida se um valor é um número positivo
  */
-export function isPositiveNumber(value: any): boolean {
+export function isPositiveNumber(value: unknown): value is number {
   return typeof value === 'number' && value >= 0 && !isNaN(value);
 }
 
 /**
  * Valida se um valor é um percentual válido (0-100)
  */
-export function isValidPercentage(value: any): boolean {
+export function isValidPercentage(value: unknown): value is number {
   return isPositiveNumber(value) && value <= 100;
 }
 

--- a/tests/components/DataTable.test.tsx
+++ b/tests/components/DataTable.test.tsx
@@ -148,18 +148,21 @@ describe('DataTable Component', () => {
 
   it('deve renderizar conteúdo customizado com render function', () => {
     const customColumns = [
-      { 
-        key: 'name', 
-        header: 'Nome' 
+      {
+        key: 'name',
+        header: 'Nome'
       },
-      { 
-        key: 'status', 
+      {
+        key: 'status',
         header: 'Status',
-        render: (value: string) => (
-          <span className={value === 'active' ? 'text-green-500' : 'text-red-500'}>
-            {value.toUpperCase()}
-          </span>
-        )
+        render: (value) => {
+          const status = value as string;
+          return (
+            <span className={status === 'active' ? 'text-green-500' : 'text-red-500'}>
+              {status.toUpperCase()}
+            </span>
+          );
+        }
       },
     ];
 


### PR DESCRIPTION
## Summary
- tighten DataTable column typing
- add explicit table row interfaces for admin dashboard
- add typed form state for shipping and fixed fee rules
- type subscription plan JSON fields and validation helpers

## Testing
- `npm test` (fails: Missing script)
- `npx vitest run` (fails: Class extends value undefined is not a constructor or null)
- `npm run lint` (fails: @typescript-eslint/no-explicit-any)
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_688e5bb151048329935c957a12f9a9ac