### PR TITLE
test: expand DataVisualization scenarios

### DIFF
--- a/src/components/ui/data-visualization.tsx
+++ b/src/components/ui/data-visualization.tsx
@@ -58,6 +58,10 @@ export function DataVisualization<T extends { id: string }>({
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const [currentPage, setCurrentPage] = useState(1);
 
+  const getValue = (item: T, key: string): unknown => {
+    return key.split('.').reduce((obj, k) => obj?.[k], item);
+  };
+
   // Filter data based on search term
   const filteredData = data.filter(item => {
     if (!searchTerm) return true;
@@ -94,10 +98,6 @@ export function DataVisualization<T extends { id: string }>({
       setSortColumn(column);
       setSortDirection("asc");
     }
-  };
-
-  const getValue = (item: T, key: string): unknown => {
-    return key.split('.').reduce((obj, k) => obj?.[k], item);
   };
 
   const renderTableView = () => (

--- a/tests/components/DataVisualization.test.tsx
+++ b/tests/components/DataVisualization.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { testUtils } from '../setup';
@@ -18,7 +18,7 @@ const createWrapper = () => {
   );
 };
 
-describe('DataVisualization Component', () => {
+describe('Componente DataVisualization', () => {
   beforeEach(() => {
     testUtils.resetAllMocks();
   });
@@ -120,6 +120,138 @@ describe('DataVisualization Component', () => {
 
     expect(screen.getByText('João')).toBeInTheDocument();
     expect(screen.getByText('Maria')).toBeInTheDocument();
+  });
+
+  it('deve filtrar dados ao buscar por termo', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DataVisualization
+        title="Busca"
+        data={mockData}
+        columns={mockColumns}
+      />, { wrapper: createWrapper() }
+    );
+
+    const input = screen.getByPlaceholderText('Buscar...');
+    await user.type(input, 'Item 1');
+
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.queryByText('Item 2')).not.toBeInTheDocument();
+  });
+
+  it('deve ordenar dados ao clicar no cabeçalho', async () => {
+    const user = userEvent.setup();
+
+    const data = [
+      { id: '1', name: 'Beta', status: 'active' },
+      { id: '2', name: 'Alpha', status: 'inactive' },
+    ];
+
+    const columns = [
+      { key: 'name', header: 'Nome', sortable: true },
+    ];
+
+    render(
+      <DataVisualization
+        title="Ordenação"
+        data={data}
+        columns={columns}
+      />, { wrapper: createWrapper() }
+    );
+
+    const header = screen.getByText('Nome');
+    await user.click(header);
+
+    let rows = screen.getAllByRole('row');
+    expect(within(rows[1]).getByText('Alpha')).toBeInTheDocument();
+
+    await user.click(header);
+    rows = screen.getAllByRole('row');
+    expect(within(rows[1]).getByText('Beta')).toBeInTheDocument();
+  });
+
+  it('deve paginar os resultados', async () => {
+    const user = userEvent.setup();
+
+    const data = [
+      { id: '1', name: 'Item 1', status: 'active' },
+      { id: '2', name: 'Item 2', status: 'inactive' },
+      { id: '3', name: 'Item 3', status: 'active' },
+    ];
+
+    render(
+      <DataVisualization
+        title="Paginação"
+        data={data}
+        columns={mockColumns}
+        itemsPerPage={1}
+      />, { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.queryByText('Item 2')).not.toBeInTheDocument();
+
+    const next = screen.getByRole('button', { name: 'Próxima' });
+    await user.click(next);
+
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+    expect(screen.queryByText('Item 1')).not.toBeInTheDocument();
+
+    const prev = screen.getByRole('button', { name: 'Anterior' });
+    await user.click(prev);
+
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+  });
+
+  it('deve chamar onViewModeChange ao alterar modo de visualização', async () => {
+    const user = userEvent.setup();
+    const mockChange = vi.fn();
+
+    render(
+      <DataVisualization
+        title="Modo"
+        data={mockData}
+        columns={mockColumns}
+        onViewModeChange={mockChange}
+        viewMode="table"
+      />, { wrapper: createWrapper() }
+    );
+
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[1]);
+    expect(mockChange).toHaveBeenCalledWith('grid');
+
+    await user.click(buttons[0]);
+    expect(mockChange).toHaveBeenCalledWith('table');
+  });
+
+  it('deve exibir ações extras no menu dropdown', async () => {
+    const user = userEvent.setup();
+    const extraAction = vi.fn();
+
+    render(
+      <DataVisualization
+        title="Dropdown"
+        data={mockData}
+        columns={mockColumns}
+        actions={[
+          { label: 'Editar', onClick: vi.fn() },
+          { label: 'Excluir', onClick: vi.fn() },
+          { label: 'Ver', onClick: extraAction }
+        ]}
+      />, { wrapper: createWrapper() }
+    );
+
+    const row = screen.getAllByRole('row')[1];
+    const actionButtons = within(row).getAllByRole('button');
+    const menuButton = actionButtons[2];
+    await user.click(menuButton);
+
+    const menuItem = await screen.findByText('Ver');
+    await user.click(menuItem);
+
+    expect(extraAction).toHaveBeenCalledWith(mockData[0]);
   });
 });
 


### PR DESCRIPTION
## Summary
- localize and expand DataVisualization tests with search, sort, pagination, view mode, and dropdown actions
- fix sorting utility position in DataVisualization component

## Testing
- `npm run test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_6890bea0d37c8329abdbfac348d26e7a