### PR TITLE
test: add tests for product hooks

### DIFF
--- a/tests/hooks/useProduct.test.tsx
+++ b/tests/hooks/useProduct.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { testUtils } from '../setup';
+import { useProduct } from '@/hooks/useProducts';
+import { productsService } from '@/services/products';
+
+vi.mock('@/services/products');
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe('useProduct', () => {
+  beforeEach(() => {
+    testUtils.resetAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('deve buscar produto por ID com sucesso', async () => {
+    const mockProduct = testUtils.createMockProduct({ id: '1', name: 'Produto 1' });
+    vi.mocked(productsService.getById).mockResolvedValue(mockProduct);
+
+    const { result } = renderHook(() => useProduct('1'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockProduct);
+    expect(productsService.getById).toHaveBeenCalledWith('1');
+  });
+
+  it('deve lidar com erro ao buscar produto por ID', async () => {
+    const mockError = new Error('Failed to fetch product');
+    vi.mocked(productsService.getById).mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useProduct('1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(mockError);
+  });
+});

--- a/tests/hooks/useProductsWithCategories.test.tsx
+++ b/tests/hooks/useProductsWithCategories.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { testUtils } from '../setup';
+import { useProductsWithCategories } from '@/hooks/useProducts';
+import { productsService } from '@/services/products';
+
+vi.mock('@/services/products');
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe('useProductsWithCategories', () => {
+  beforeEach(() => {
+    testUtils.resetAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('deve buscar produtos com categorias com sucesso', async () => {
+    const mockProducts = [
+      {
+        ...testUtils.createMockProduct({ id: '1', name: 'Produto 1', category_id: 'cat-1' }),
+        categories: testUtils.createMockCategory({ id: 'cat-1', name: 'Categoria 1' }),
+      },
+      {
+        ...testUtils.createMockProduct({ id: '2', name: 'Produto 2', category_id: 'cat-2' }),
+        categories: testUtils.createMockCategory({ id: 'cat-2', name: 'Categoria 2' }),
+      },
+    ];
+
+    vi.mocked(productsService.getAllWithCategories).mockResolvedValue(mockProducts);
+
+    const { result } = renderHook(() => useProductsWithCategories(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockProducts);
+    expect(productsService.getAllWithCategories).toHaveBeenCalledOnce();
+  });
+
+  it('deve lidar com erro ao buscar produtos com categorias', async () => {
+    const mockError = new Error('Failed to fetch products with categories');
+    vi.mocked(productsService.getAllWithCategories).mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useProductsWithCategories(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(mockError);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for useProductsWithCategories hook
- add tests for useProduct hook

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6890c874e1f883299b40438aa9015959