### PR TITLE
feat: add delete support for sales and shipping rules

### DIFF
--- a/src/components/forms/enhanced/SalesFormEnhanced.tsx
+++ b/src/components/forms/enhanced/SalesFormEnhanced.tsx
@@ -7,6 +7,8 @@ import { DataVisualization } from "@/components/ui/data-visualization";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { Button } from "@/components/ui/button";
 import { SalesForm } from "@/components/forms/SalesForm";
+import { useToast } from "@/hooks/use-toast";
+import { salesService } from "@/services/sales";
 
 interface Sale {
   id: string;
@@ -22,6 +24,7 @@ interface Sale {
 export function SalesFormEnhanced() {
   const [showForm, setShowForm] = useState(false);
   const [editingSale, setEditingSale] = useState<Sale | null>(null);
+  const { toast } = useToast();
 
   const { data: sales = [], isLoading, refetch } = useQuery({
     queryKey: ['sales'],
@@ -129,9 +132,22 @@ export function SalesFormEnhanced() {
     {
       label: "Excluir",
       icon: <Trash2 className="w-4 h-4" />,
-      onClick: (sale: Sale) => {
-        // TODO: Implement delete
-        console.log("Delete sale:", sale.id);
+      onClick: async (sale: Sale) => {
+        try {
+          await salesService.delete(sale.id);
+          toast({
+            title: "Sucesso",
+            description: "Venda excluída com sucesso!",
+          });
+          await refetch();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Erro ao excluir venda";
+          toast({
+            title: "Erro",
+            description: message,
+            variant: "destructive",
+          });
+        }
       },
       variant: "destructive" as const
     }

--- a/src/components/forms/enhanced/ShippingRuleFormEnhanced.tsx
+++ b/src/components/forms/enhanced/ShippingRuleFormEnhanced.tsx
@@ -7,6 +7,8 @@ import { DataVisualization } from "@/components/ui/data-visualization";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { Button } from "@/components/ui/button";
 import { ShippingRuleForm } from "@/components/forms/ShippingRuleForm";
+import { useToast } from "@/hooks/use-toast";
+import { shippingRulesService } from "@/services/shipping-rules";
 
 interface ShippingRule {
   id: string;
@@ -20,6 +22,7 @@ interface ShippingRule {
 export function ShippingRuleFormEnhanced() {
   const [showForm, setShowForm] = useState(false);
   const [editingRule, setEditingRule] = useState<ShippingRule | null>(null);
+  const { toast } = useToast();
 
   const { data: shippingRules = [], isLoading, refetch } = useQuery({
     queryKey: ['shipping-rules'],
@@ -91,9 +94,22 @@ export function ShippingRuleFormEnhanced() {
     {
       label: "Excluir",
       icon: <Trash2 className="w-4 h-4" />,
-      onClick: (rule: ShippingRule) => {
-        // TODO: Implement delete
-        console.log("Delete rule:", rule.id);
+      onClick: async (rule: ShippingRule) => {
+        try {
+          await shippingRulesService.delete(rule.id);
+          toast({
+            title: "Sucesso",
+            description: "Regra de frete excluída com sucesso!",
+          });
+          await refetch();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Erro ao excluir regra";
+          toast({
+            title: "Erro",
+            description: message,
+            variant: "destructive",
+          });
+        }
       },
       variant: "destructive" as const
     }

--- a/src/services/shipping-rules.ts
+++ b/src/services/shipping-rules.ts
@@ -1,0 +1,43 @@
+import { supabase } from "@/integrations/supabase/client";
+import { BaseService } from "./base";
+
+interface ShippingRuleType {
+  id: string;
+  product_id: string;
+  marketplace_id: string;
+  shipping_cost: number;
+}
+
+interface ShippingRuleWithDetails extends ShippingRuleType {
+  products?: { id: string; name: string; sku: string };
+  marketplaces?: { id: string; name: string };
+}
+
+export class ShippingRulesService extends BaseService<ShippingRuleType> {
+  constructor() {
+    super('shipping_rules');
+  }
+
+  async getAllWithDetails(): Promise<ShippingRuleWithDetails[]> {
+    const { data, error } = await supabase
+      .from('shipping_rules')
+      .select(`
+        *,
+        products:product_id (
+          id,
+          name,
+          sku
+        ),
+        marketplaces:marketplace_id (
+          id,
+          name
+        )
+      `)
+      .order('shipping_cost', { ascending: false });
+
+    if (error) this.handleError(error, 'Buscar regras de frete com detalhes');
+    return (data as ShippingRuleWithDetails[]) || [];
+  }
+}
+
+export const shippingRulesService = new ShippingRulesService();


### PR DESCRIPTION
## Summary
- implement service-based deletion for sales entries and shipping rules
- create shipping rules service to encapsulate CRUD operations
- remove list entries and display success or error toasts after deletion

## Testing
- `npm test -- --run` (fails: Pricing Utils > formatarMoeda)
- `npm run lint` (fails: 87 problems)


------
https://chatgpt.com/codex/tasks/task_e_688e8d0d9920832994895e62a7478a50