### PR TITLE
test: add categories service tests

### DIFF
--- a/tests/services/categories.test.ts
+++ b/tests/services/categories.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { categoriesService } from '@/services/categories';
+import { testUtils } from '../setup';
+
+// Mock do Supabase é feito no setup.ts
+describe('CategoriesService', () => {
+  beforeEach(() => {
+    testUtils.resetAllMocks();
+  });
+
+  describe('getWithProductCount', () => {
+    it('deve mapear product_count corretamente', async () => {
+      const mockCategories = [
+        {
+          ...testUtils.createMockCategory({ id: '1', name: 'Categoria 1' }),
+          products: [{ count: 3 }]
+        },
+        {
+          ...testUtils.createMockCategory({ id: '2', name: 'Categoria 2' }),
+          products: []
+        }
+      ];
+
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: mockCategories, error: null })
+      };
+      testUtils.mockSupabaseClient.from.mockReturnValue(mockQuery);
+
+      const result = await categoriesService.getWithProductCount();
+
+      expect(testUtils.mockSupabaseClient.from).toHaveBeenCalledWith('categories');
+      expect(mockQuery.select).toHaveBeenCalledWith(`
+        *,
+        products:products(count)
+      `);
+      expect(result).toEqual([
+        { ...mockCategories[0], product_count: 3 },
+        { ...mockCategories[1], product_count: 0 }
+      ]);
+    });
+  });
+
+  describe('validateName', () => {
+    it('deve retornar true quando nome é único', async () => {
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ data: [], error: null })
+      };
+      testUtils.mockSupabaseClient.from.mockReturnValue(mockQuery);
+
+      const result = await categoriesService.validateName('Nome Único');
+
+      expect(result).toBe(true);
+      expect(mockQuery.eq).toHaveBeenCalledWith('name', 'Nome Único');
+    });
+
+    it('deve retornar false quando nome já existe', async () => {
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ data: [{ id: 'existing-id' }], error: null })
+      };
+      testUtils.mockSupabaseClient.from.mockReturnValue(mockQuery);
+
+      const result = await categoriesService.validateName('Nome Existente');
+
+      expect(result).toBe(false);
+    });
+
+    it('deve excluir ID específico na validação', async () => {
+      const mockQueryAfterEq = {
+        neq: vi.fn().mockResolvedValue({ data: [], error: null })
+      };
+      const mockQuery = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnValue(mockQueryAfterEq)
+      };
+      testUtils.mockSupabaseClient.from.mockReturnValue(mockQuery);
+
+      const result = await categoriesService.validateName('Nome', 'test-id');
+
+      expect(mockQuery.eq).toHaveBeenCalledWith('name', 'Nome');
+      expect(mockQueryAfterEq.neq).toHaveBeenCalledWith('id', 'test-id');
+      expect(result).toBe(true);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for categories service product count mapping and name validation

## Testing
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6890cb4dd8e48329afa48e6c2271725e