### PR TITLE
chore: enforce no-unused-vars and clean up code

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,15 @@ export default tseslint.config(
         "warn",
         { allowConstantExport: true },
       ],
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrors: "none",
+          ignoreRestSiblings: true,
+        },
+      ],
     },
   }
 );

--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -7,7 +7,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Edit, Trash2 } from "lucide-react";
 import { EmptyState } from "./EmptyState";
 import { LoadingSpinner } from "./LoadingSpinner";

--- a/src/components/forms/CategoryForm.tsx
+++ b/src/components/forms/CategoryForm.tsx
@@ -5,7 +5,6 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { useToast } from "@/hooks/use-toast";
 import { Trash2, Edit } from "lucide-react";
 import { useCategories, useCreateCategory, useUpdateCategory, useDeleteCategory } from "@/hooks/useCategories";
 import { CategoryType, CategoryFormData } from "@/types/categories";
@@ -16,7 +15,6 @@ export const CategoryForm = () => {
     description: ""
   });
   const [editingId, setEditingId] = useState<string | null>(null);
-  const { toast } = useToast();
 
   const { data: categories = [], isLoading } = useCategories();
   const createMutation = useCreateCategory();

--- a/src/components/forms/CommissionForm.tsx
+++ b/src/components/forms/CommissionForm.tsx
@@ -6,7 +6,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useToast } from "@/hooks/use-toast";
 import { Trash2, Edit, Info } from "lucide-react";
 import { useMarketplaces } from "@/hooks/useMarketplaces";
 import { useCategories } from "@/hooks/useCategories";
@@ -22,7 +21,6 @@ export const CommissionForm = () => {
     rate: 0
   });
   const [editingId, setEditingId] = useState<string | null>(null);
-  const { toast } = useToast();
 
   const { data: marketplaces = [] } = useMarketplaces();
   const { data: categories = [] } = useCategories();

--- a/src/components/forms/DashboardForm.tsx
+++ b/src/components/forms/DashboardForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -274,7 +274,7 @@ export const DashboardForm = () => {
   });
 
   // Fetch saved pricing for selected product and marketplaces
-  const { data: savedPricings = [], isLoading: loadingSavedPricings } = useQuery({
+  const { data: savedPricings = [], isLoading: loadingSavedPricings } = useQuery<SavedPricing[]>({
     queryKey: ["saved-pricing", selectedProductId, selectedMarketplaces],
     queryFn: async () => {
       if (!selectedProductId || selectedMarketplaces.length === 0) return [];

--- a/src/components/forms/MarketplaceForm.tsx
+++ b/src/components/forms/MarketplaceForm.tsx
@@ -5,9 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { useToast } from "@/hooks/use-toast";
 import { Trash2, Edit, ChevronRight } from "lucide-react";
 import { useMarketplacesHierarchical, useMarketplaceParents, useCreateMarketplace, useUpdateMarketplace, useDeleteMarketplace } from "@/hooks/useMarketplaces";
 import { MarketplaceType, MarketplaceFormData } from "@/types/marketplaces";
@@ -21,7 +19,6 @@ export const MarketplaceForm = () => {
     parent_marketplace_id: null
   });
   const [editingId, setEditingId] = useState<string | null>(null);
-  const { toast } = useToast();
 
   const { data: hierarchicalMarketplaces = [], isLoading } = useMarketplacesHierarchical();
   const { data: parentMarketplaces = [] } = useMarketplaceParents();

--- a/src/components/forms/ProductForm.tsx
+++ b/src/components/forms/ProductForm.tsx
@@ -6,7 +6,6 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { useToast } from "@/hooks/use-toast";
 import { Trash2, Edit } from "lucide-react";
 import { useProductsWithCategories, useCreateProduct, useUpdateProduct, useDeleteProduct } from "@/hooks/useProducts";
 import { useCategories } from "@/hooks/useCategories";
@@ -24,7 +23,6 @@ export const ProductForm = () => {
     tax_rate: 0
   });
   const [editingId, setEditingId] = useState<string | null>(null);
-  const { toast } = useToast();
 
   const { data: categories = [] } = useCategories();
   const { data: products = [], isLoading } = useProductsWithCategories();

--- a/src/components/forms/SalesForm.tsx
+++ b/src/components/forms/SalesForm.tsx
@@ -5,7 +5,6 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { useToast } from "@/hooks/use-toast";
 import { Trash2, Edit } from "lucide-react";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
@@ -24,7 +23,6 @@ export const SalesForm = () => {
     sold_at: new Date().toISOString()
   });
   const [editingId, setEditingId] = useState<string | null>(null);
-  const { toast } = useToast();
 
   const { data: products = [] } = useProducts();
   const { data: marketplaces = [] } = useMarketplaces();

--- a/src/components/forms/StrategyForm.tsx
+++ b/src/components/forms/StrategyForm.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { TrendingUp, TrendingDown, BarChart3, Target, Package, PieChart, ScatterChart, AlertTriangle, Star } from "lucide-react";
+import { TrendingUp, BarChart3, Target, Package, PieChart, ScatterChart, AlertTriangle, Star } from "lucide-react";
 import { EnhancedTooltip } from "@/components/common/EnhancedTooltip";
 import { QuadrantScatterChart } from "@/components/charts/QuadrantScatterChart";
 import { QuadrantDonutChart } from "@/components/charts/QuadrantDonutChart";

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,7 +1,7 @@
 import { Search, Bell, User, LogOut, Settings, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Badge } from "@/components/ui/badge";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -1,19 +1,17 @@
 import { 
-  LayoutDashboard, 
-  Target, 
-  Store, 
-  FolderOpen, 
-  Package, 
-  Truck, 
-  Percent, 
-  DollarSign, 
-  BarChart3, 
+  LayoutDashboard,
+  Target,
+  Store,
+  FolderOpen,
+  Package,
+  Truck,
+  Percent,
+  DollarSign,
+  BarChart3,
   Calculator,
   Crown,
   Settings,
   Shield,
-  ChevronLeft,
-  ChevronRight,
   Zap,
   Activity,
   ChevronDown,
@@ -39,7 +37,6 @@ import {
   SidebarHeader,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 
 const mainMenuItems = [

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -73,13 +73,13 @@ const addToRemoveQueue = (toastId: string) => {
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
-    case "ADD_TOAST":
+    case actionTypes.ADD_TOAST:
       return {
         ...state,
         toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
       }
 
-    case "UPDATE_TOAST":
+    case actionTypes.UPDATE_TOAST:
       return {
         ...state,
         toasts: state.toasts.map((t) =>
@@ -87,7 +87,7 @@ export const reducer = (state: State, action: Action): State => {
         ),
       }
 
-    case "DISMISS_TOAST": {
+    case actionTypes.DISMISS_TOAST: {
       const { toastId } = action
 
       // ! Side effects ! - This could be extracted into a dismissToast() action,
@@ -112,7 +112,7 @@ export const reducer = (state: State, action: Action): State => {
         ),
       }
     }
-    case "REMOVE_TOAST":
+    case actionTypes.REMOVE_TOAST:
       if (action.toastId === undefined) {
         return {
           ...state,

--- a/src/hooks/useCommissions.ts
+++ b/src/hooks/useCommissions.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { commissionsService } from "@/services/commissions";
-import { CommissionFormData, CommissionType, CommissionWithDetails } from "@/types/commissions";
+import { CommissionFormData } from "@/types/commissions";
 import { useToast } from "@/hooks/use-toast";
 import { logger } from "@/utils/logger";
 

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { productsService } from "@/services/products";
-import { ProductType, ProductFormData } from "@/types/products";
+import { ProductFormData } from "@/types/products";
 import { toast } from "@/hooks/use-toast";
 
 export const PRODUCTS_QUERY_KEY = "products";

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,5 +1,4 @@
 import { useAuth } from '@/contexts/AuthContext';
-import { useSubscriptionPlans, useCurrentSubscription } from '@/hooks/useSubscription';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -6,12 +6,10 @@ import { Separator } from '@/components/ui/separator';
 import { Progress } from '@/components/ui/progress';
 import { Check, Crown, Zap, Star, ArrowRight, Infinity } from 'lucide-react';
 import { useSubscriptionPlans, useCurrentSubscription, useUsageTracking } from '@/hooks/useSubscription';
-import { useAuth } from '@/contexts/AuthContext';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { EmptyState } from '@/components/common/EmptyState';
 
 export default function Subscription() {
-  const { user } = useAuth();
   const [billingCycle, setBillingCycle] = useState<'monthly' | 'yearly'>('monthly');
   
   const { data: plans, isLoading: plansLoading } = useSubscriptionPlans();

--- a/src/services/marketplaces.ts
+++ b/src/services/marketplaces.ts
@@ -1,6 +1,6 @@
 import { supabase } from "@/integrations/supabase/client";
 import { BaseService } from "./base";
-import { MarketplaceType, MarketplaceWithChildren, MarketplaceHierarchy } from "@/types/marketplaces";
+import { MarketplaceType, MarketplaceHierarchy } from "@/types/marketplaces";
 
 export class MarketplacesService extends BaseService<MarketplaceType> {
   constructor() {

--- a/src/services/pricing.ts
+++ b/src/services/pricing.ts
@@ -1,6 +1,6 @@
 import { supabase } from "@/integrations/supabase/client";
 import { BaseService } from "./base";
-import { SavedPricingType, PricingCalculationParams, MargemRealParams } from "@/types/pricing";
+import { SavedPricingType } from "@/types/pricing";
 import { logger } from "@/utils/logger";
 
 export class PricingService extends BaseService<SavedPricingType> {
@@ -115,9 +115,8 @@ export class PricingService extends BaseService<SavedPricingType> {
           );
 
           // Calcular margem real se tiver preço praticado
-          let margemReal = null;
           if (pricing.preco_praticado > 0) {
-            margemReal = await this.calcularMargemReal(
+            await this.calcularMargemReal(
               pricing.product_id,
               pricing.marketplace_id,
               pricing.taxa_cartao,

--- a/tests/components/DataTable.test.tsx
+++ b/tests/components/DataTable.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { testUtils } from '../setup';

--- a/tests/utils/pricing.test.ts
+++ b/tests/utils/pricing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { testUtils } from '../setup';
 import { formatarMoeda, formatarPercentual, calcularMargemRealLocal, calcularMargemUnitariaLocal } from '@/utils/pricing';
 


### PR DESCRIPTION
## Summary
- enable `@typescript-eslint/no-unused-vars` rule with ignore patterns
- remove unused imports and variables across components, hooks, services, and tests

## Testing
- `npm run lint` (fails: Unexpected any, no-require-imports)
- `npm test` (fails: TypeError in services/auth, assertion formatting errors)


------
https://chatgpt.com/codex/tasks/task_e_688e758f3a8483299f2f936f941f14f7