### PR TITLE
chore: add type checking script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "preview": "vite preview",

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -26,5 +26,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -16,7 +16,8 @@
     "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "tailwind.config.ts", ".storybook"]
 }


### PR DESCRIPTION
## Summary
- add project-wide type checking script
- include tests and config files in TypeScript config

## Testing
- `npm run type-check`
- `npm test -- --run` *(fails: AppSidebar accessibility allows keyboard navigation through items)*
- `npm run lint` *(fails: 41 errors, 804 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_6890e8264570832981cafca1336fe654