### PR TITLE
chore: standardize toast provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { Toaster } from "@/components/ui/toaster";
-import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
@@ -29,7 +28,6 @@ const App = () => (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <TooltipProvider>
         <Toaster />
-        <Sonner />
         <BrowserRouter>
           <AuthProvider>
             <Routes>

--- a/src/components/forms/CategoryForm.tsx
+++ b/src/components/forms/CategoryForm.tsx
@@ -9,7 +9,7 @@ import { FolderOpen, Save, X, AlertCircle, Edit, Trash2 } from '@/components/ui/
 import { useCategories, useCreateCategory, useUpdateCategory, useDeleteCategory } from "@/hooks/useCategories";
 import { CategoryType, CategoryFormData } from "@/types/categories";
 import { DataVisualization } from "@/components/ui/data-visualization";
-import { useToast } from "@/hooks/use-toast";
+import { useToast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 
 export const CategoryForm = () => {

--- a/src/components/forms/DashboardForm.tsx
+++ b/src/components/forms/DashboardForm.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { useToast } from "@/hooks/use-toast";
+import { useToast } from "@/components/ui/use-toast";
 import { Badge } from "@/components/ui/badge";
 import { ArrowUpDown, TrendingUp, TrendingDown, DollarSign, Package, Target, GripVertical, RefreshCw } from '@/components/ui/icons';
 import { Sparkline } from "@/components/ui/sparkline";

--- a/src/components/forms/FixedFeeRuleForm.tsx
+++ b/src/components/forms/FixedFeeRuleForm.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useToast } from "@/hooks/use-toast";
+import { useToast } from "@/components/ui/use-toast";
 import { Trash2, Edit, Info } from '@/components/ui/icons';
 import { handleSupabaseError } from "@/utils/errors";
 

--- a/src/components/forms/PricingForm.tsx
+++ b/src/components/forms/PricingForm.tsx
@@ -5,7 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { useToast } from "@/hooks/use-toast";
+import { useToast } from "@/components/ui/use-toast";
 import { useProducts } from "@/hooks/useProducts";
 import { useMarketplaces } from "@/hooks/useMarketplaces";
 import { useCalculatePrice, useCalculateMargemReal, useSavePricing } from "@/hooks/usePricing";

--- a/src/components/forms/ProductForm.tsx
+++ b/src/components/forms/ProductForm.tsx
@@ -13,7 +13,7 @@ import { useCategories } from "@/hooks/useCategories";
 import { ProductWithCategory, ProductFormData } from "@/types/products";
 import { formatarMoeda } from "@/utils/pricing";
 import { DataVisualization } from "@/components/ui/data-visualization";
-import { useToast } from "@/hooks/use-toast";
+import { useToast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 
 export const ProductForm = () => {

--- a/src/components/forms/ShippingRuleForm.tsx
+++ b/src/components/forms/ShippingRuleForm.tsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { useToast } from "@/hooks/use-toast";
+import { useToast } from "@/components/ui/use-toast";
 import { Trash2, Edit } from '@/components/ui/icons';
 import { handleSupabaseError } from "@/utils/errors";
 

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,4 +1,4 @@
-import { useToast } from "@/hooks/use-toast"
+import { useToast } from "@/components/ui/use-toast"
 import {
   Toast,
   ToastClose,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,7 +3,7 @@ import { User, Session } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { AuthContextType, Profile } from '@/types/auth';
 import { authService } from '@/services/auth';
-import { toast } from '@/hooks/use-toast';
+import { toast } from '@/components/ui/use-toast';
 import { useLogger } from '@/utils/logger';
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/src/hooks/useAutomaticPricingUpdate.ts
+++ b/src/hooks/useAutomaticPricingUpdate.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { pricingService } from "@/services/pricing";
-import { toast } from "@/hooks/use-toast";
+import { toast } from "@/components/ui/use-toast";
 import { useQueryClient } from "@tanstack/react-query";
 import { PRICING_QUERY_KEY } from "./usePricing";
 import { logger } from "@/utils/logger";

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { categoriesService } from "@/services/categories";
 import { CategoryFormData } from "@/types/categories";
-import { toast } from "@/hooks/use-toast";
+import { toast } from "@/components/ui/use-toast";
 
 export const CATEGORIES_QUERY_KEY = "categories";
 

--- a/src/hooks/useCommissions.ts
+++ b/src/hooks/useCommissions.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { commissionsService } from "@/services/commissions";
 import { CommissionFormData } from "@/types/commissions";
-import { useToast } from "@/hooks/use-toast";
+import { useToast } from "@/components/ui/use-toast";
 import { logger } from "@/utils/logger";
 
 const QUERY_KEYS = {

--- a/src/hooks/useMarketplaces.ts
+++ b/src/hooks/useMarketplaces.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { marketplacesService } from "@/services/marketplaces";
 import { MarketplaceFormData } from "@/types/marketplaces";
-import { toast } from "@/hooks/use-toast";
+import { toast } from "@/components/ui/use-toast";
 
 export const MARKETPLACES_QUERY_KEY = "marketplaces";
 

--- a/src/hooks/usePricing.ts
+++ b/src/hooks/usePricing.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { pricingService } from "@/services/pricing";
 import { PricingFormData, PricingCalculationParams } from "@/types/pricing";
-import { toast } from "@/hooks/use-toast";
+import { toast } from "@/components/ui/use-toast";
 
 export const PRICING_QUERY_KEY = "saved_pricing";
 

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { productsService } from "@/services/products";
 import { ProductFormData } from "@/types/products";
-import { toast } from "@/hooks/use-toast";
+import { toast } from "@/components/ui/use-toast";
 
 export const PRODUCTS_QUERY_KEY = "products";
 

--- a/src/hooks/useSales.ts
+++ b/src/hooks/useSales.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { salesService } from "@/services/sales";
 import { SaleFormData } from "@/types/sales";
-import { toast } from "@/hooks/use-toast";
+import { toast } from "@/components/ui/use-toast";
 
 export const SALES_QUERY_KEY = "sales";
 

--- a/src/hooks/useSubscription.ts
+++ b/src/hooks/useSubscription.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { subscriptionService } from '@/services/subscription';
 import { useAuth } from '@/contexts/AuthContext';
-import { toast } from '@/hooks/use-toast';
+import { toast } from '@/components/ui/use-toast';
 
 export function useSubscriptionPlans() {
   return useQuery({

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -54,7 +54,7 @@ beforeAll(() => {
   }));
 
   // Mock do toast
-  vi.doMock('@/hooks/use-toast', () => ({
+  vi.doMock('@/components/ui/use-toast', () => ({
     toast: mockToast,
     useToast: () => ({ toast: mockToast }),
   }));


### PR DESCRIPTION
## Summary
- remove Sonner component and keep Toaster as the sole toast provider
- route all toast calls through `@/components/ui/use-toast` and update tests

## Testing
- `npm test` *(fails: Class extends value undefined is not a constructor or null)*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_688f7a8e5ab483298860652625a23e30