### PR TITLE
feat: responsive sidebar with improved accessibility

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -128,6 +128,7 @@ function CollapsibleMenuGroup({ title, icon: Icon, items, collapsed, location }:
                 )}
               </>
             )}
+            {collapsed && <span className="sr-only">{title}</span>}
           </SidebarMenuButton>
         </CollapsibleTrigger>
         {!collapsed && (

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -9,7 +9,7 @@ interface MainLayoutProps {
 
 export function MainLayout({ children }: MainLayoutProps) {
   return (
-    <SidebarProvider defaultOpen={true}>
+    <SidebarProvider>
       <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         

--- a/src/components/layout/SharedLayout.tsx
+++ b/src/components/layout/SharedLayout.tsx
@@ -10,7 +10,7 @@ interface SharedLayoutProps {
 
 export function SharedLayout({ children }: SharedLayoutProps) {
   return (
-    <SidebarProvider defaultOpen={true}>
+    <SidebarProvider>
       <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -3,7 +3,7 @@ import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
-import { useIsMobile } from "@/hooks/use-mobile"
+import { useMediaQuery } from "@/hooks/use-media-query"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -65,12 +65,13 @@ const SidebarProvider = React.forwardRef<
     },
     ref
   ) => {
-    const isMobile = useIsMobile()
+    const isDesktop = useMediaQuery("(min-width: 768px)")
+    const isMobile = !isDesktop
     const [openMobile, setOpenMobile] = React.useState(false)
 
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(defaultOpen)
+    const [_open, _setOpen] = React.useState(defaultOpen ?? isDesktop)
     const open = openProp ?? _open
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
@@ -86,6 +87,14 @@ const SidebarProvider = React.forwardRef<
       },
       [setOpenProp, open]
     )
+
+    React.useEffect(() => {
+      if (!isDesktop) {
+        setOpen(false)
+      } else if (defaultOpen === undefined) {
+        setOpen(true)
+      }
+    }, [isDesktop, defaultOpen, setOpen])
 
     // Helper to toggle the sidebar.
     const toggleSidebar = React.useCallback(() => {
@@ -204,7 +213,7 @@ const Sidebar = React.forwardRef<
             }
             side={side}
           >
-            <div className="flex h-full w-full flex-col">{children}</div>
+            <nav className="flex h-full w-full flex-col">{children}</nav>
           </SheetContent>
         </Sheet>
       )
@@ -244,12 +253,12 @@ const Sidebar = React.forwardRef<
           )}
           {...props}
         >
-          <div
+          <nav
             data-sidebar="sidebar"
             className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
           >
             {children}
-          </div>
+          </nav>
         </div>
       </div>
     )

--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+export function useMediaQuery(query: string) {
+  const [matches, setMatches] = React.useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  });
+
+  React.useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+    const listener = () => setMatches(mediaQueryList.matches);
+
+    listener();
+    mediaQueryList.addEventListener("change", listener);
+    return () => mediaQueryList.removeEventListener("change", listener);
+  }, [query]);
+
+  return matches;
+}
+

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,19 +1,8 @@
-import * as React from "react"
+import { useMediaQuery } from "./use-media-query";
 
-const MOBILE_BREAKPOINT = 768
+const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
 }
+

--- a/tests/components/Sidebar.test.tsx
+++ b/tests/components/Sidebar.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ profile: null }),
+}));
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { SidebarProvider, useSidebar } from '@/components/ui/sidebar';
+import { AppSidebar } from '@/components/layout/AppSidebar';
+
+function SidebarState() {
+  const { open } = useSidebar();
+  return <div>{open ? 'open' : 'closed'}</div>;
+}
+
+describe('SidebarProvider responsive behavior', () => {
+  it('closes by default on mobile screens', () => {
+    render(
+      <SidebarProvider>
+        <SidebarState />
+      </SidebarProvider>
+    );
+
+    expect(screen.getByText('closed')).toBeInTheDocument();
+  });
+
+  it('opens by default on desktop screens', () => {
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      matches: query.includes('min-width: 768px'),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    render(
+      <SidebarProvider>
+        <SidebarState />
+      </SidebarProvider>
+    );
+
+    expect(screen.getByText('open')).toBeInTheDocument();
+    window.matchMedia = originalMatchMedia;
+  });
+});
+
+describe('AppSidebar accessibility', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      matches: query.includes('min-width: 768px'),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('provides accessible labels when collapsed', () => {
+    render(
+      <MemoryRouter>
+        <SidebarProvider defaultOpen={false}>
+          <AppSidebar />
+        </SidebarProvider>
+      </MemoryRouter>
+    );
+
+    const [configButton] = screen.getAllByRole('button', { name: /configurações/i });
+    expect(configButton).toBeInTheDocument();
+  });
+
+  it('allows keyboard navigation through items', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <SidebarProvider defaultOpen={true}>
+          <AppSidebar />
+        </SidebarProvider>
+      </MemoryRouter>
+    );
+
+    await user.tab();
+    expect(screen.getByRole('link', { name: /dashboard/i })).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole('link', { name: /estratégia/i })).toHaveFocus();
+
+    await user.tab();
+    const [configButton] = screen.getAllByRole('button', { name: /configurações/i });
+    expect(configButton).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole('link', { name: /marketplaces/i })).toHaveFocus();
+  });
+});
+


### PR DESCRIPTION
## Summary
- close sidebar on small screens and switch between overlay and dock using a media query
- add sr-only labels and nav semantics for better accessibility
- cover sidebar interactions with keyboard-focused tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa15096088329bc62f1a4d04b3738