### PR TITLE
refactor: use configuration page layout

### DIFF
--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -1,21 +1,24 @@
 import { CategoryForm } from "@/components/forms/CategoryForm";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
+import { FolderTree } from "@/components/ui/icons";
 
 const Categories = () => {
+  const breadcrumbs = [
+    { label: "Configurações", href: "/dashboard" },
+    { label: "Categorias" }
+  ];
+
   return (
-    <div className="p-lg">
-      <Card>
-        <CardHeader>
-          <CardTitle>Gerenciar Categorias</CardTitle>
-          <CardDescription>
-            Organize seus produtos em categorias para melhor gestão
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <CategoryForm />
-        </CardContent>
-      </Card>
-    </div>
+    <ConfigurationPageLayout
+      title="Gerenciar Categorias"
+      description="Organize seus produtos em categorias para melhor gestão"
+      icon={<FolderTree className="w-6 h-6" />}
+      breadcrumbs={breadcrumbs}
+    >
+      <div className="xl:col-span-6">
+        <CategoryForm />
+      </div>
+    </ConfigurationPageLayout>
   );
 };
 

--- a/src/pages/Commissions.tsx
+++ b/src/pages/Commissions.tsx
@@ -1,21 +1,24 @@
 import { CommissionForm } from "@/components/forms/CommissionForm";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
+import { Percent } from "@/components/ui/icons";
 
 const Commissions = () => {
+  const breadcrumbs = [
+    { label: "Configurações", href: "/dashboard" },
+    { label: "Comissões" }
+  ];
+
   return (
-    <div className="p-lg">
-      <Card>
-        <CardHeader>
-          <CardTitle>Comissões</CardTitle>
-          <CardDescription>
-            Configure comissões por marketplace e categoria
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <CommissionForm />
-        </CardContent>
-      </Card>
-    </div>
+    <ConfigurationPageLayout
+      title="Comissões"
+      description="Configure comissões por marketplace e categoria"
+      icon={<Percent className="w-6 h-6" />}
+      breadcrumbs={breadcrumbs}
+    >
+      <div className="xl:col-span-6">
+        <CommissionForm />
+      </div>
+    </ConfigurationPageLayout>
   );
 };
 

--- a/src/pages/FixedFees.tsx
+++ b/src/pages/FixedFees.tsx
@@ -1,21 +1,24 @@
 import { FixedFeeRuleForm } from "@/components/forms/FixedFeeRuleForm";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
+import { Coins } from "@/components/ui/icons";
 
 const FixedFees = () => {
+  const breadcrumbs = [
+    { label: "Configurações", href: "/dashboard" },
+    { label: "Regras de valor fixo" }
+  ];
+
   return (
-    <div className="p-lg">
-      <Card>
-        <CardHeader>
-          <CardTitle>Regras de valor fixo</CardTitle>
-          <CardDescription>
-            Configure regras de valor fixo por marketplace com diferentes tipos
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <FixedFeeRuleForm />
-        </CardContent>
-      </Card>
-    </div>
+    <ConfigurationPageLayout
+      title="Regras de valor fixo"
+      description="Configure regras de valor fixo por marketplace com diferentes tipos"
+      icon={<Coins className="w-6 h-6" />}
+      breadcrumbs={breadcrumbs}
+    >
+      <div className="xl:col-span-6">
+        <FixedFeeRuleForm />
+      </div>
+    </ConfigurationPageLayout>
   );
 };
 

--- a/src/pages/Marketplaces.tsx
+++ b/src/pages/Marketplaces.tsx
@@ -1,27 +1,24 @@
 import { MarketplaceForm } from "@/components/forms/MarketplaceForm";
-import { Card, CardContent } from "@/components/ui/card";
-import { Heading, Text } from "@/components/ui/typography";
+import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
+import { Store } from "@/components/ui/icons";
 
 const Marketplaces = () => {
-  return (
-    <div className="space-y-lg">
-      {/* Page Header */}
-      <div className="space-y-sm">
-        <Heading variant="h1" className="tracking-tight">
-          🏪 Marketplaces
-        </Heading>
-        <Text className="text-muted-foreground">
-          Cadastre e gerencie os marketplaces onde seus produtos são vendidos
-        </Text>
-      </div>
+  const breadcrumbs = [
+    { label: "Configurações", href: "/dashboard" },
+    { label: "Marketplaces" }
+  ];
 
-      {/* Main Content */}
-      <Card className="shadow-card border-0 bg-gradient-subtle">
-        <CardContent className="p-lg">
-          <MarketplaceForm />
-        </CardContent>
-      </Card>
-    </div>
+  return (
+    <ConfigurationPageLayout
+      title="Gerenciar Marketplaces"
+      description="Cadastre e gerencie os marketplaces onde seus produtos são vendidos"
+      icon={<Store className="w-6 h-6" />}
+      breadcrumbs={breadcrumbs}
+    >
+      <div className="xl:col-span-6">
+        <MarketplaceForm />
+      </div>
+    </ConfigurationPageLayout>
   );
 };
 

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -1,27 +1,24 @@
 import { PricingForm } from "@/components/forms/PricingForm";
-import { Card, CardContent } from "@/components/ui/card";
-import { Heading, Text } from "@/components/ui/typography";
+import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
+import { Calculator } from "@/components/ui/icons";
 
 const Pricing = () => {
-  return (
-    <div className="space-y-lg">
-      {/* Page Header */}
-      <div className="space-y-sm">
-        <Heading variant="h1" className="tracking-tight">
-          Precificação
-        </Heading>
-        <Text className="text-muted-foreground">
-          Calcule preços sugeridos e margens de lucro para seus produtos
-        </Text>
-      </div>
+  const breadcrumbs = [
+    { label: "Configurações", href: "/dashboard" },
+    { label: "Precificação" }
+  ];
 
-      {/* Main Content */}
-      <Card className="shadow-card border-0 bg-gradient-subtle">
-        <CardContent className="p-lg">
-          <PricingForm />
-        </CardContent>
-      </Card>
-    </div>
+  return (
+    <ConfigurationPageLayout
+      title="Precificação"
+      description="Calcule preços sugeridos e margens de lucro para seus produtos"
+      icon={<Calculator className="w-6 h-6" />}
+      breadcrumbs={breadcrumbs}
+    >
+      <div className="xl:col-span-6">
+        <PricingForm />
+      </div>
+    </ConfigurationPageLayout>
   );
 };
 

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,27 +1,24 @@
 import { ProductForm } from "@/components/forms/ProductForm";
-import { Card, CardContent } from "@/components/ui/card";
-import { Heading, Text } from "@/components/ui/typography";
+import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
+import { Package } from "@/components/ui/icons";
 
 const Products = () => {
-  return (
-    <div className="space-y-lg">
-      {/* Page Header */}
-      <div className="space-y-sm">
-        <Heading variant="h1" className="tracking-tight">
-          📦 Produtos
-        </Heading>
-        <Text className="text-muted-foreground">
-          Cadastre e gerencie produtos com custos, impostos e categorias
-        </Text>
-      </div>
+  const breadcrumbs = [
+    { label: "Configurações", href: "/dashboard" },
+    { label: "Produtos" }
+  ];
 
-      {/* Main Content */}
-      <Card className="shadow-card border-0 bg-gradient-subtle">
-        <CardContent className="p-lg">
-          <ProductForm />
-        </CardContent>
-      </Card>
-    </div>
+  return (
+    <ConfigurationPageLayout
+      title="Gerenciar Produtos"
+      description="Cadastre e gerencie produtos com custos, impostos e categorias"
+      icon={<Package className="w-6 h-6" />}
+      breadcrumbs={breadcrumbs}
+    >
+      <div className="xl:col-span-6">
+        <ProductForm />
+      </div>
+    </ConfigurationPageLayout>
   );
 };
 

--- a/src/pages/Shipping.tsx
+++ b/src/pages/Shipping.tsx
@@ -1,27 +1,24 @@
 import { ShippingRuleForm } from "@/components/forms/ShippingRuleForm";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Heading, Text } from "@/components/ui/typography";
+import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
+import { Truck } from "@/components/ui/icons";
 
 const Shipping = () => {
+  const breadcrumbs = [
+    { label: "Configurações", href: "/dashboard" },
+    { label: "Regras de Frete" }
+  ];
+
   return (
-    <div className="p-lg">
-      <Card>
-        <CardHeader>
-          <Heading
-            variant="h3"
-            className="font-semibold leading-none tracking-tight"
-          >
-            Regras de Frete
-          </Heading>
-          <Text className="text-sm text-muted-foreground">
-            Configure regras de frete por produto e marketplace
-          </Text>
-        </CardHeader>
-        <CardContent>
-          <ShippingRuleForm />
-        </CardContent>
-      </Card>
-    </div>
+    <ConfigurationPageLayout
+      title="Regras de Frete"
+      description="Configure regras de frete por produto e marketplace"
+      icon={<Truck className="w-6 h-6" />}
+      breadcrumbs={breadcrumbs}
+    >
+      <div className="xl:col-span-6">
+        <ShippingRuleForm />
+      </div>
+    </ConfigurationPageLayout>
   );
 };
 


### PR DESCRIPTION
## Summary
- apply ConfigurationPageLayout across configuration pages
- pass breadcrumbs and icons via props for consistent header

## Testing
- `npm test` (fails: Class extends value undefined is not a constructor)
- `npm run lint` (fails: 59 errors, 624 warnings)


------
https://chatgpt.com/codex/tasks/task_e_688f6d9b84bc8329a6f5e859b671a87e