### PR TITLE
Add assistant mode tests and enforce strategic product requirement

### DIFF
--- a/src/services/assistants.ts
+++ b/src/services/assistants.ts
@@ -135,23 +135,35 @@ export class AssistantsService extends BaseService<Assistant> {
     }
   }
 
-  async getAssistantByMarketplace(marketplace: string, mode: 'quick' | 'strategic' = 'quick'): Promise<Assistant | null> {
+  async getAssistantByMarketplace(
+    marketplace: string,
+    mode: 'quick' | 'strategic' = 'quick',
+    productId?: string
+  ): Promise<Assistant | null> {
     try {
-      this.logger.debug('Buscando assistente por marketplace e modo', { marketplace, mode });
+      this.logger.debug('Buscando assistente por marketplace e modo', { marketplace, mode, productId });
 
-      const { data, error } = await supabase
+      const query = supabase
         .from('assistants')
         .select('*')
         .eq('marketplace', marketplace)
-        .eq('mode', mode)
-        .maybeSingle();
+        .eq('mode', mode);
+
+      if (mode === 'strategic') {
+        if (!productId) {
+          throw new Error('productId é obrigatório no modo estratégico');
+        }
+        query.eq('product_id', productId);
+      }
+
+      const { data, error } = await query.maybeSingle();
 
       if (error) {
         throw error;
       }
 
       if (!data) {
-        this.logger.debug('Nenhum assistente encontrado para o marketplace e modo', { marketplace, mode });
+        this.logger.debug('Nenhum assistente encontrado para o marketplace e modo', { marketplace, mode, productId });
         return null;
       }
 

--- a/src/types/assistants.ts
+++ b/src/types/assistants.ts
@@ -3,6 +3,7 @@ export interface Assistant {
   name: string;
   marketplace: 'mercado_livre' | 'shopee' | 'instagram';
   mode: 'quick' | 'strategic';
+  product_id?: string;
   model: string;
   instructions: string;
   assistant_id: string; // OpenAI Assistant ID

--- a/tests/services/assistants.test.ts
+++ b/tests/services/assistants.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { assistantsService } from '@/services/assistants';
+import { testUtils } from '../setup';
+
+// Helper to create a complete mock of the Supabase query
+const createQueryMock = (overrides: Record<string, any> = {}) => ({
+  select: vi.fn().mockReturnThis(),
+  insert: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  delete: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  neq: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  single: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  ilike: vi.fn().mockReturnThis(),
+  is: vi.fn().mockReturnThis(),
+  maybeSingle: vi.fn().mockReturnThis(),
+  ...overrides,
+});
+
+describe('AssistantsService', () => {
+  beforeEach(() => {
+    testUtils.resetAllMocks();
+  });
+
+  describe('getAssistantByMarketplace', () => {
+    it('deve buscar assistente no modo rápido apenas com marketplace', async () => {
+      const mockAssistant = {
+        id: '1',
+        name: 'Quick Assistant',
+        marketplace: 'mercado_livre',
+        mode: 'quick'
+      };
+
+      const mockQuery = createQueryMock({
+        maybeSingle: vi.fn().mockResolvedValue({ data: mockAssistant, error: null })
+      });
+      testUtils.mockSupabaseClient.from.mockReturnValue(mockQuery);
+
+      const result = await assistantsService.getAssistantByMarketplace('mercado_livre');
+
+      expect(testUtils.mockSupabaseClient.from).toHaveBeenCalledWith('assistants');
+      expect(mockQuery.eq).toHaveBeenNthCalledWith(1, 'marketplace', 'mercado_livre');
+      expect(mockQuery.eq).toHaveBeenNthCalledWith(2, 'mode', 'quick');
+      expect(result).toEqual(mockAssistant);
+    });
+
+    it('deve buscar assistente estratégico usando marketplace e productId', async () => {
+      const mockAssistant = {
+        id: '2',
+        name: 'Strategic Assistant',
+        marketplace: 'mercado_livre',
+        mode: 'strategic',
+        product_id: 'prod-1'
+      };
+
+      const mockQuery = createQueryMock({
+        maybeSingle: vi.fn().mockResolvedValue({ data: mockAssistant, error: null })
+      });
+      testUtils.mockSupabaseClient.from.mockReturnValue(mockQuery);
+
+      const result = await assistantsService.getAssistantByMarketplace('mercado_livre', 'strategic', 'prod-1');
+
+      expect(testUtils.mockSupabaseClient.from).toHaveBeenCalledWith('assistants');
+      expect(mockQuery.eq).toHaveBeenNthCalledWith(1, 'marketplace', 'mercado_livre');
+      expect(mockQuery.eq).toHaveBeenNthCalledWith(2, 'mode', 'strategic');
+      expect(mockQuery.eq).toHaveBeenNthCalledWith(3, 'product_id', 'prod-1');
+      expect(result).toEqual(mockAssistant);
+    });
+
+    it('deve lançar erro se modo estratégico for chamado sem productId', async () => {
+      await expect(
+        assistantsService.getAssistantByMarketplace('mercado_livre', 'strategic')
+      ).rejects.toThrow('productId');
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- require product ID when fetching strategic assistants
- record product context on assistant type
- verify assistant lookup behavior for quick and strategic modes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689203d514548329beb12d462a475041