### PR TITLE
test: include beforeEach/afterEach in Sidebar tests

### DIFF
--- a/tests/components/Sidebar.test.tsx
+++ b/tests/components/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({ profile: null }),


### PR DESCRIPTION
## Summary
- import Vitest lifecycle hooks in Sidebar test

## Testing
- `npm test tests/components/Sidebar.test.tsx`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6891f5748220832981adf3659b0dad40