### PR TITLE
fix: expand AdGenerator grid layout

### DIFF
--- a/src/pages/AdGenerator.tsx
+++ b/src/pages/AdGenerator.tsx
@@ -90,7 +90,7 @@ export default function AdGenerator() {
       description="Gere anúncios otimizados usando inteligência artificial"
       breadcrumbs={breadcrumbs}
     >
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:col-span-12">
         {/* Configuração */}
         <div className="lg:col-span-1 space-y-6">
           {/* Seleção de Modo */}


### PR DESCRIPTION
## Summary
- expand AdGenerator top-level grid to span full width on large screens

## Testing
- `npm test -- --run` (fails: AppSidebar accessibility allows keyboard navigation through items)
- `npm run lint` (fails: Unexpected any in tests)
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68920f1009e88329bdc8c380606aa7cb