### PR TITLE
refactor: centralize design tokens

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -4,9 +4,7 @@
 O design system centraliza estilos, componentes e padrões de interface para garantir consistência e escalabilidade em toda a aplicação.
 
 ## Tokens
-- **Cores**: definidos no `tailwind.config.ts` como tokens de marca e temas.
-- **Tipografia**: utiliza a família padrão do projeto com tamanhos em `rem`.
-- **Espaçamento**: valores de `spacing` do Tailwind servem como base para margens e paddings.
+- **Cores, tipografia e espaçamento**: centralizados em `src/styles/tokens.ts` e importados pelo `tailwind.config.ts` e pelos componentes que precisarem dessas variáveis.
 - **Radius**: tokens de borda preservam a identidade visual em elementos interativos.
 
 ## Componentes Base

--- a/src/components/charts/QuadrantDonutChart.tsx
+++ b/src/components/charts/QuadrantDonutChart.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { ChartTooltipProps, ChartLegendProps } from '@/types/charts';
+import { colors } from "@/styles/tokens";
 
 interface QuadrantCounts {
   alta_margem_alto_giro: number;
@@ -14,33 +15,33 @@ interface QuadrantDonutChartProps {
 }
 
 const QUADRANT_DATA = [
-  { 
-    name: "Estrelas", 
-    key: "alta_margem_alto_giro", 
-    color: "#22c55e",
+  {
+    name: "Estrelas",
+    key: "alta_margem_alto_giro",
+    color: colors.success.DEFAULT,
     emoji: "⭐",
-    description: "Alta Margem + Alto Giro"
+    description: "Alta Margem + Alto Giro",
   },
-  { 
-    name: "Joias", 
-    key: "alta_margem_baixo_giro", 
-    color: "#3b82f6",
+  {
+    name: "Joias",
+    key: "alta_margem_baixo_giro",
+    color: colors.primary.DEFAULT,
     emoji: "💎",
-    description: "Alta Margem + Baixo Giro"
+    description: "Alta Margem + Baixo Giro",
   },
-  { 
-    name: "Movimento", 
-    key: "baixa_margem_alto_giro", 
-    color: "#eab308",
+  {
+    name: "Movimento",
+    key: "baixa_margem_alto_giro",
+    color: colors.warning.DEFAULT,
     emoji: "🔄",
-    description: "Baixa Margem + Alto Giro"
+    description: "Baixa Margem + Alto Giro",
   },
-  { 
-    name: "Questionáveis", 
-    key: "baixa_margem_baixo_giro", 
-    color: "#ef4444",
+  {
+    name: "Questionáveis",
+    key: "baixa_margem_baixo_giro",
+    color: colors.destructive.DEFAULT,
     emoji: "❓",
-    description: "Baixa Margem + Baixo Giro"
+    description: "Baixa Margem + Baixo Giro",
   },
 ];
 
@@ -78,8 +79,8 @@ export const QuadrantDonutChart: React.FC<QuadrantDonutChartProps> = ({ quadrant
       <div className="flex flex-wrap justify-center gap-4 mt-4">
         {payload?.map((entry, index: number) => (
           <div key={index} className="flex items-center gap-2 text-sm">
-            <div 
-              className="w-3 h-3 rounded-full" 
+            <div
+              className="w-3 h-3 rounded-full"
               style={{ backgroundColor: entry.color }}
             />
             <span>{String(entry.payload?.emoji || '')} {entry.value}</span>

--- a/src/components/charts/QuadrantScatterChart.tsx
+++ b/src/components/charts/QuadrantScatterChart.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from "recharts";
 import { ChartTooltipProps } from '@/types/charts';
+import { colors } from "@/styles/tokens";
 
 interface ProductStrategy {
   product_id: string;
@@ -20,11 +21,16 @@ interface QuadrantScatterChartProps {
 
 const getQuadrantColor = (quadrant: ProductStrategy["quadrant"]) => {
   switch (quadrant) {
-    case "alta_margem_alto_giro": return "#22c55e"; // green
-    case "alta_margem_baixo_giro": return "#3b82f6"; // blue
-    case "baixa_margem_alto_giro": return "#eab308"; // yellow
-    case "baixa_margem_baixo_giro": return "#ef4444"; // red
-    default: return "#6b7280";
+    case "alta_margem_alto_giro":
+      return colors.success.DEFAULT;
+    case "alta_margem_baixo_giro":
+      return colors.primary.DEFAULT;
+    case "baixa_margem_alto_giro":
+      return colors.warning.DEFAULT;
+    case "baixa_margem_baixo_giro":
+      return colors.destructive.DEFAULT;
+    default:
+      return colors.muted.foreground;
   }
 };
 
@@ -107,7 +113,7 @@ export const QuadrantScatterChart: React.FC<QuadrantScatterChartProps> = ({
             y1="0%" 
             x2={`${giroLimitAlto}%`} 
             y2="100%" 
-            stroke="hsl(var(--muted-foreground))" 
+            stroke={colors.muted.foreground}
             strokeDasharray="5,5" 
             opacity={0.5}
           />
@@ -116,7 +122,7 @@ export const QuadrantScatterChart: React.FC<QuadrantScatterChartProps> = ({
             y1={`${100 - (margeLimitAlta / Math.max(...data.map(d => d.margin_percentage)) * 100)}%`} 
             x2="100%" 
             y2={`${100 - (margeLimitAlta / Math.max(...data.map(d => d.margin_percentage)) * 100)}%`} 
-            stroke="hsl(var(--muted-foreground))" 
+            stroke={colors.muted.foreground}
             strokeDasharray="5,5" 
             opacity={0.5}
           />

--- a/src/components/charts/RevenueByQuadrantChart.tsx
+++ b/src/components/charts/RevenueByQuadrantChart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from "recharts";
 import { formatarMoeda } from "@/utils/pricing";
 import { ChartTooltipProps } from '@/types/charts';
+import { colors } from "@/styles/tokens";
 
 interface ProductStrategy {
   product_id: string;
@@ -18,10 +19,10 @@ interface RevenueByQuadrantChartProps {
 }
 
 const QUADRANT_CONFIG = {
-  alta_margem_alto_giro: { name: "⭐ Estrelas", color: "#22c55e" },
-  alta_margem_baixo_giro: { name: "💎 Joias", color: "#3b82f6" },
-  baixa_margem_alto_giro: { name: "🔄 Movimento", color: "#eab308" },
-  baixa_margem_baixo_giro: { name: "❓ Questionáveis", color: "#ef4444" },
+  alta_margem_alto_giro: { name: "⭐ Estrelas", color: colors.success.DEFAULT },
+  alta_margem_baixo_giro: { name: "💎 Joias", color: colors.primary.DEFAULT },
+  baixa_margem_alto_giro: { name: "🔄 Movimento", color: colors.warning.DEFAULT },
+  baixa_margem_baixo_giro: { name: "❓ Questionáveis", color: colors.destructive.DEFAULT },
 };
 
 export const RevenueByQuadrantChart: React.FC<RevenueByQuadrantChartProps> = ({ data }) => {

--- a/src/components/forms/DashboardForm.tsx
+++ b/src/components/forms/DashboardForm.tsx
@@ -16,6 +16,7 @@ import { useCalculatePrice, useSavePricing } from "@/hooks/usePricing";
 import { useAutomaticPricingUpdate } from "@/hooks/useAutomaticPricingUpdate";
 import { PRICING_CONFIG } from "@/lib/config";
 import { useLogger } from "@/utils/logger";
+import { colors } from "@/styles/tokens";
 import { 
   DndContext, 
   closestCenter, 
@@ -157,7 +158,7 @@ const SortableCard = ({ result, index }: SortableCardProps) => {
           </div>
           <Sparkline
             data={sparklineData}
-            stroke={result.margem_percentual >= 15 ? "hsl(var(--success))" : "hsl(var(--warning))"}
+            stroke={result.margem_percentual >= 15 ? colors.success.DEFAULT : colors.warning.DEFAULT}
             size="sm"
           />
         </CardTitle>

--- a/src/components/ui/sparkline.tsx
+++ b/src/components/ui/sparkline.tsx
@@ -3,6 +3,7 @@ import { LineChart, Line, ResponsiveContainer } from "recharts"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
+import { colors } from "@/styles/tokens"
 
 const sparklineVariants = cva("", {
   variants: {
@@ -24,7 +25,7 @@ interface SparklineProps
   stroke?: string
 }
 
-function Sparkline({ data, stroke = "hsl(var(--primary))", size, className, ...props }: SparklineProps) {
+function Sparkline({ data, stroke = colors.primary.DEFAULT, size, className, ...props }: SparklineProps) {
   const chartData = data.map((value, index) => ({ value, index }))
 
   return (

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -1,0 +1,74 @@
+export const colors = {
+  border: 'hsl(var(--border))',
+  input: 'hsl(var(--input))',
+  ring: 'hsl(var(--ring))',
+  background: 'hsl(var(--background))',
+  foreground: 'hsl(var(--foreground))',
+  primary: {
+    DEFAULT: 'hsl(var(--primary))',
+    foreground: 'hsl(var(--primary-foreground))',
+  },
+  secondary: {
+    DEFAULT: 'hsl(var(--secondary))',
+    foreground: 'hsl(var(--secondary-foreground))',
+  },
+  destructive: {
+    DEFAULT: 'hsl(var(--destructive))',
+    foreground: 'hsl(var(--destructive-foreground))',
+  },
+  success: {
+    DEFAULT: 'hsl(var(--success))',
+    foreground: 'hsl(var(--success-foreground))',
+  },
+  warning: {
+    DEFAULT: 'hsl(var(--warning))',
+    foreground: 'hsl(var(--warning-foreground))',
+  },
+  muted: {
+    DEFAULT: 'hsl(var(--muted))',
+    foreground: 'hsl(var(--muted-foreground))',
+  },
+  accent: {
+    DEFAULT: 'hsl(var(--accent))',
+    foreground: 'hsl(var(--accent-foreground))',
+  },
+  popover: {
+    DEFAULT: 'hsl(var(--popover))',
+    foreground: 'hsl(var(--popover-foreground))',
+  },
+  card: {
+    DEFAULT: 'hsl(var(--card))',
+    foreground: 'hsl(var(--card-foreground))',
+  },
+  sidebar: {
+    DEFAULT: 'hsl(var(--sidebar-background))',
+    foreground: 'hsl(var(--sidebar-foreground))',
+    primary: 'hsl(var(--sidebar-primary))',
+    'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+    accent: 'hsl(var(--sidebar-accent))',
+    'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+    border: 'hsl(var(--sidebar-border))',
+    ring: 'hsl(var(--sidebar-ring))',
+  },
+} as const;
+
+export const typography = {
+  h1: 'var(--font-h1)',
+  h2: 'var(--font-h2)',
+  h3: 'var(--font-h3)',
+  h4: 'var(--font-h4)',
+  h5: 'var(--font-h5)',
+  h6: 'var(--font-h6)',
+  body: 'var(--font-body)',
+  caption: 'var(--font-caption)',
+} as const;
+
+export const spacing = {
+  xs: 'var(--spacing-xs)',
+  sm: 'var(--spacing-sm)',
+  md: 'var(--spacing-md)',
+  lg: 'var(--spacing-lg)',
+  xl: 'var(--spacing-xl)',
+  '2xl': 'var(--spacing-2xl)',
+} as const;
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import type { Config } from "tailwindcss";
 import tailwindcssAnimate from "tailwindcss-animate";
+import { colors, typography, spacing } from "./src/styles/tokens";
 
 export default {
 	darkMode: ["class"],
@@ -18,60 +19,8 @@ export default {
 				'2xl': '1400px'
 			}
 		},
-		extend: {
-			colors: {
-				border: 'hsl(var(--border))',
-				input: 'hsl(var(--input))',
-				ring: 'hsl(var(--ring))',
-				background: 'hsl(var(--background))',
-				foreground: 'hsl(var(--foreground))',
-				primary: {
-					DEFAULT: 'hsl(var(--primary))',
-					foreground: 'hsl(var(--primary-foreground))'
-				},
-				secondary: {
-					DEFAULT: 'hsl(var(--secondary))',
-					foreground: 'hsl(var(--secondary-foreground))'
-				},
-				destructive: {
-					DEFAULT: 'hsl(var(--destructive))',
-					foreground: 'hsl(var(--destructive-foreground))'
-				},
-				success: {
-					DEFAULT: 'hsl(var(--success))',
-					foreground: 'hsl(var(--success-foreground))'
-				},
-				warning: {
-					DEFAULT: 'hsl(var(--warning))',
-					foreground: 'hsl(var(--warning-foreground))'
-				},
-				muted: {
-					DEFAULT: 'hsl(var(--muted))',
-					foreground: 'hsl(var(--muted-foreground))'
-				},
-				accent: {
-					DEFAULT: 'hsl(var(--accent))',
-					foreground: 'hsl(var(--accent-foreground))'
-				},
-				popover: {
-					DEFAULT: 'hsl(var(--popover))',
-					foreground: 'hsl(var(--popover-foreground))'
-				},
-				card: {
-					DEFAULT: 'hsl(var(--card))',
-					foreground: 'hsl(var(--card-foreground))'
-				},
-				sidebar: {
-					DEFAULT: 'hsl(var(--sidebar-background))',
-					foreground: 'hsl(var(--sidebar-foreground))',
-					primary: 'hsl(var(--sidebar-primary))',
-					'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-					accent: 'hsl(var(--sidebar-accent))',
-					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-					border: 'hsl(var(--sidebar-border))',
-					ring: 'hsl(var(--sidebar-ring))'
-				}
-			},
+                extend: {
+                        colors,
 			backgroundImage: {
 				'gradient-primary': 'var(--gradient-primary)',
 				'gradient-card': 'var(--gradient-card)',
@@ -111,24 +60,8 @@ export default {
                                 'accordion-down': 'accordion-down 0.2s ease-out',
                                 'accordion-up': 'accordion-up 0.2s ease-out'
                         },
-                        fontSize: {
-                                h1: 'var(--font-h1)',
-                                h2: 'var(--font-h2)',
-                                h3: 'var(--font-h3)',
-                                h4: 'var(--font-h4)',
-                                h5: 'var(--font-h5)',
-                                h6: 'var(--font-h6)',
-                                body: 'var(--font-body)',
-                                caption: 'var(--font-caption)'
-                        },
-                        spacing: {
-                                xs: 'var(--spacing-xs)',
-                                sm: 'var(--spacing-sm)',
-                                md: 'var(--spacing-md)',
-                                lg: 'var(--spacing-lg)',
-                                xl: 'var(--spacing-xl)',
-                                '2xl': 'var(--spacing-2xl)'
-                        }
+                        fontSize: typography,
+                        spacing,
                 }
         },
         plugins: [tailwindcssAnimate],


### PR DESCRIPTION
## Summary
- centralize colors, typography and spacing tokens
- reuse tokens in Tailwind and chart components
- document new token structure

## Testing
- `npm test`
- `npm run lint` *(fails: 576 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688f8aa86cf483298b1cd7f0a876c9cd