### PR TITLE
Handle zero price margin calculation

### DIFF
--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -13,10 +13,15 @@ export function calcularMargemRealLocal(
   provisaoDesconto: number,
   taxRate: number = 0
 ): number {
+  if (precoVenda === 0) {
+    return 0;
+  }
+
   const totalCustos = custoTotal + valorFixo + frete;
-  const comissaoLimitada = Math.min(precoVenda * comissao / 100, 100.00);
-  const totalTaxas = comissaoLimitada + (precoVenda * (taxaCartao + provisaoDesconto + taxRate)) / 100;
-  
+  const comissaoLimitada = Math.min((precoVenda * comissao) / 100, 100.0);
+  const totalTaxas =
+    comissaoLimitada + (precoVenda * (taxaCartao + provisaoDesconto + taxRate)) / 100;
+
   return ((precoVenda - totalCustos - totalTaxas) / precoVenda) * 100;
 }
 


### PR DESCRIPTION
## Summary
- avoid divide-by-zero in `calcularMargemRealLocal`

## Testing
- `npm test`
- `npx eslint src/utils/pricing.ts tests/utils/pricing.enhanced.test.ts`
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6890ad692f44832989997c13dcf0568c