### PR TITLE
feat: add theme provider and switcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { ThemeProvider } from "@/components/theme-provider";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { SharedLayout } from "@/components/layout/SharedLayout";
@@ -25,12 +26,13 @@ const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <AuthProvider>
-          <Routes>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <AuthProvider>
+            <Routes>
             {/* Auth route - now inside AuthProvider context */}
             <Route path="/auth" element={<Auth />} />
             <Route path="/" element={<Navigate to="/dashboard" replace />} />
@@ -165,8 +167,9 @@ const App = () => (
             <Route path="*" element={<NotFound />} />
           </Routes>
         </AuthProvider>
-      </BrowserRouter>
-    </TooltipProvider>
+        </BrowserRouter>
+      </TooltipProvider>
+    </ThemeProvider>
   </QueryClientProvider>
 );
 

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
+import type { ThemeProviderProps } from "next-themes/dist/types";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}
+
+export { useTheme };

--- a/src/components/ui/theme-switcher.tsx
+++ b/src/components/ui/theme-switcher.tsx
@@ -1,0 +1,19 @@
+import { Moon, Sun } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useTheme } from "@/components/theme-provider"
+
+export function ThemeSwitcher() {
+  const { theme, setTheme } = useTheme()
+
+  const toggleTheme = () => {
+    setTheme(theme === "dark" ? "light" : "dark")
+  }
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme}>
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -123,6 +123,37 @@ All colors MUST be HSL.
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --success: 142 76% 36%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 0 0% 100%;
+    --radius: 0.75rem;
+    --gradient-primary: linear-gradient(135deg, hsl(258 56% 52%), hsl(270 56% 60%));
+    --gradient-card: linear-gradient(135deg, hsl(258 56% 52%), hsl(258 56% 45%));
+    --gradient-subtle: linear-gradient(180deg, hsl(0 0% 100%), hsl(258 56% 52% / 0.02));
+    --gradient-config: linear-gradient(135deg, hsl(258 56% 52%), hsl(270 56% 60%));
+    --shadow-elegant: 0 10px 30px -10px hsl(258 56% 52% / 0.2);
+    --shadow-card: 0 4px 20px hsl(258 56% 52% / 0.15);
+    --shadow-hover: 0 8px 25px -8px hsl(258 56% 52% / 0.25);
+    --shadow-form: 0 2px 10px hsl(258 56% 52% / 0.1);
+    --config-primary: 258 56% 52%;
+    --config-secondary: 217.2 32.6% 17.5%;
+    --config-accent: 142 76% 36%;
+    --config-warning: 38 92% 50%;
+    --font-h1: 2.25rem;
+    --font-h2: 1.875rem;
+    --font-h3: 1.5rem;
+    --font-h4: 1.25rem;
+    --font-h5: 1.125rem;
+    --font-h6: 1rem;
+    --font-body: 1rem;
+    --font-caption: 0.875rem;
+    --spacing-xs: 0.25rem;
+    --spacing-sm: 0.5rem;
+    --spacing-md: 1rem;
+    --spacing-lg: 1.5rem;
+    --spacing-xl: 2rem;
+    --spacing-2xl: 3rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- add `next-themes` based theme provider
- wrap app router with theme provider
- add theme switcher component and dark CSS variables

## Testing
- `npm test` *(fails: TypeError Class extends value undefined and assertion errors)*
- `npm run lint` *(fails: many @typescript-eslint errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688edde3b1088329b0dee14f51d62e88