### PR TITLE
test: add ilike and is stubs

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,18 +8,22 @@ afterEach(() => {
 });
 
 // Mock do Supabase Client
+const mockFromReturn = {
+  select: vi.fn().mockReturnThis(),
+  insert: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  delete: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  neq: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  single: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  ilike: vi.fn().mockReturnThis(),
+  is: vi.fn().mockReturnThis(),
+};
+
 const mockSupabaseClient = {
-  from: vi.fn(() => ({
-    select: vi.fn().mockReturnThis(),
-    insert: vi.fn().mockReturnThis(),
-    update: vi.fn().mockReturnThis(),
-    delete: vi.fn().mockReturnThis(),
-    eq: vi.fn().mockReturnThis(),
-    neq: vi.fn().mockReturnThis(),
-    order: vi.fn().mockReturnThis(),
-    single: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockReturnThis(),
-  })),
+  from: vi.fn(() => mockFromReturn),
   rpc: vi.fn(),
   auth: {
     getUser: vi.fn(),
@@ -135,5 +139,6 @@ export const testUtils = {
     mockSupabaseClient.rpc.mockClear();
     mockToast.mockClear();
     Object.values(mockQueryClient).forEach(fn => fn.mockClear());
+    Object.values(mockFromReturn).forEach(fn => fn.mockClear());
   },
 };


### PR DESCRIPTION
## Summary
- extend Supabase client mock with `ilike` and `is` methods for query chaining
- ensure test mocks are reset for all query builder functions

## Testing
- `npm test` *(fails: AuthService.getCurrentProfile destructuring 'data' of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6891f7e21b9c8329b6bc7917e9289e5d