### PR TITLE
feat: add auth redirect url env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Exemplo de variáveis de ambiente para o Catalog Maker Hub
+# URL de redirecionamento utilizada após o cadastro no Supabase Auth (sem barra final)
+VITE_AUTH_REDIRECT_URL=http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Catalog Maker Hub é uma plataforma SaaS para gestão de marketplaces e definiç
 1. Clone o repositório: `git clone <URL-do-repositório>`
 2. Acesse a pasta do projeto: `cd catalog-maker-hub`
 3. Instale as dependências: `npm install`
-4. Configure as variáveis de ambiente no arquivo `.env`
+4. Copie o arquivo `.env.example` para `.env` e ajuste as variáveis de ambiente conforme necessário
 5. Inicie o ambiente de desenvolvimento: `npm run dev`
+
+## Variáveis de Ambiente
+- `VITE_AUTH_REDIRECT_URL`: URL utilizada pelo Supabase para redirecionar o usuário após o cadastro. Caso não seja definida, o aplicativo utilizará `window.location.origin`.
 
 ## Scripts Disponíveis
 - `npm run dev` – inicia o servidor de desenvolvimento

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -17,7 +17,7 @@ export class AuthService extends BaseService<Profile> {
   }
 
   async signUp(email: string, password: string, fullName?: string) {
-    const redirectUrl = `${window.location.origin}/`;
+    const redirectUrl = `${import.meta.env.VITE_AUTH_REDIRECT_URL || window.location.origin}/`;
     
     const { data, error } = await supabase.auth.signUp({
       email,


### PR DESCRIPTION
## Summary
- add VITE_AUTH_REDIRECT_URL env variable with fallback
- document auth redirect URL env var and example file

## Testing
- `bash scripts/quality-check.sh` *(fails: Unexpected any...)*
- `npm test` *(fails: Class extends value undefined is not a constructor or null)*

------
https://chatgpt.com/codex/tasks/task_e_688e7a500e588329bc5f2e5677f3fe99