### PR TITLE
fix: correct background color token

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@ All colors MUST be HSL.
 
 @layer base {
   :root {
-    --background: 248 250% 99%;
+    --background: 248 25% 99%;
     --foreground: 215 25% 27%;
 
     --card: 0 0% 100%;


### PR DESCRIPTION
## Summary
- ensure all :root HSL tokens stay within valid ranges
- reduce background saturation to `248 25% 99%`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f89af838083298415e7471b5214e6