### PR TITLE
feat(ui): add typography tokens and components

### DIFF
--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,4 +1,5 @@
 import { PackageOpen } from "lucide-react";
+import { Heading, Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
 interface EmptyStateProps {
@@ -17,22 +18,27 @@ export function EmptyState({
   className,
 }: EmptyStateProps) {
   return (
-    <div className={cn(
-      "flex flex-col items-center justify-center py-12 px-4 text-center",
-      className
-    )}>
-      <div className="rounded-full bg-muted p-4 mb-4">
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center py-2xl px-md text-center",
+        className
+      )}
+    >
+      <div className="rounded-full bg-muted p-md mb-md">
         {icon || <PackageOpen className="h-8 w-8 text-muted-foreground" />}
       </div>
-      
-      <h3 className="text-lg font-semibold text-foreground mb-2">
+
+      <Heading variant="h3" className="text-foreground mb-sm">
         {message}
-      </h3>
-      
+      </Heading>
+
       {description && (
-        <p className="text-muted-foreground text-sm mb-6 max-w-sm">
+        <Text
+          variant="caption"
+          className="text-muted-foreground mb-lg max-w-sm"
+        >
           {description}
-        </p>
+        </Text>
       )}
       
       {action}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -3,3 +3,4 @@ export { StatusBadge } from "./status-badge";
 export { ProgressIndicator } from "./progress-indicator";
 export { SmartForm } from "./smart-form";
 export { DataVisualization } from "./data-visualization";
+export { Heading, Text } from "./typography";

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const headingVariants = cva("font-bold", {
+  variants: {
+    variant: {
+      h1: "text-h1",
+      h2: "text-h2",
+      h3: "text-h3",
+      h4: "text-h4",
+      h5: "text-h5",
+      h6: "text-h6",
+    },
+  },
+  defaultVariants: {
+    variant: "h3",
+  },
+});
+
+export interface HeadingProps
+  extends React.HTMLAttributes<HTMLHeadingElement>,
+    VariantProps<typeof headingVariants> {}
+
+export const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
+  ({ className, variant, ...props }, ref) => {
+    const Tag = (variant ?? "h3") as keyof JSX.IntrinsicElements;
+    return (
+      <Tag
+        ref={ref}
+        className={cn(headingVariants({ variant }), className)}
+        {...props}
+      />
+    );
+  }
+);
+Heading.displayName = "Heading";
+
+const textVariants = cva("", {
+  variants: {
+    variant: {
+      body: "text-body",
+      caption: "text-caption",
+    },
+  },
+  defaultVariants: {
+    variant: "body",
+  },
+});
+
+export interface TextProps
+  extends React.HTMLAttributes<HTMLParagraphElement>,
+    VariantProps<typeof textVariants> {}
+
+export const Text = React.forwardRef<HTMLParagraphElement, TextProps>(
+  ({ className, variant, ...props }, ref) => {
+    return (
+      <p ref={ref} className={cn(textVariants({ variant }), className)} {...props} />
+    );
+  }
+);
+Text.displayName = "Text";
+

--- a/src/index.css
+++ b/src/index.css
@@ -67,6 +67,24 @@ All colors MUST be HSL.
     --config-secondary: 220 13% 95%;
     --config-accent: 142 76% 36%;
     --config-warning: 38 92% 50%;
+
+    /* Typography */
+    --font-h1: 2.25rem;
+    --font-h2: 1.875rem;
+    --font-h3: 1.5rem;
+    --font-h4: 1.25rem;
+    --font-h5: 1.125rem;
+    --font-h6: 1rem;
+    --font-body: 1rem;
+    --font-caption: 0.875rem;
+
+    /* Spacing */
+    --spacing-xs: 0.25rem;
+    --spacing-sm: 0.5rem;
+    --spacing-md: 1rem;
+    --spacing-lg: 1.5rem;
+    --spacing-xl: 2rem;
+    --spacing-2xl: 3rem;
   }
 
   .dark {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { DataTable, Column } from '@/components/common/DataTable';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { Heading, Text } from '@/components/ui/typography';
 import { Crown, Users, TrendingUp, DollarSign, Activity, Settings, UserPlus, BarChart3 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
@@ -41,13 +42,13 @@ export default function AdminDashboard() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <Crown className="h-16 w-16 text-muted-foreground mx-auto mb-4" />
-          <h1 className="text-2xl font-bold text-destructive mb-2">
+          <Crown className="h-16 w-16 text-muted-foreground mx-auto mb-md" />
+          <Heading variant="h2" className="text-destructive mb-sm">
             Acesso Restrito
-          </h1>
-          <p className="text-muted-foreground">
+          </Heading>
+          <Text className="text-muted-foreground">
             Apenas super administradores podem acessar esta área.
-          </p>
+          </Text>
         </div>
       </div>
     );

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 const Categories = () => {
   return (
-    <div className="p-6">
+    <div className="p-lg">
       <Card>
         <CardHeader>
           <CardTitle>Gerenciar Categorias</CardTitle>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,26 +2,30 @@ import { DashboardForm } from "@/components/forms/DashboardForm";
 import { OnboardingTour } from "@/components/onboarding/OnboardingTour";
 import { useOnboarding } from "@/hooks/useOnboarding";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Heading, Text } from "@/components/ui/typography";
 
 const Dashboard = () => {
   const { showOnboarding, completeOnboarding, skipOnboarding } = useOnboarding();
 
   return (
     <>
-      <div className="space-y-6">
+      <div className="space-y-lg">
         {/* Page Header */}
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">
+        <div className="space-y-sm">
+          <Heading
+            variant="h1"
+            className="tracking-tight bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent"
+          >
             📊 Dashboard
-          </h1>
-          <p className="text-muted-foreground text-lg">
+          </Heading>
+          <Text className="text-muted-foreground text-h5">
             Compare preços e margens entre diferentes marketplaces para seus produtos
-          </p>
+          </Text>
         </div>
 
         {/* Main Content */}
         <Card className="shadow-card border-0 bg-gradient-subtle">
-          <CardContent className="p-6">
+          <CardContent className="p-lg">
             <DashboardForm />
           </CardContent>
         </Card>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { Heading, Text } from "@/components/ui/typography";
 import { useLogger } from "@/utils/logger";
 
 const NotFound = () => {
@@ -16,8 +17,12 @@ const NotFound = () => {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+        <Heading variant="h1" className="mb-md">
+          404
+        </Heading>
+        <Text className="text-gray-600 text-h4 mb-md">
+          Oops! Page not found
+        </Text>
         <a href="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
         </a>
@@ -27,3 +32,4 @@ const NotFound = () => {
 };
 
 export default NotFound;
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -106,11 +106,29 @@ export default {
 					}
 				}
 			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out'
-			}
-		}
-	},
-	plugins: [require("tailwindcss-animate")],
+                        animation: {
+                                'accordion-down': 'accordion-down 0.2s ease-out',
+                                'accordion-up': 'accordion-up 0.2s ease-out'
+                        },
+                        fontSize: {
+                                h1: 'var(--font-h1)',
+                                h2: 'var(--font-h2)',
+                                h3: 'var(--font-h3)',
+                                h4: 'var(--font-h4)',
+                                h5: 'var(--font-h5)',
+                                h6: 'var(--font-h6)',
+                                body: 'var(--font-body)',
+                                caption: 'var(--font-caption)'
+                        },
+                        spacing: {
+                                xs: 'var(--spacing-xs)',
+                                sm: 'var(--spacing-sm)',
+                                md: 'var(--spacing-md)',
+                                lg: 'var(--spacing-lg)',
+                                xl: 'var(--spacing-xl)',
+                                '2xl': 'var(--spacing-2xl)'
+                        }
+                }
+        },
+        plugins: [require("tailwindcss-animate")],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add font size and spacing scales to tailwind theme
- expose `--font-*` and `--spacing-*` variables
- create reusable `Heading` and `Text` components and apply across pages

## Testing
- `npm test` *(fails: Class extends value undefined is not a constructor or null; DataTable button assertions; pricing format expectations)*

------
https://chatgpt.com/codex/tasks/task_e_688edbbe8270832991bbd4d462533400