### PR TITLE
refactor: use typography components for page headers

### DIFF
--- a/src/pages/Marketplaces.tsx
+++ b/src/pages/Marketplaces.tsx
@@ -1,15 +1,18 @@
 import { MarketplaceForm } from "@/components/forms/MarketplaceForm";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
+import { Heading, Text } from "@/components/ui/typography";
 
 const Marketplaces = () => {
   return (
     <div className="space-y-lg">
       {/* Page Header */}
       <div className="space-y-sm">
-        <h1 className="text-3xl font-bold tracking-tight">🏪 Marketplaces</h1>
-        <p className="text-muted-foreground">
+        <Heading variant="h1" className="tracking-tight">
+          🏪 Marketplaces
+        </Heading>
+        <Text className="text-muted-foreground">
           Cadastre e gerencie os marketplaces onde seus produtos são vendidos
-        </p>
+        </Text>
       </div>
 
       {/* Main Content */}

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -1,15 +1,18 @@
 import { PricingForm } from "@/components/forms/PricingForm";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
+import { Heading, Text } from "@/components/ui/typography";
 
 const Pricing = () => {
   return (
     <div className="space-y-lg">
       {/* Page Header */}
       <div className="space-y-sm">
-        <h1 className="text-3xl font-bold tracking-tight">Precificação</h1>
-        <p className="text-muted-foreground">
+        <Heading variant="h1" className="tracking-tight">
+          Precificação
+        </Heading>
+        <Text className="text-muted-foreground">
           Calcule preços sugeridos e margens de lucro para seus produtos
-        </p>
+        </Text>
       </div>
 
       {/* Main Content */}

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,15 +1,18 @@
 import { ProductForm } from "@/components/forms/ProductForm";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
+import { Heading, Text } from "@/components/ui/typography";
 
 const Products = () => {
   return (
     <div className="space-y-lg">
       {/* Page Header */}
       <div className="space-y-sm">
-        <h1 className="text-3xl font-bold tracking-tight">📦 Produtos</h1>
-        <p className="text-muted-foreground">
+        <Heading variant="h1" className="tracking-tight">
+          📦 Produtos
+        </Heading>
+        <Text className="text-muted-foreground">
           Cadastre e gerencie produtos com custos, impostos e categorias
-        </p>
+        </Text>
       </div>
 
       {/* Main Content */}

--- a/src/pages/Sales.tsx
+++ b/src/pages/Sales.tsx
@@ -1,15 +1,21 @@
 import { SalesForm } from "@/components/forms/SalesForm";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Heading, Text } from "@/components/ui/typography";
 
 const Sales = () => {
   return (
     <div className="p-lg">
       <Card>
         <CardHeader>
-          <CardTitle>Vendas</CardTitle>
-          <CardDescription>
+          <Heading
+            variant="h3"
+            className="font-semibold leading-none tracking-tight"
+          >
+            Vendas
+          </Heading>
+          <Text className="text-sm text-muted-foreground">
             Registre vendas para cálculo de margens
-          </CardDescription>
+          </Text>
         </CardHeader>
         <CardContent>
           <SalesForm />

--- a/src/pages/Shipping.tsx
+++ b/src/pages/Shipping.tsx
@@ -1,15 +1,21 @@
 import { ShippingRuleForm } from "@/components/forms/ShippingRuleForm";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Heading, Text } from "@/components/ui/typography";
 
 const Shipping = () => {
   return (
     <div className="p-lg">
       <Card>
         <CardHeader>
-          <CardTitle>Regras de Frete</CardTitle>
-          <CardDescription>
+          <Heading
+            variant="h3"
+            className="font-semibold leading-none tracking-tight"
+          >
+            Regras de Frete
+          </Heading>
+          <Text className="text-sm text-muted-foreground">
             Configure regras de frete por produto e marketplace
-          </CardDescription>
+          </Text>
         </CardHeader>
         <CardContent>
           <ShippingRuleForm />


### PR DESCRIPTION
## Summary
- replace raw HTML headings and paragraphs with Heading/Text components across pages
- adjust typography via variant props and classes

## Testing
- `npm run lint` *(fails: Unexpected any, forbidden require import)*
- `npm test` *(fails: snapshot mismatch, unhandled service class, formatting issues)*

------
https://chatgpt.com/codex/tasks/task_e_688f6acbfa108329a5ab092358ff48f2