### PR TITLE
fix: adjust typings and mocks for lint compliance

### DIFF
--- a/src/services/ads.ts
+++ b/src/services/ads.ts
@@ -48,7 +48,7 @@ export class AdsService extends BaseService<ProductImage> {
       const filePath = `${tenantId}/${productId}/${fileName}`;
 
       // Upload do arquivo para o Storage
-      const { data: uploadData, error: uploadError } = await supabase.storage
+      const { error: uploadError } = await supabase.storage
         .from('product-images')
         .upload(filePath, file);
 

--- a/src/services/assistants.ts
+++ b/src/services/assistants.ts
@@ -11,7 +11,7 @@ export class AssistantsService extends BaseService<Assistant> {
   }
 
   // Método para fazer requisições HTTP com retry e timeout
-  private async makeRequest(method: string, endpoint: string, body?: any): Promise<any> {
+  private async makeRequest(method: string, endpoint: string, body?: unknown): Promise<unknown> {
     const maxRetries = 3;
     const timeout = 30000; // 30 segundos
     
@@ -48,19 +48,21 @@ export class AssistantsService extends BaseService<Assistant> {
         const result = await response.json();
         this.logger.debug(`Sucesso na tentativa ${attempt}`, result);
         return result;
-        
-      } catch (error: any) {
+
+      } catch (error: unknown) {
         this.logger.error(`Erro na tentativa ${attempt}/${maxRetries}`, error);
         
         if (attempt === maxRetries) {
           // Se é a última tentativa, relançar o erro
-          if (error.name === 'AbortError') {
-            throw new Error('Timeout na requisição - tente novamente');
-          }
-          if (error.message.includes('SSL') || error.message.includes('handshake')) {
-            throw new Error('Erro de conectividade SSL - tente novamente em alguns minutos');
-          }
-          throw error;
+            if (error instanceof Error) {
+              if (error.name === 'AbortError') {
+                throw new Error('Timeout na requisição - tente novamente');
+              }
+              if (error.message.includes('SSL') || error.message.includes('handshake')) {
+                throw new Error('Erro de conectividade SSL - tente novamente em alguns minutos');
+              }
+            }
+            throw error;
         }
         
         // Aguardar antes de tentar novamente (backoff exponencial)
@@ -109,7 +111,7 @@ export class AssistantsService extends BaseService<Assistant> {
       this.logger.debug('Atualizando assistente', { id, data });
 
       // Usar fetch direto para PUT com retry e timeout
-      const result = await this.makeRequest('PUT', `assistants/${id}`, data);
+        const result = await this.makeRequest('PUT', `assistants/${id}`, data);
       
       this.logger.info('Assistente atualizado com sucesso', result);
       return result as Assistant;
@@ -138,7 +140,7 @@ export class AssistantsService extends BaseService<Assistant> {
       this.logger.debug('Buscando assistente por marketplace', { marketplace });
 
       const { data, error } = await supabase
-        .from(this.tableName as any)
+        .from(this.tableName)
         .select('*')
         .eq('marketplace', marketplace)
         .single();

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -10,7 +10,7 @@ export abstract class BaseService<T = Record<string, unknown>> {
 
   async getAll(): Promise<T[]> {
     const { data, error } = await supabase
-      .from(this.tableName as any)
+      .from(this.tableName)
       .select('*')
       .order('created_at', { ascending: false });
 
@@ -20,7 +20,7 @@ export abstract class BaseService<T = Record<string, unknown>> {
 
   async getById(id: string): Promise<T | null> {
     const { data, error } = await supabase
-      .from(this.tableName as any)
+      .from(this.tableName)
       .select('*')
       .eq('id', id)
       .single();
@@ -37,8 +37,8 @@ export abstract class BaseService<T = Record<string, unknown>> {
     const dataWithTenant = await this.addTenantId(data);
     
     const { data: result, error } = await supabase
-      .from(this.tableName as any)
-      .insert(dataWithTenant as any)
+      .from(this.tableName)
+      .insert(dataWithTenant as Partial<T>)
       .select()
       .single();
 
@@ -77,8 +77,8 @@ export abstract class BaseService<T = Record<string, unknown>> {
 
   async update(id: string, data: Partial<T>): Promise<T> {
     const { data: result, error } = await supabase
-      .from(this.tableName as any)
-      .update(data as any)
+      .from(this.tableName)
+      .update(data as Partial<T>)
       .eq('id', id)
       .select()
       .single();
@@ -89,7 +89,7 @@ export abstract class BaseService<T = Record<string, unknown>> {
 
   async delete(id: string): Promise<void> {
     const { error } = await supabase
-      .from(this.tableName as any)
+      .from(this.tableName)
       .delete()
       .eq('id', id);
 

--- a/src/services/marketplaces.ts
+++ b/src/services/marketplaces.ts
@@ -62,7 +62,7 @@ export class MarketplacesService extends BaseService<MarketplaceType> {
   }
 
   async getModalitiesByPlatform(platformId: string, categoryId?: string): Promise<MarketplaceType[]> {
-    let query = supabase
+    const query = supabase
       .from('marketplaces')
       .select('*')
       .eq('platform_id', platformId)

--- a/src/types/ads.ts
+++ b/src/types/ads.ts
@@ -20,12 +20,12 @@ export interface AdGenerationRequest {
   custom_prompt?: string;
 }
 
-export interface AdGenerationResult {
-  title: string;
-  description: string;
-  keywords: string[];
-  marketplace_specific_data?: Record<string, any>;
-}
+  export interface AdGenerationResult {
+    title: string;
+    description: string;
+    keywords: string[];
+    marketplace_specific_data?: Record<string, unknown>;
+  }
 
 export const productImageSchema = z.object({
   product_id: z.string().uuid("Product ID deve ser um UUID válido"),

--- a/supabase/functions/assistants/index.ts
+++ b/supabase/functions/assistants/index.ts
@@ -87,11 +87,12 @@ serve(async (req) => {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         });
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('ERRO GERAL na edge function:', error);
-    return new Response(JSON.stringify({ 
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(JSON.stringify({
       error: 'Erro interno do servidor',
-      details: error.message 
+      details: message
     }), {
       status: 500,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
@@ -165,9 +166,10 @@ async function handleCreateAssistant(req: Request) {
     return new Response(JSON.stringify(data), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Erro em handleCreateAssistant:', error);
-    return new Response(JSON.stringify({ error: error.message }), {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(JSON.stringify({ error: message }), {
       status: 500,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
@@ -253,9 +255,10 @@ async function handleUpdateAssistant(req: Request, assistantDbId: string) {
     return new Response(JSON.stringify(data), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Erro em handleUpdateAssistant:', error);
-    return new Response(JSON.stringify({ error: error.message }), {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(JSON.stringify({ error: message }), {
       status: 500,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
@@ -300,7 +303,7 @@ async function handleDeleteAssistant(assistantDbId: string) {
         },
       });
       console.log('OpenAI Delete Response status:', openaiResponse.status);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Erro ao deletar da OpenAI (continuando):', error);
     }
 
@@ -320,9 +323,10 @@ async function handleDeleteAssistant(assistantDbId: string) {
     return new Response(JSON.stringify({ success: true }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Erro em handleDeleteAssistant:', error);
-    return new Response(JSON.stringify({ error: error.message }), {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(JSON.stringify({ error: message }), {
       status: 500,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });

--- a/supabase/functions/generate-ad-chat/index.ts
+++ b/supabase/functions/generate-ad-chat/index.ts
@@ -145,9 +145,17 @@ Agora inicie o processo estratégico conforme suas instruções. Faça o diagnó
     });
 
     const messagesData = await messagesResponse.json();
-    
+
     // Pegar a resposta mais recente do assistente
-    const assistantMessage = messagesData.data.find((msg: any) => msg.role === 'assistant');
+    interface ThreadMessage {
+      role: string;
+      content: Array<{ text?: { value: string } }>; // structure from OpenAI thread response
+    }
+
+    const assistantMessage = messagesData.data.find(
+      (msg: ThreadMessage) => msg.role === 'assistant'
+    ) as ThreadMessage | undefined;
+
     const responseText = assistantMessage?.content[0]?.text?.value || 'Erro ao obter resposta';
 
     console.log('Resposta do assistente obtida');

--- a/tests/services/commissions.test.ts
+++ b/tests/services/commissions.test.ts
@@ -52,7 +52,7 @@ describe('CommissionsService', () => {
         select: mockSelect
       }));
 
-      (supabase.from as any).mockImplementation(mockFrom);
+      (supabase.from as unknown as vi.Mock).mockImplementation(mockFrom);
 
       const result = await commissionsService.findApplicableCommission({
         marketplaceId: 'marketplace-1',
@@ -96,7 +96,7 @@ describe('CommissionsService', () => {
         select: mockSelect
       }));
 
-      (supabase.from as any).mockImplementation(mockFrom);
+      (supabase.from as unknown as vi.Mock).mockImplementation(mockFrom);
 
       const result = await commissionsService.findApplicableCommission({
         marketplaceId: 'marketplace-1',
@@ -122,7 +122,7 @@ describe('CommissionsService', () => {
         select: mockSelect
       }));
 
-      (supabase.from as any).mockImplementation(mockFrom);
+      (supabase.from as unknown as vi.Mock).mockImplementation(mockFrom);
 
       const result = await commissionsService.findApplicableCommission({
         marketplaceId: 'marketplace-1',
@@ -145,7 +145,7 @@ describe('CommissionsService', () => {
         select: mockSelect
       }));
 
-      (supabase.from as any).mockImplementation(mockFrom);
+      (supabase.from as unknown as vi.Mock).mockImplementation(mockFrom);
 
       const result = await commissionsService.validateUniqueRule(
         'marketplace-1',
@@ -166,7 +166,7 @@ describe('CommissionsService', () => {
         select: mockSelect
       }));
 
-      (supabase.from as any).mockImplementation(mockFrom);
+      (supabase.from as unknown as vi.Mock).mockImplementation(mockFrom);
 
       const result = await commissionsService.validateUniqueRule(
         'marketplace-1',
@@ -187,7 +187,7 @@ describe('CommissionsService', () => {
         select: mockSelect
       }));
 
-      (supabase.from as any).mockImplementation(mockFrom);
+      (supabase.from as unknown as vi.Mock).mockImplementation(mockFrom);
 
       const result = await commissionsService.validateUniqueRule(
         'marketplace-1',


### PR DESCRIPTION
## Summary
- tighten supabase edge functions and services typings
- clean up ads image upload and service mocks
- improve base service generics and marketplace query usage

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing lint errors across forms and pages)*

------
https://chatgpt.com/codex/tasks/task_e_6890bd1ff6c48329973be5898f8d6804