### PR TITLE
chore: use design tokens for marketplace colors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -27,9 +27,12 @@ All colors MUST be HSL.
     --destructive-foreground: 0 0% 100%;
     --success: 142 76% 36%;
     --success-foreground: 0 0% 100%;
-    --warning: 38 92% 50%;
-    --warning-foreground: 0 0% 100%;
-    --border: 220 13% 91%;
+      --warning: 38 92% 50%;
+      --warning-foreground: 0 0% 100%;
+      --mercado-livre: 45 93% 47%;
+      --shopee: 25 95% 53%;
+      --instagram: 330 81% 60%;
+      --border: 220 13% 91%;
     --input: 220 13% 91%;
     --ring: 258 56% 52%;
     --radius: 0rem; /* Corporate style: no rounding */
@@ -112,6 +115,9 @@ All colors MUST be HSL.
     --success-foreground: 0 0% 100%;
     --warning: 38 92% 50%;
     --warning-foreground: 0 0% 100%;
+    --mercado-livre: 45 93% 47%;
+    --shopee: 25 95% 53%;
+    --instagram: 330 81% 60%;
     --border: 0 0% 85%;
     --input: 0 0% 85%;
     --ring: 100 27% 43%;
@@ -189,6 +195,9 @@ All colors MUST be HSL.
     --success-foreground: 0 0% 100%;
     --warning: 38 92% 50%;
     --warning-foreground: 0 0% 100%;
+    --mercado-livre: 45 93% 47%;
+    --shopee: 25 95% 53%;
+    --instagram: 330 81% 60%;
     --border: 210 30% 86%;
     --input: 210 30% 86%;
     --ring: 210 90% 50%;
@@ -271,6 +280,9 @@ All colors MUST be HSL.
     --success-foreground: 0 0% 100%;
     --warning: 38 92% 50%;
     --warning-foreground: 0 0% 100%;
+    --mercado-livre: 45 93% 47%;
+    --shopee: 25 95% 53%;
+    --instagram: 330 81% 60%;
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;

--- a/src/pages/AdGenerator.tsx
+++ b/src/pages/AdGenerator.tsx
@@ -2,12 +2,10 @@ import { useState } from "react";
 import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { 
   Wand2, 
@@ -20,13 +18,12 @@ import { useProducts } from "@/hooks/useProducts";
 import { useGenerateListing } from "@/hooks/useAdGeneration";
 import { AdChatInterface } from "@/components/forms/AdChatInterface";
 import { MarketplaceDestination } from "@/types/ads";
-import { cn } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 
 const MARKETPLACE_OPTIONS = [
-  { value: 'mercado_livre', label: 'Mercado Livre', icon: '🛒', color: 'bg-yellow-500' },
-  { value: 'shopee', label: 'Shopee', icon: '🛍️', color: 'bg-orange-500' },
-  { value: 'instagram', label: 'Instagram', icon: '📸', color: 'bg-pink-500' },
+  { value: 'mercado_livre', label: 'Mercado Livre', icon: '🛒', color: 'bg-mercado-livre' },
+  { value: 'shopee', label: 'Shopee', icon: '🛍️', color: 'bg-shopee' },
+  { value: 'instagram', label: 'Instagram', icon: '📸', color: 'bg-instagram' },
 ] as const;
 
 export default function AdGenerator() {

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -50,6 +50,10 @@ export const colors = {
     border: 'hsl(var(--sidebar-border))',
     ring: 'hsl(var(--sidebar-ring))',
   },
+  /* Marketplace brand colors */
+  'mercado-livre': 'hsl(var(--mercado-livre))',
+  shopee: 'hsl(var(--shopee))',
+  instagram: 'hsl(var(--instagram))',
   /* Corporate Theme Colors */
   gunmetal: '200 40% 13%',
   'fern-green': '100 27% 43%',


### PR DESCRIPTION
## Summary
- replace hardcoded marketplace background colors with design tokens
- add brand color tokens for Mercado Livre, Shopee and Instagram
- define CSS variables for new tokens across themes

## Testing
- `npx eslint src/pages/AdGenerator.tsx src/styles/tokens.ts src/index.css`
- `npm run type-check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68922b123de883298b9396db340ec139