### PR TITLE
refactor: use spacing tokens

### DIFF
--- a/src/components/charts/QuadrantScatterChart.tsx
+++ b/src/components/charts/QuadrantScatterChart.tsx
@@ -57,7 +57,7 @@ export const QuadrantScatterChart: React.FC<QuadrantScatterChartProps> = ({
         <div className="bg-background border rounded-lg shadow-elegant p-3 text-sm animate-fade-in">
           <p className="font-semibold text-primary">{name}</p>
           <p className="text-muted-foreground text-xs mb-2">{marketplace}</p>
-          <div className="space-y-1">
+          <div className="space-y-xs">
             <div className="flex justify-between">
               <span>Margem:</span>
               <span className="font-medium">{y.toFixed(1)}%</span>

--- a/src/components/common/DataTable.tsx
+++ b/src/components/common/DataTable.tsx
@@ -68,7 +68,7 @@ export function DataTable<T extends { id: string }>({
   };
   if (loading) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-md">
         {(title || searchable || onCreate) && (
           <div className="flex items-center justify-between">
             {title && <h2 className="text-xl font-semibold">{title}</h2>}
@@ -95,7 +95,7 @@ export function DataTable<T extends { id: string }>({
 
   if (!filteredData.length && searchTerm) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-md">
         {(title || searchable || onCreate) && (
           <div className="flex items-center justify-between">
             {title && <h2 className="text-xl font-semibold">{title}</h2>}
@@ -130,7 +130,7 @@ export function DataTable<T extends { id: string }>({
 
   if (!data.length) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-md">
         {(title || searchable || onCreate) && (
           <div className="flex items-center justify-between">
             {title && <h2 className="text-xl font-semibold">{title}</h2>}
@@ -168,7 +168,7 @@ export function DataTable<T extends { id: string }>({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-md">
       {/* Header with title, search and actions */}
       {(title || searchable || onCreate) && (
         <div className="flex items-center justify-between">

--- a/src/components/common/EnhancedTooltip.tsx
+++ b/src/components/common/EnhancedTooltip.tsx
@@ -36,9 +36,9 @@ export const EnhancedTooltip: React.FC<EnhancedTooltipProps> = ({
         {children}
       </TooltipTrigger>
       <TooltipContent side="top" className="max-w-64">
-        <div className="space-y-2">
+        <div className="space-y-sm">
           <p className="font-medium text-sm">{title}</p>
-          <div className="space-y-1">
+          <div className="space-y-xs">
             {details.map((detail, index) => (
               <div key={index} className="flex justify-between text-xs">
                 <span className="text-muted-foreground">{detail.label}:</span>

--- a/src/components/common/FormField.tsx
+++ b/src/components/common/FormField.tsx
@@ -36,7 +36,7 @@ export function FormField({
   };
 
   return (
-    <div className={cn("space-y-2", className)}>
+    <div className={cn("space-y-sm", className)}>
       <Label htmlFor={name} className={required ? "after:content-['*'] after:text-destructive after:ml-1" : ""}>
         {label}
       </Label>

--- a/src/components/common/MiniProgressBar.tsx
+++ b/src/components/common/MiniProgressBar.tsx
@@ -20,7 +20,7 @@ export const MiniProgressBar: React.FC<MiniProgressBarProps> = ({
   const trend = isAboveTarget ? "up" : "down";
   
   return (
-    <div className={`space-y-1 ${className}`}>
+    <div className={`space-y-xs ${className}`}>
       <div className="flex items-center justify-between text-xs">
         {label && <span className="text-muted-foreground">{label}</span>}
         <div className="flex items-center gap-1">

--- a/src/components/common/SkeletonLoaders.tsx
+++ b/src/components/common/SkeletonLoaders.tsx
@@ -7,7 +7,7 @@ interface SkeletonTableProps {
 
 export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-md">
       {/* Header skeleton */}
       <div className="flex items-center justify-between">
         <Skeleton className="h-6 w-48" />
@@ -20,7 +20,7 @@ export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
       {/* Table skeleton */}
       <div className="rounded-lg border border-border/50 overflow-hidden">
         {/* Table header */}
-        <div className="bg-muted/50 p-4 border-b">
+        <div className="bg-muted/50 p-md border-b">
           <div className="grid gap-4" style={{ gridTemplateColumns: `repeat(${columns}, 1fr) auto` }}>
             {Array.from({ length: columns }).map((_, i) => (
               <Skeleton key={i} className="h-4 w-20" />
@@ -32,7 +32,7 @@ export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
         {/* Table rows */}
         <div className="space-y-0">
           {Array.from({ length: rows }).map((_, rowIndex) => (
-            <div key={rowIndex} className="p-4 border-b last:border-b-0">
+            <div key={rowIndex} className="p-md border-b last:border-b-0">
               <div className="grid gap-4" style={{ gridTemplateColumns: `repeat(${columns}, 1fr) auto` }}>
                 {Array.from({ length: columns }).map((_, colIndex) => (
                   <Skeleton key={colIndex} className="h-4 w-full" />
@@ -54,21 +54,21 @@ interface SkeletonFormProps {
 
 export function SkeletonForm({ sections = 2, fieldsPerSection = 3 }: SkeletonFormProps) {
   return (
-    <div className="space-y-8">
+    <div className="space-y-xl">
       <div className="rounded-lg border border-border/50 overflow-hidden">
         {/* Header */}
-        <div className="bg-gradient-primary p-6">
+        <div className="bg-gradient-primary p-lg">
           <Skeleton className="h-6 w-48 bg-white/20" />
         </div>
         
         {/* Form content */}
-        <div className="p-6 space-y-6">
+        <div className="p-lg space-y-lg">
           {Array.from({ length: sections }).map((_, sectionIndex) => (
-            <div key={sectionIndex} className="space-y-4">
+            <div key={sectionIndex} className="space-y-md">
               <Skeleton className="h-5 w-32" />
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {Array.from({ length: fieldsPerSection }).map((_, fieldIndex) => (
-                  <div key={fieldIndex} className="space-y-2">
+                  <div key={fieldIndex} className="space-y-sm">
                     <Skeleton className="h-4 w-20" />
                     <Skeleton className="h-10 w-full" />
                   </div>
@@ -94,9 +94,9 @@ interface SkeletonCardProps {
 
 export function SkeletonCard({ count = 1 }: SkeletonCardProps) {
   return (
-    <div className="space-y-4">
+    <div className="space-y-md">
       {Array.from({ length: count }).map((_, index) => (
-        <div key={index} className="rounded-lg border border-border/50 p-6 space-y-4">
+        <div key={index} className="rounded-lg border border-border/50 p-lg space-y-md">
           <div className="flex items-center justify-between">
             <Skeleton className="h-6 w-48" />
             <Skeleton className="h-8 w-8 rounded" />

--- a/src/components/forms/CategoryForm.tsx
+++ b/src/components/forms/CategoryForm.tsx
@@ -134,7 +134,7 @@ export const CategoryForm = () => {
   ];
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-xl">
       {/* Form Section */}
       <Card className="shadow-form border border-border/50">
         <CardHeader className="bg-gradient-primary text-white rounded-t-lg">
@@ -143,10 +143,10 @@ export const CategoryForm = () => {
             {editingId ? "✏️ Editar Categoria" : "➕ Nova Categoria"}
           </CardTitle>
         </CardHeader>
-        <CardContent className="space-y-6 p-6">
-          <form onSubmit={handleSubmit} className="space-y-6">
+        <CardContent className="space-y-lg p-lg">
+          <form onSubmit={handleSubmit} className="space-y-lg">
             {/* Seção de Informações */}
-            <div className="space-y-4">
+            <div className="space-y-md">
               <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
                 📂 Informações da Categoria
               </h3>

--- a/src/components/forms/CommissionForm.tsx
+++ b/src/components/forms/CommissionForm.tsx
@@ -66,13 +66,13 @@ export const CommissionForm = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-lg">
       <Card>
         <CardHeader>
           <CardTitle>{editingId ? "Editar Comissão" : "Nova Comissão"}</CardTitle>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-md">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="marketplace">Marketplace *</Label>

--- a/src/components/forms/DashboardForm.tsx
+++ b/src/components/forms/DashboardForm.tsx
@@ -172,7 +172,7 @@ const SortableCard = ({ result, index }: SortableCardProps) => {
         />
         
         <div className="grid grid-cols-2 gap-3 text-sm">
-          <div className="space-y-1">
+          <div className="space-y-xs">
             <div className="flex items-center gap-1 text-muted-foreground">
               <Package className="h-3 w-3" />
               <span>Custo Total</span>
@@ -180,7 +180,7 @@ const SortableCard = ({ result, index }: SortableCardProps) => {
             <div className="font-medium">R$ {result.custo_total.toFixed(2)}</div>
           </div>
           
-          <div className="space-y-1">
+          <div className="space-y-xs">
             <div className="flex items-center gap-1 text-muted-foreground">
               <DollarSign className="h-3 w-3" />
               <span>Preço Praticado</span>
@@ -188,7 +188,7 @@ const SortableCard = ({ result, index }: SortableCardProps) => {
             <div className="font-bold text-lg">R$ {result.preco_praticado.toFixed(2)}</div>
           </div>
           
-          <div className="space-y-1">
+          <div className="space-y-xs">
             <div className="flex items-center gap-1 text-muted-foreground">
               <TrendingUp className="h-3 w-3" />
               <span>Margem R$</span>
@@ -196,7 +196,7 @@ const SortableCard = ({ result, index }: SortableCardProps) => {
             <div className="font-semibold text-success">R$ {result.margem_unitaria.toFixed(2)}</div>
           </div>
           
-          <div className="space-y-1">
+          <div className="space-y-xs">
             <div className="flex items-center gap-1 text-muted-foreground">
               <Target className="h-3 w-3" />
               <span>Comissão</span>
@@ -217,7 +217,7 @@ const SortableCard = ({ result, index }: SortableCardProps) => {
           </div>
         </div>
         
-        <div className="pt-2 border-t border-border/30 text-xs text-muted-foreground space-y-1">
+        <div className="pt-2 border-t border-border/30 text-xs text-muted-foreground space-y-xs">
           <div className="font-medium text-foreground mb-2">Detalhamento:</div>
           <div className="grid grid-cols-2 gap-x-2 gap-y-1">
             <div>Valor Fixo: R$ {result.valor_fixo.toFixed(2)}</div>
@@ -490,7 +490,7 @@ export const DashboardForm = () => {
   const isLoading = loadingSavedPricings || isRecalculating;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-lg">
       {/* Controls */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <Card>
@@ -639,7 +639,7 @@ export const DashboardForm = () => {
 
       {/* Results */}
       {selectedProductId && selectedMarketplaces.length > 0 && (
-        <div className="space-y-4">
+        <div className="space-y-md">
           <h3 className="text-lg font-semibold">Comparação de Preços</h3>
           
           {isLoading ? (
@@ -650,7 +650,7 @@ export const DashboardForm = () => {
                     <div className="h-4 bg-muted rounded w-3/4"></div>
                   </CardHeader>
                   <CardContent>
-                    <div className="space-y-2">
+                    <div className="space-y-sm">
                       <div className="h-3 bg-muted rounded"></div>
                       <div className="h-3 bg-muted rounded w-5/6"></div>
                       <div className="h-3 bg-muted rounded w-4/6"></div>

--- a/src/components/forms/FixedFeeRuleForm.tsx
+++ b/src/components/forms/FixedFeeRuleForm.tsx
@@ -227,13 +227,13 @@ export const FixedFeeRuleForm = () => {
   const showRangeFields = formData.rule_type === "faixa" || formData.rule_type === "percentual";
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-lg">
       <Card>
         <CardHeader>
           <CardTitle>{editingId ? "Editar Taxa Fixa" : "Nova Taxa Fixa"}</CardTitle>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-md">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="marketplace">Marketplace *</Label>
@@ -260,7 +260,7 @@ export const FixedFeeRuleForm = () => {
                         <Info className="w-4 h-4 text-muted-foreground" />
                       </TooltipTrigger>
                       <TooltipContent className="max-w-sm">
-                        <div className="space-y-2">
+                        <div className="space-y-sm">
                           {RULE_TYPES.map((type) => (
                             <div key={type.value}>
                               <p className="font-medium">{type.label}:</p>

--- a/src/components/forms/MarketplaceForm.tsx
+++ b/src/components/forms/MarketplaceForm.tsx
@@ -60,13 +60,13 @@ export const MarketplaceForm = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-lg">
       <Card>
         <CardHeader>
           <CardTitle>{editingId ? "Editar Marketplace" : "Novo Marketplace"}</CardTitle>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-md">
             <div>
               <Label htmlFor="name">Nome *</Label>
               <Input
@@ -141,9 +141,9 @@ export const MarketplaceForm = () => {
           {isLoading ? (
             <p>Carregando...</p>
           ) : (
-            <div className="space-y-4">
+            <div className="space-y-md">
               {hierarchicalMarketplaces.map((hierarchy) => (
-                <div key={hierarchy.parent.id} className="border rounded-lg p-4">
+                <div key={hierarchy.parent.id} className="border rounded-lg p-md">
                   <div className="flex items-center justify-between mb-2">
                     <div className="flex items-center gap-2">
                       <h3 className="font-semibold text-lg">{hierarchy.parent.name}</h3>
@@ -179,7 +179,7 @@ export const MarketplaceForm = () => {
                   </p>
                   
                   {hierarchy.children.length > 0 && (
-                    <div className="ml-4 space-y-2">
+                    <div className="ml-4 space-y-sm">
                       {hierarchy.children.map((child) => (
                         <div key={child.id} className="flex items-center justify-between p-3 bg-muted rounded-md">
                           <div className="flex items-center gap-2">

--- a/src/components/forms/PricingForm.tsx
+++ b/src/components/forms/PricingForm.tsx
@@ -179,9 +179,9 @@ export const PricingForm = () => {
         <CardHeader className="bg-gradient-primary text-white rounded-t-lg">
           <CardTitle className="text-xl">📊 Calculadora de Preços</CardTitle>
         </CardHeader>
-        <CardContent className="space-y-6 p-6">
+        <CardContent className="space-y-lg p-lg">
           {/* Seção de Seleção */}
-          <div className="space-y-4">
+          <div className="space-y-md">
             <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
               🎯 Seleção de Produto e Marketplace
             </h3>
@@ -253,7 +253,7 @@ export const PricingForm = () => {
           </div>
 
           {/* Seção de Configurações */}
-          <div className="space-y-4">
+          <div className="space-y-md">
             <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
               ⚙️ Configurações de Margem
             </h3>
@@ -297,7 +297,7 @@ export const PricingForm = () => {
           </div>
 
           {/* Seção de Análise */}
-          <div className="space-y-4">
+          <div className="space-y-md">
             <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
               📈 Análise de Preço Praticado
             </h3>
@@ -343,9 +343,9 @@ export const PricingForm = () => {
         <CardHeader className="bg-gradient-card text-white rounded-t-lg">
           <CardTitle className="text-xl">📊 Resultado do Cálculo</CardTitle>
         </CardHeader>
-        <CardContent className="p-6">
+        <CardContent className="p-lg">
           {pricingResult ? (
-            <div className="space-y-4">
+            <div className="space-y-md">
               <div className="grid grid-cols-2 gap-2 text-sm">
                 <div>Produto:</div>
                 <div className="font-medium">{pricingResult.product_name || 'N/A'}</div>
@@ -383,7 +383,7 @@ export const PricingForm = () => {
               {margemRealResult && (
                 <>
                   <Separator className="my-4" />
-                  <div className="bg-muted/50 p-4 rounded-lg">
+                  <div className="bg-muted/50 p-md rounded-lg">
                     <h4 className="font-semibold mb-3 text-orange-600 dark:text-orange-400">
                       📊 Análise do Preço Praticado
                     </h4>

--- a/src/components/forms/ProductForm.tsx
+++ b/src/components/forms/ProductForm.tsx
@@ -218,7 +218,7 @@ export const ProductForm = () => {
   ];
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-xl">
       {/* Form Section */}
       <Card className="shadow-form border border-border/50">
         <CardHeader className="bg-gradient-primary text-white rounded-t-lg">
@@ -227,10 +227,10 @@ export const ProductForm = () => {
             {editingId ? "✏️ Editar Produto" : "➕ Novo Produto"}
           </CardTitle>
         </CardHeader>
-        <CardContent className="space-y-6 p-6">
-          <form onSubmit={handleSubmit} className="space-y-6">
+        <CardContent className="space-y-lg p-lg">
+          <form onSubmit={handleSubmit} className="space-y-lg">
             {/* Seção de Informações Básicas */}
-            <div className="space-y-4">
+            <div className="space-y-md">
               <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2 flex items-center gap-2">
                 📝 Informações Básicas
               </h3>
@@ -306,7 +306,7 @@ export const ProductForm = () => {
             <Separator />
 
             {/* Seção de Custos */}
-            <div className="space-y-4">
+            <div className="space-y-md">
               <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2 flex items-center gap-2">
                 💰 Configuração de Custos
               </h3>
@@ -383,7 +383,7 @@ export const ProductForm = () => {
 
               {/* Preview do custo total */}
               {custoTotal > 0 && (
-                <div className="bg-muted/50 p-4 rounded-lg border border-border/50">
+                <div className="bg-muted/50 p-md rounded-lg border border-border/50">
                   <div className="flex items-center justify-between">
                     <span className="text-sm font-medium">Custo Total:</span>
                     <span className="text-lg font-bold text-primary">

--- a/src/components/forms/SalesForm.tsx
+++ b/src/components/forms/SalesForm.tsx
@@ -81,13 +81,13 @@ export const SalesForm = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-lg">
       <Card>
         <CardHeader>
           <CardTitle>{editingId ? "Editar Venda" : "Nova Venda"}</CardTitle>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-md">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="product">Produto *</Label>

--- a/src/components/forms/ShippingRuleForm.tsx
+++ b/src/components/forms/ShippingRuleForm.tsx
@@ -228,13 +228,13 @@ export const ShippingRuleForm = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-lg">
       <Card>
         <CardHeader>
           <CardTitle>{editingId ? "Editar Regra de Frete" : "Nova Regra de Frete"}</CardTitle>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-md">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="product">Produto *</Label>

--- a/src/components/forms/StrategyForm.tsx
+++ b/src/components/forms/StrategyForm.tsx
@@ -204,7 +204,7 @@ export const StrategyForm = () => {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-lg">
       {/* Controls */}
       <Card>
         <CardHeader>
@@ -340,7 +340,7 @@ export const StrategyForm = () => {
                     <PieChart className="h-4 w-4 text-primary" />
                     Distribuição dos Quadrantes
                   </h4>
-                  <div className="rounded-lg border bg-gradient-to-br from-card to-card/50 p-4">
+                  <div className="rounded-lg border bg-gradient-to-br from-card to-card/50 p-md">
                     <QuadrantDonutChart quadrantCounts={strategyAnalysis.quadrantCounts} />
                   </div>
                 </div>
@@ -349,7 +349,7 @@ export const StrategyForm = () => {
                     <BarChart3 className="h-4 w-4 text-primary" />
                     Receita por Quadrante
                   </h4>
-                  <div className="rounded-lg border bg-gradient-to-br from-card to-card/50 p-4">
+                  <div className="rounded-lg border bg-gradient-to-br from-card to-card/50 p-md">
                     <RevenueByQuadrantChart data={strategyAnalysis.products} />
                   </div>
                 </div>
@@ -401,12 +401,12 @@ export const StrategyForm = () => {
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="pt-0">
-                    <div className="space-y-1 max-h-32 overflow-y-auto">
+                    <div className="space-y-xs max-h-32 overflow-y-auto">
                       {strategyAnalysis.products
                         .filter(p => p.quadrant === "alta_margem_baixo_giro")
                         .slice(0, 5)
                         .map((product, i) => (
-                        <div key={i} className="text-xs p-1 bg-white rounded border">
+                        <div key={i} className="text-xs p-xs bg-white rounded border">
                           <div className="font-medium truncate">{product.product_name}</div>
                           <div className="text-muted-foreground">{product.marketplace_name}</div>
                         </div>
@@ -429,12 +429,12 @@ export const StrategyForm = () => {
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="pt-0">
-                    <div className="space-y-1 max-h-32 overflow-y-auto">
+                    <div className="space-y-xs max-h-32 overflow-y-auto">
                       {strategyAnalysis.products
                         .filter(p => p.quadrant === "alta_margem_alto_giro")
                         .slice(0, 5)
                         .map((product, i) => (
-                        <div key={i} className="text-xs p-1 bg-white rounded border">
+                        <div key={i} className="text-xs p-xs bg-white rounded border">
                           <div className="font-medium truncate">{product.product_name}</div>
                           <div className="text-muted-foreground">{product.marketplace_name}</div>
                         </div>
@@ -457,12 +457,12 @@ export const StrategyForm = () => {
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="pt-0">
-                    <div className="space-y-1 max-h-32 overflow-y-auto">
+                    <div className="space-y-xs max-h-32 overflow-y-auto">
                       {strategyAnalysis.products
                         .filter(p => p.quadrant === "baixa_margem_baixo_giro")
                         .slice(0, 5)
                         .map((product, i) => (
-                        <div key={i} className="text-xs p-1 bg-white rounded border">
+                        <div key={i} className="text-xs p-xs bg-white rounded border">
                           <div className="font-medium truncate">{product.product_name}</div>
                           <div className="text-muted-foreground">{product.marketplace_name}</div>
                         </div>
@@ -485,12 +485,12 @@ export const StrategyForm = () => {
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="pt-0">
-                    <div className="space-y-1 max-h-32 overflow-y-auto">
+                    <div className="space-y-xs max-h-32 overflow-y-auto">
                       {strategyAnalysis.products
                         .filter(p => p.quadrant === "baixa_margem_alto_giro")
                         .slice(0, 5)
                         .map((product, i) => (
-                        <div key={i} className="text-xs p-1 bg-white rounded border">
+                        <div key={i} className="text-xs p-xs bg-white rounded border">
                           <div className="font-medium truncate">{product.product_name}</div>
                           <div className="text-muted-foreground">{product.marketplace_name}</div>
                         </div>
@@ -521,7 +521,7 @@ export const StrategyForm = () => {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="space-y-4">
+              <div className="space-y-md">
                 {(["alta_margem_alto_giro", "alta_margem_baixo_giro", "baixa_margem_alto_giro", "baixa_margem_baixo_giro"] as const).map((quadrant) => {
                   const products = strategyAnalysis.products.filter(p => p.quadrant === quadrant);
                   if (products.length === 0) return null;

--- a/src/components/forms/enhanced/MarketplaceFormEnhanced.tsx
+++ b/src/components/forms/enhanced/MarketplaceFormEnhanced.tsx
@@ -102,7 +102,7 @@ export function MarketplaceFormEnhanced({
       icon: <Store className="w-4 h-4" />,
       required: true,
       children: (
-        <div className="space-y-4">
+        <div className="space-y-md">
           <div>
             <Label htmlFor="name">Nome do Marketplace *</Label>
             <Input

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -72,7 +72,7 @@ export function AppHeader() {
           {/* User Profile Dropdown */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="flex items-center gap-3 h-auto p-2">
+              <Button variant="ghost" className="flex items-center gap-3 h-auto p-sm">
                 <Avatar className="w-8 h-8">
                   <AvatarFallback className="bg-primary text-primary-foreground text-sm">
                     {getUserInitials(profile?.full_name)}
@@ -91,7 +91,7 @@ export function AppHeader() {
             
             <DropdownMenuContent align="end" className="w-56">
               <DropdownMenuLabel>
-                <div className="flex flex-col space-y-1">
+                <div className="flex flex-col space-y-xs">
                   <p className="text-sm font-medium leading-none">
                     {profile?.full_name || 'Usuário'}
                   </p>

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -166,7 +166,7 @@ export function AppSidebar() {
 
   return (
     <Sidebar collapsible="icon" className="border-r-0 bg-sidebar">
-      <SidebarHeader className="p-6">
+      <SidebarHeader className="p-lg">
         <div className="flex items-center gap-3">
           <div className="w-8 h-8 bg-primary/10 rounded-lg flex items-center justify-center">
             <Zap className="w-5 h-5 text-primary" />
@@ -184,7 +184,7 @@ export function AppSidebar() {
         </div>
       </SidebarHeader>
 
-      <SidebarContent className="space-y-4">
+      <SidebarContent className="space-y-md">
         {/* Main Navigation */}
         <SidebarGroup>
           <SidebarGroupLabel className="text-sidebar-foreground/70 text-xs uppercase tracking-wider">

--- a/src/components/layout/ConfigurationHeader.tsx
+++ b/src/components/layout/ConfigurationHeader.tsx
@@ -62,7 +62,7 @@ export function ConfigurationHeader({
           <div className="flex-1">
             <div className="flex items-center gap-3 mb-2">
               {icon && (
-                <div className="p-2 bg-primary/10 rounded-lg text-primary">
+                <div className="p-sm bg-primary/10 rounded-lg text-primary">
                   {icon}
                 </div>
               )}

--- a/src/components/layout/SharedLayout.tsx
+++ b/src/components/layout/SharedLayout.tsx
@@ -24,7 +24,7 @@ export function SharedLayout({ children }: SharedLayoutProps) {
           
           {/* Main Content with improved container */}
           <main className="flex-1 overflow-auto">
-            <div className="container max-w-7xl mx-auto p-6 space-y-6">
+            <div className="container max-w-7xl mx-auto p-lg space-y-lg">
               {children}
             </div>
           </main>

--- a/src/components/onboarding/OnboardingTour.tsx
+++ b/src/components/onboarding/OnboardingTour.tsx
@@ -90,7 +90,7 @@ export function OnboardingTour({ onComplete, onSkip }: OnboardingTourProps) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-md">
       <Card className="w-full max-w-2xl">
         <CardHeader className="text-center pb-2">
           <div className="flex items-center justify-between mb-4">
@@ -114,7 +114,7 @@ export function OnboardingTour({ onComplete, onSkip }: OnboardingTourProps) {
           </CardDescription>
         </CardHeader>
 
-        <CardContent className="space-y-6">
+        <CardContent className="space-y-lg">
           {/* Steps Overview */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             {steps.map((s, index) => (

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-lg shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}
@@ -49,7 +49,7 @@ const AlertDialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
+      "flex flex-col space-y-sm text-center sm:text-left",
       className
     )}
     {...props}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  "relative w-full rounded-lg border p-md [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
   {
     variants: {
       variant: {

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -18,8 +18,8 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
       classNames={{
-        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-        month: "space-y-4",
+        months: "flex flex-col sm:flex-row space-y-md sm:space-x-4 sm:space-y-0",
+        month: "space-y-md",
         caption: "flex justify-center pt-1 relative items-center",
         caption_label: "text-sm font-medium",
         nav: "space-x-1 flex items-center",
@@ -29,7 +29,7 @@ function Calendar({
         ),
         nav_button_previous: "absolute left-1",
         nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-y-1",
+        table: "w-full border-collapse space-y-xs",
         head_row: "flex",
         head_cell:
           "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-lg", className)}
     {...props}
   />
 ))
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-lg pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -70,7 +70,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn("flex items-center p-lg pt-0", className)}
     {...props}
   />
 ))

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -87,7 +87,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      "overflow-hidden p-xs text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
       className
     )}
     {...props}

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -44,7 +44,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-xs text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -60,7 +60,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-xs text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/src/components/ui/data-visualization.tsx
+++ b/src/components/ui/data-visualization.tsx
@@ -187,7 +187,7 @@ export function DataVisualization<T extends { id: string }>({
   if (isLoading) {
     return (
       <Card className={className}>
-        <CardContent className="p-6">
+        <CardContent className="p-lg">
           <div className="text-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
             <p className="text-muted-foreground mt-2">Carregando...</p>
@@ -256,7 +256,7 @@ export function DataVisualization<T extends { id: string }>({
             </div>
           )
         ) : (
-          <div className="space-y-4">
+          <div className="space-y-md">
             {renderTableView()}
             
             {/* Pagination */}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-lg shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -58,7 +58,7 @@ const DrawerHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    className={cn("grid gap-1.5 p-md text-center sm:text-left", className)}
     {...props}
   />
 )
@@ -69,7 +69,7 @@ const DrawerFooter = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    className={cn("mt-auto flex flex-col gap-2 p-md", className)}
     {...props}
   />
 )

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -45,7 +45,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-xs text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -63,7 +63,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-xs text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -78,7 +78,7 @@ const FormItem = React.forwardRef<
 
   return (
     <FormItemContext.Provider value={{ id }}>
-      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+      <div ref={ref} className={cn("space-y-sm", className)} {...props} />
     </FormItemContext.Provider>
   )
 })

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -16,7 +16,7 @@ const HoverCardContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 w-64 rounded-md border bg-popover p-md text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -21,7 +21,7 @@ const Menubar = React.forwardRef<
   <MenubarPrimitive.Root
     ref={ref}
     className={cn(
-      "flex h-10 items-center space-x-1 rounded-md border bg-background p-1",
+      "flex h-10 items-center space-x-1 rounded-md border bg-background p-xs",
       className
     )}
     {...props}
@@ -72,7 +72,7 @@ const MenubarSubContent = React.forwardRef<
   <MenubarPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-xs text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-xs text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className
         )}
         {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 rounded-md border bg-popover p-md text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/src/components/ui/progress-indicator.tsx
+++ b/src/components/ui/progress-indicator.tsx
@@ -33,7 +33,7 @@ export function ProgressIndicator({
 
   if (!showDetails) {
     return (
-      <div className={cn("space-y-2", className)}>
+      <div className={cn("space-y-sm", className)}>
         <div className="flex items-center justify-between text-sm">
           <span className="font-medium text-foreground">
             Progresso da Configuração
@@ -51,8 +51,8 @@ export function ProgressIndicator({
 
   return (
     <Card className={className}>
-      <CardContent className="p-6">
-        <div className="space-y-4">
+      <CardContent className="p-lg">
+        <div className="space-y-md">
           <div className="flex items-center justify-between">
             <h3 className="text-lg font-semibold">Progresso da Configuração</h3>
             <span className="text-sm text-muted-foreground">
@@ -63,7 +63,7 @@ export function ProgressIndicator({
           <Progress value={progressPercentage} className="h-2" />
           
           <div className={cn(
-            "space-y-4",
+            "space-y-md",
             !isVertical && "md:grid md:grid-cols-2 md:gap-4 md:space-y-0"
           )}>
             {steps.map((step, index) => {

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -84,7 +84,7 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          "p-1 pointer-events-auto",
+          "p-xs pointer-events-auto",
           position === "popper" &&
             "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
         )}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -29,7 +29,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-50 gap-4 bg-background p-lg shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {
@@ -78,7 +78,7 @@ const SheetHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
+      "flex flex-col space-y-sm text-center sm:text-left",
       className
     )}
     {...props}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -238,7 +238,7 @@ const Sidebar = React.forwardRef<
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
             // Adjust the padding for floating and inset variants.
             variant === "floating" || variant === "inset"
-              ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
+              ? "p-sm group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"
               : "group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l",
             className
           )}
@@ -356,7 +356,7 @@ const SidebarHeader = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="header"
-      className={cn("flex flex-col gap-2 p-2", className)}
+      className={cn("flex flex-col gap-2 p-sm", className)}
       {...props}
     />
   )
@@ -371,7 +371,7 @@ const SidebarFooter = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="footer"
-      className={cn("flex flex-col gap-2 p-2", className)}
+      className={cn("flex flex-col gap-2 p-sm", className)}
       {...props}
     />
   )
@@ -419,7 +419,7 @@ const SidebarGroup = React.forwardRef<
     <div
       ref={ref}
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn("relative flex w-full min-w-0 flex-col p-sm", className)}
       {...props}
     />
   )
@@ -510,7 +510,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem"
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-sm text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-sm [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/src/components/ui/smart-form.tsx
+++ b/src/components/ui/smart-form.tsx
@@ -67,10 +67,10 @@ export function SmartForm({
         </div>
       </CardHeader>
       
-      <CardContent className="p-6">
-        <form onSubmit={onSubmit} className="space-y-6">
+      <CardContent className="p-lg">
+        <form onSubmit={onSubmit} className="space-y-lg">
           {sections.map((section, index) => (
-            <div key={section.id} className="space-y-4">
+            <div key={section.id} className="space-y-md">
               {/* Section Header */}
               <div className="flex items-center gap-2 pb-2 border-b border-border">
                 {section.icon && (

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -87,7 +87,7 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn("p-md align-middle [&:has([role=checkbox])]:pr-0", className)}
     {...props}
   />
 ))

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-xs text-muted-foreground",
       className
     )}
     {...props}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-md sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-lg pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
     variants: {
       variant: {
@@ -75,7 +75,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-xs text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className
     )}
     toast-close=""

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -266,7 +266,7 @@ export default function AdminDashboard() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         {stats.map((stat, index) => (
           <Card key={index} className="border-0 shadow-md">
-            <CardContent className="p-6">
+            <CardContent className="p-lg">
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm font-medium text-muted-foreground mb-1">
@@ -286,7 +286,7 @@ export default function AdminDashboard() {
       </div>
 
       {/* Main Content */}
-      <Tabs defaultValue="users" className="space-y-6">
+      <Tabs defaultValue="users" className="space-y-lg">
         <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="users" className="flex items-center gap-2">
             <Users className="w-4 h-4" />
@@ -302,7 +302,7 @@ export default function AdminDashboard() {
           </TabsTrigger>
         </TabsList>
 
-        <TabsContent value="users" className="space-y-6">
+        <TabsContent value="users" className="space-y-lg">
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
@@ -322,7 +322,7 @@ export default function AdminDashboard() {
           </Card>
         </TabsContent>
 
-        <TabsContent value="subscriptions" className="space-y-6">
+        <TabsContent value="subscriptions" className="space-y-lg">
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
@@ -342,7 +342,7 @@ export default function AdminDashboard() {
           </Card>
         </TabsContent>
 
-        <TabsContent value="analytics" className="space-y-6">
+        <TabsContent value="analytics" className="space-y-lg">
           <div className="grid gap-6">
             <Card>
               <CardHeader>

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -109,9 +109,9 @@ export default function Auth() {
               </TabsList>
 
               {/* Login Form */}
-              <TabsContent value="login" className="space-y-4">
-                <form onSubmit={loginForm.handleSubmit(onLogin)} className="space-y-4">
-                  <div className="space-y-2">
+              <TabsContent value="login" className="space-y-md">
+                <form onSubmit={loginForm.handleSubmit(onLogin)} className="space-y-md">
+                  <div className="space-y-sm">
                     <Label htmlFor="login-email">Email</Label>
                     <Input
                       id="login-email"
@@ -127,7 +127,7 @@ export default function Auth() {
                     )}
                   </div>
 
-                  <div className="space-y-2">
+                  <div className="space-y-sm">
                     <Label htmlFor="login-password">Senha</Label>
                     <div className="relative">
                       <Input
@@ -165,9 +165,9 @@ export default function Auth() {
               </TabsContent>
 
               {/* Sign Up Form */}
-              <TabsContent value="signup" className="space-y-4">
-                <form onSubmit={signUpForm.handleSubmit(onSignUp)} className="space-y-4">
-                  <div className="space-y-2">
+              <TabsContent value="signup" className="space-y-md">
+                <form onSubmit={signUpForm.handleSubmit(onSignUp)} className="space-y-md">
+                  <div className="space-y-sm">
                     <Label htmlFor="signup-name">Nome Completo</Label>
                     <Input
                       id="signup-name"
@@ -183,7 +183,7 @@ export default function Auth() {
                     )}
                   </div>
 
-                  <div className="space-y-2">
+                  <div className="space-y-sm">
                     <Label htmlFor="signup-company">Empresa (Opcional)</Label>
                     <Input
                       id="signup-company"
@@ -193,7 +193,7 @@ export default function Auth() {
                     />
                   </div>
 
-                  <div className="space-y-2">
+                  <div className="space-y-sm">
                     <Label htmlFor="signup-email">Email</Label>
                     <Input
                       id="signup-email"
@@ -209,7 +209,7 @@ export default function Auth() {
                     )}
                   </div>
 
-                  <div className="space-y-2">
+                  <div className="space-y-sm">
                     <Label htmlFor="signup-password">Senha</Label>
                     <div className="relative">
                       <Input
@@ -240,7 +240,7 @@ export default function Auth() {
                     )}
                   </div>
 
-                  <div className="space-y-2">
+                  <div className="space-y-sm">
                     <Label htmlFor="signup-confirm-password">Confirmar Senha</Label>
                     <Input
                       id="signup-confirm-password"

--- a/src/pages/Commissions.tsx
+++ b/src/pages/Commissions.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 const Commissions = () => {
   return (
-    <div className="p-6">
+    <div className="p-lg">
       <Card>
         <CardHeader>
           <CardTitle>Comissões</CardTitle>

--- a/src/pages/FixedFees.tsx
+++ b/src/pages/FixedFees.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 const FixedFees = () => {
   return (
-    <div className="p-6">
+    <div className="p-lg">
       <Card>
         <CardHeader>
           <CardTitle>Regras de valor fixo</CardTitle>

--- a/src/pages/Marketplaces.tsx
+++ b/src/pages/Marketplaces.tsx
@@ -3,9 +3,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 const Marketplaces = () => {
   return (
-    <div className="space-y-6">
+    <div className="space-y-lg">
       {/* Page Header */}
-      <div className="space-y-2">
+      <div className="space-y-sm">
         <h1 className="text-3xl font-bold tracking-tight">🏪 Marketplaces</h1>
         <p className="text-muted-foreground">
           Cadastre e gerencie os marketplaces onde seus produtos são vendidos
@@ -14,7 +14,7 @@ const Marketplaces = () => {
 
       {/* Main Content */}
       <Card className="shadow-card border-0 bg-gradient-subtle">
-        <CardContent className="p-6">
+        <CardContent className="p-lg">
           <MarketplaceForm />
         </CardContent>
       </Card>

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -3,9 +3,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 const Pricing = () => {
   return (
-    <div className="space-y-6">
+    <div className="space-y-lg">
       {/* Page Header */}
-      <div className="space-y-2">
+      <div className="space-y-sm">
         <h1 className="text-3xl font-bold tracking-tight">Precificação</h1>
         <p className="text-muted-foreground">
           Calcule preços sugeridos e margens de lucro para seus produtos
@@ -14,7 +14,7 @@ const Pricing = () => {
 
       {/* Main Content */}
       <Card className="shadow-card border-0 bg-gradient-subtle">
-        <CardContent className="p-6">
+        <CardContent className="p-lg">
           <PricingForm />
         </CardContent>
       </Card>

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -3,9 +3,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 const Products = () => {
   return (
-    <div className="space-y-6">
+    <div className="space-y-lg">
       {/* Page Header */}
-      <div className="space-y-2">
+      <div className="space-y-sm">
         <h1 className="text-3xl font-bold tracking-tight">📦 Produtos</h1>
         <p className="text-muted-foreground">
           Cadastre e gerencie produtos com custos, impostos e categorias
@@ -14,7 +14,7 @@ const Products = () => {
 
       {/* Main Content */}
       <Card className="shadow-card border-0 bg-gradient-subtle">
-        <CardContent className="p-6">
+        <CardContent className="p-lg">
           <ProductForm />
         </CardContent>
       </Card>

--- a/src/pages/Sales.tsx
+++ b/src/pages/Sales.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 const Sales = () => {
   return (
-    <div className="p-6">
+    <div className="p-lg">
       <Card>
         <CardHeader>
           <CardTitle>Vendas</CardTitle>

--- a/src/pages/Shipping.tsx
+++ b/src/pages/Shipping.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 const Shipping = () => {
   return (
-    <div className="p-6">
+    <div className="p-lg">
       <Card>
         <CardHeader>
           <CardTitle>Regras de Frete</CardTitle>

--- a/src/pages/Strategy.tsx
+++ b/src/pages/Strategy.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 
 const Strategy = () => {
   return (
-    <div className="p-6">
+    <div className="p-lg">
       <Card>
         <CardHeader>
           <CardTitle>Estratégia de Precificação</CardTitle>

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -115,11 +115,11 @@ export default function Subscription() {
             </CardDescription>
           </CardHeader>
           
-          <CardContent className="space-y-4">
+          <CardContent className="space-y-md">
             <h4 className="font-semibold mb-3">Uso do Período Atual</h4>
             
             {/* Products Usage */}
-            <div className="space-y-2">
+            <div className="space-y-sm">
               <div className="flex justify-between text-sm">
                 <span>Produtos</span>
                 <span>
@@ -134,7 +134,7 @@ export default function Subscription() {
             </div>
 
             {/* API Calls Usage */}
-            <div className="space-y-2">
+            <div className="space-y-sm">
               <div className="flex justify-between text-sm">
                 <span>Chamadas API</span>
                 <span>
@@ -153,7 +153,7 @@ export default function Subscription() {
 
       {/* Billing Cycle Toggle */}
       <div className="flex justify-center mb-8">
-        <div className="bg-muted p-1 rounded-lg">
+        <div className="bg-muted p-xs rounded-lg">
           <button
             onClick={() => setBillingCycle('monthly')}
             className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
@@ -223,11 +223,11 @@ export default function Subscription() {
                 </div>
               </CardHeader>
 
-              <CardContent className="space-y-4">
+              <CardContent className="space-y-md">
                 {/* Features */}
-                <div className="space-y-2">
+                <div className="space-y-sm">
                   <h4 className="font-semibold text-sm">Recursos inclusos:</h4>
-                  <ul className="space-y-1 text-sm">
+                  <ul className="space-y-xs text-sm">
                     {Object.entries(plan.features || {}).map(([feature, enabled]) => {
                       if (!enabled) return null;
                       
@@ -257,9 +257,9 @@ export default function Subscription() {
                 <Separator />
 
                 {/* Limits */}
-                <div className="space-y-2">
+                <div className="space-y-sm">
                   <h4 className="font-semibold text-sm">Limites:</h4>
-                  <ul className="space-y-1 text-sm text-muted-foreground">
+                  <ul className="space-y-xs text-sm text-muted-foreground">
                     {Object.entries(plan.limits || {}).map(([limit, value]) => {
                       const limitLabels: Record<string, string> = {
                         products: 'Produtos',

--- a/src/pages/enhanced/CommissionsEnhanced.tsx
+++ b/src/pages/enhanced/CommissionsEnhanced.tsx
@@ -141,14 +141,14 @@ const CommissionsEnhanced = () => {
       progressTotal={totalCommissions}
     >
       {/* Form Column */}
-      <div className="xl:col-span-5 space-y-6">
+      <div className="xl:col-span-5 space-y-lg">
         <CommissionFormEnhanced
           editingCommission={editingCommission}
           onCancelEdit={() => setEditingCommission(null)}
         />
         
         {/* Quick Stats Card */}
-        <div className="bg-card rounded-lg p-6 border">
+        <div className="bg-card rounded-lg p-lg border">
           <h3 className="font-semibold mb-4">Estatísticas Rápidas</h3>
           <div className="grid grid-cols-2 gap-4">
             <div className="text-center">

--- a/src/pages/enhanced/MarketplacesEnhanced.tsx
+++ b/src/pages/enhanced/MarketplacesEnhanced.tsx
@@ -127,7 +127,7 @@ const MarketplacesEnhanced = () => {
       progressTotal={totalMarketplaces}
     >
       {/* Form Column */}
-      <div className="xl:col-span-5 space-y-6">
+      <div className="xl:col-span-5 space-y-lg">
         <MarketplaceFormEnhanced 
           editingMarketplace={editingMarketplace}
           onCancelEdit={() => setEditingMarketplace(null)}


### PR DESCRIPTION
## Summary
- replace numeric padding and spacing utilities with token classes from `tailwind.config.ts`

## Testing
- `npm run lint` *(fails: Unexpected any, no-require-imports)*
- `npm test` *(fails: DataTable snapshot mismatch and other existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688f6567daa88329be8bd4ef8dcb4aa1