### PR TITLE
refactor typography to use Heading and Text components

### DIFF
--- a/src/components/layout/ConfigurationHeader.tsx
+++ b/src/components/layout/ConfigurationHeader.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import { ChevronRight, Home } from '@/components/ui/icons';
 import { Link } from "react-router-dom";
+import { Heading, Text } from "@/components/ui/typography";
 
 interface Breadcrumb {
   label: string;
@@ -59,15 +60,14 @@ export function ConfigurationHeader({
                 </div>
               )}
               <div>
-                <h1 className="text-3xl font-bold tracking-tight text-foreground">
+                <Heading variant="h1" className="tracking-tight">
                   {title}
-                </h1>
+                </Heading>
               </div>
             </div>
-            
-            <p className="text-lg text-muted-foreground max-w-3xl">
+            <Text variant="muted" className="max-w-3xl">
               {description}
-            </p>
+            </Text>
           </div>
 
           {actions && (

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -43,6 +43,7 @@ const textVariants = cva("", {
     variant: {
       body: "text-body",
       caption: "text-caption",
+      muted: "text-body text-muted-foreground",
     },
   },
   defaultVariants: {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -370,15 +370,15 @@ export default function AdminDashboard() {
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold flex items-center gap-3">
+          <Heading variant="h1" className="flex items-center gap-3">
             <div className="w-10 h-10 bg-primary/10 rounded-lg flex items-center justify-center">
               <BarChart3 className="w-6 h-6 text-primary" />
             </div>
             Dashboard Admin
-          </h1>
-          <p className="text-muted-foreground mt-1">
+          </Heading>
+          <Text variant="muted" className="mt-1">
             Visão geral da plataforma Peepers Hub
-          </p>
+          </Text>
         </div>
         
         <div className="flex gap-2">
@@ -400,12 +400,12 @@ export default function AdminDashboard() {
             <CardContent className="p-lg">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-muted-foreground mb-1">
+                  <Text variant="caption" className="font-medium text-muted-foreground mb-1">
                     {stat.title}
-                  </p>
-                  <p className="text-2xl font-bold">
+                  </Text>
+                  <Text className="font-bold text-h3">
                     {stat.value}
-                  </p>
+                  </Text>
                 </div>
                 <div className={`w-12 h-12 rounded-full ${stat.bgColor} flex items-center justify-center`}>
                   <stat.icon className={`w-6 h-6 ${stat.color}`} />
@@ -465,12 +465,12 @@ export default function AdminDashboard() {
               </CardHeader>
               <CardContent className="text-center py-12">
                 <Activity className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
-                <h3 className="text-lg font-semibold mb-2">
+                <Heading variant="h3" className="mb-2">
                   Funcionalidade em Desenvolvimento
-                </h3>
-                <p className="text-muted-foreground">
+                </Heading>
+                <Text variant="muted">
                   Gráficos de uso, conversão e retenção serão implementados na próxima versão.
-                </p>
+                </Text>
               </CardContent>
             </Card>
           </div>

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Eye, EyeOff, Zap } from '@/components/ui/icons';
+import { Heading, Text } from "@/components/ui/typography";
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -85,12 +86,16 @@ export default function Auth() {
           <div className="inline-flex items-center justify-center w-16 h-16 bg-primary/10 rounded-full mb-4">
             <Zap className="w-8 h-8 text-primary" />
           </div>
-          <h1 className="text-3xl font-bold bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">
-            Peepers Hub
-          </h1>
-          <p className="text-muted-foreground mt-2">
+            <Heading
+              variant="h1"
+              className="bg-gradient-to-r from-primary to-primary/70 bg-clip-text"
+              style={{ color: 'transparent' }}
+            >
+              Peepers Hub
+            </Heading>
+          <Text variant="muted" className="mt-2">
             Ferramentas inteligentes para marketplaces
-          </p>
+          </Text>
         </div>
 
         <Card className="border-0 shadow-form bg-card/50 backdrop-blur-sm">
@@ -121,9 +126,9 @@ export default function Auth() {
                       className={loginForm.formState.errors.email ? 'border-destructive' : ''}
                     />
                     {loginForm.formState.errors.email && (
-                      <p className="text-sm text-destructive">
+                      <Text variant="caption" className="text-destructive">
                         {loginForm.formState.errors.email.message}
-                      </p>
+                      </Text>
                     )}
                   </div>
 
@@ -152,9 +157,9 @@ export default function Auth() {
                       </Button>
                     </div>
                     {loginForm.formState.errors.password && (
-                      <p className="text-sm text-destructive">
+                      <Text variant="caption" className="text-destructive">
                         {loginForm.formState.errors.password.message}
-                      </p>
+                      </Text>
                     )}
                   </div>
 
@@ -177,9 +182,9 @@ export default function Auth() {
                       className={signUpForm.formState.errors.fullName ? 'border-destructive' : ''}
                     />
                     {signUpForm.formState.errors.fullName && (
-                      <p className="text-sm text-destructive">
+                      <Text variant="caption" className="text-destructive">
                         {signUpForm.formState.errors.fullName.message}
-                      </p>
+                      </Text>
                     )}
                   </div>
 
@@ -203,9 +208,9 @@ export default function Auth() {
                       className={signUpForm.formState.errors.email ? 'border-destructive' : ''}
                     />
                     {signUpForm.formState.errors.email && (
-                      <p className="text-sm text-destructive">
+                      <Text variant="caption" className="text-destructive">
                         {signUpForm.formState.errors.email.message}
-                      </p>
+                      </Text>
                     )}
                   </div>
 
@@ -234,9 +239,9 @@ export default function Auth() {
                       </Button>
                     </div>
                     {signUpForm.formState.errors.password && (
-                      <p className="text-sm text-destructive">
+                      <Text variant="caption" className="text-destructive">
                         {signUpForm.formState.errors.password.message}
-                      </p>
+                      </Text>
                     )}
                   </div>
 
@@ -250,9 +255,9 @@ export default function Auth() {
                       className={signUpForm.formState.errors.confirmPassword ? 'border-destructive' : ''}
                     />
                     {signUpForm.formState.errors.confirmPassword && (
-                      <p className="text-sm text-destructive">
+                      <Text variant="caption" className="text-destructive">
                         {signUpForm.formState.errors.confirmPassword.message}
-                      </p>
+                      </Text>
                     )}
                   </div>
 
@@ -265,9 +270,9 @@ export default function Auth() {
           </CardContent>
         </Card>
 
-        <div className="text-center mt-6 text-sm text-muted-foreground">
-          <p>© 2024 Peepers Hub. Todos os direitos reservados.</p>
-        </div>
+        <Text variant="caption" className="text-center mt-6 text-muted-foreground">
+          © 2024 Peepers Hub. Todos os direitos reservados.
+        </Text>
       </div>
     </div>
   );

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -8,6 +8,7 @@ import { Check, Crown, Zap, Star, ArrowRight, Infinity } from '@/components/ui/i
 import { useSubscriptionPlans, useCurrentSubscription, useUsageTracking } from '@/hooks/useSubscription';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { EmptyState } from '@/components/ui/empty-state';
+import { Heading, Text } from "@/components/ui/typography";
 
 export default function Subscription() {
   const [billingCycle, setBillingCycle] = useState<'monthly' | 'yearly'>('monthly');
@@ -89,12 +90,16 @@ export default function Subscription() {
         <div className="inline-flex items-center justify-center w-16 h-16 bg-primary/10 rounded-full mb-4">
           <Crown className="w-8 h-8 text-primary" />
         </div>
-        <h1 className="text-4xl font-bold bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent mb-4">
+        <Heading
+          variant="h1"
+          className="bg-gradient-to-r from-primary to-primary/70 bg-clip-text mb-4"
+          style={{ color: 'transparent' }}
+        >
           Escolha seu Plano
-        </h1>
-        <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+        </Heading>
+        <Text variant="muted" className="max-w-2xl mx-auto">
           Desbloqueie todo o potencial do Peepers Hub com ferramentas avançadas para seu marketplace
-        </p>
+        </Text>
       </div>
 
       {/* Current Subscription Status */}
@@ -301,10 +306,12 @@ export default function Subscription() {
 
       {/* FAQ or Additional Info */}
       <div className="mt-16 text-center">
-        <h3 className="text-2xl font-bold mb-4">Precisa de ajuda para escolher?</h3>
-        <p className="text-muted-foreground mb-6">
+        <Heading variant="h3" className="mb-4">
+          Precisa de ajuda para escolher?
+        </Heading>
+        <Text variant="muted" className="mb-6">
           Nossa equipe está pronta para ajudar você a encontrar o plano ideal para seu negócio.
-        </p>
+        </Text>
         <Button variant="outline" size="lg">
           Falar com Vendas
         </Button>

--- a/tests/pages/__snapshots__/pages.snapshots.test.tsx.snap
+++ b/tests/pages/__snapshots__/pages.snapshots.test.tsx.snap
@@ -102,14 +102,14 @@ exports[`Snapshots das páginas principais > deve renderizar AdGenerator correta
             >
               <div>
                 <h1
-                  class="text-3xl font-bold tracking-tight text-foreground"
+                  class="font-bold text-h1 tracking-tight"
                 >
                   Gerador de Anúncios IA
                 </h1>
               </div>
             </div>
             <p
-              class="text-lg text-muted-foreground max-w-3xl"
+              class="text-muted-foreground max-w-3xl"
             >
               Gere anúncios otimizados usando inteligência artificial
             </p>


### PR DESCRIPTION
## Summary
- use shared Heading/Text components instead of raw h1/h3/p tags
- add muted variant to Text and clean up manual typography classes
- update page snapshots to reflect new typography tokens

## Testing
- `npm test -- --run -u --testTimeout=10000`


------
https://chatgpt.com/codex/tasks/task_e_6892a4f49a988329b2f0e2b41fcbebba