### PR TITLE
refactor: use typography components in ad generator

### DIFF
--- a/src/pages/AdGenerator.tsx
+++ b/src/pages/AdGenerator.tsx
@@ -7,6 +7,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Heading, Text } from "@/components/ui/typography";
+import { EmptyState } from "@/components/ui/empty-state";
 import { 
   Wand2, 
   Sparkles,
@@ -187,15 +189,25 @@ export default function AdGenerator() {
               {/* Produto Selecionado Info */}
               {selectedProduct && (
                 <div className="mt-4 p-3 bg-muted rounded-lg">
-                  <h4 className="text-sm font-semibold mb-2">Produto Selecionado</h4>
+                  <Heading variant="h4" className="text-sm font-semibold mb-2">
+                    Produto Selecionado
+                  </Heading>
                   <div className="space-y-1 text-sm text-muted-foreground">
-                    <p><strong>Nome:</strong> {selectedProduct.name}</p>
+                    <Text>
+                      <strong>Nome:</strong> {selectedProduct.name}
+                    </Text>
                     {selectedProduct.sku && (
-                      <p><strong>SKU:</strong> {selectedProduct.sku}</p>
+                      <Text>
+                        <strong>SKU:</strong> {selectedProduct.sku}
+                      </Text>
                     )}
-                    <p><strong>Custo:</strong> R$ {selectedProduct.cost_unit.toFixed(2)}</p>
+                    <Text>
+                      <strong>Custo:</strong> R$ {selectedProduct.cost_unit.toFixed(2)}
+                    </Text>
                     {selectedProduct.description && (
-                      <p><strong>Descrição:</strong> {selectedProduct.description.slice(0, 100)}...</p>
+                      <Text>
+                        <strong>Descrição:</strong> {selectedProduct.description.slice(0, 100)}...
+                      </Text>
                     )}
                   </div>
                 </div>
@@ -292,7 +304,9 @@ export default function AdGenerator() {
                 {generatedResult ? (
                   <div className="space-y-4">
                     <div className="p-4 bg-muted rounded-lg">
-                      <h4 className="text-sm font-semibold mb-2">Anúncio Gerado</h4>
+                      <Heading variant="h4" className="text-sm font-semibold mb-2">
+                        Anúncio Gerado
+                      </Heading>
                       <div className="whitespace-pre-wrap text-sm">
                         {generatedResult.description}
                       </div>
@@ -316,16 +330,24 @@ export default function AdGenerator() {
                     </div>
                   </div>
                 ) : (
-                  <div className="text-center py-12 text-muted-foreground">
-                    <ShoppingCart className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                    <p>Nenhum anúncio gerado ainda</p>
-                    <p className="text-sm mt-1">
-                      {mode === 'quick' 
-                        ? 'Use a geração rápida para criar um anúncio instantaneamente'
-                        : 'Configure produto e marketplace para iniciar a geração estratégica'
-                      }
-                    </p>
-                  </div>
+                  <EmptyState
+                    icon={<ShoppingCart className="h-8 w-8" />}
+                    title="Nenhum anúncio gerado ainda"
+                    description={
+                      mode === "quick"
+                        ? "Use a geração rápida para criar um anúncio instantaneamente"
+                        : "Configure produto e marketplace para iniciar a geração estratégica"
+                    }
+                    action={
+                      mode === "quick" && !!isQuickFormValid
+                        ? {
+                            label: "Gerar Anúncio",
+                            onClick: handleQuickGenerate,
+                            icon: <Wand2 className="w-4 h-4 mr-2" />,
+                          }
+                        : undefined
+                    }
+                  />
                 )}
               </CardContent>
             </Card>

--- a/tests/pages/__snapshots__/pages.snapshots.test.tsx.snap
+++ b/tests/pages/__snapshots__/pages.snapshots.test.tsx.snap
@@ -458,39 +458,45 @@ exports[`Snapshots das páginas principais > deve renderizar AdGenerator correta
                   class="p-lg pt-0"
                 >
                   <div
-                    class="text-center py-12 text-muted-foreground"
+                    class="rounded-lg border bg-card text-card-foreground shadow-sm flex flex-col items-center justify-center py-2xl px-md text-center"
                   >
-                    <svg
-                      class="lucide lucide-shopping-cart h-12 w-12 mx-auto mb-4 opacity-50"
-                      fill="none"
-                      height="24"
-                      stroke="currentColor"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <div
+                      class="rounded-full bg-muted p-md mb-md"
                     >
-                      <circle
-                        cx="8"
-                        cy="21"
-                        r="1"
-                      />
-                      <circle
-                        cx="19"
-                        cy="21"
-                        r="1"
-                      />
-                      <path
-                        d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12"
-                      />
-                    </svg>
-                    <p>
+                      <svg
+                        class="lucide lucide-shopping-cart h-8 w-8"
+                        fill="none"
+                        height="24"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="8"
+                          cy="21"
+                          r="1"
+                        />
+                        <circle
+                          cx="19"
+                          cy="21"
+                          r="1"
+                        />
+                        <path
+                          d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12"
+                        />
+                      </svg>
+                    </div>
+                    <h3
+                      class="font-bold text-foreground mb-sm"
+                    >
                       Nenhum anúncio gerado ainda
-                    </p>
+                    </h3>
                     <p
-                      class="text-sm mt-1"
+                      class="text-muted-foreground mb-lg max-w-sm"
                     >
                       Use a geração rápida para criar um anúncio instantaneamente
                     </p>


### PR DESCRIPTION
## Summary
- refactor h4/p to Heading/Text in ad generator
- show EmptyState when no ad generated

## Testing
- `npm test -- --run` *(fails: Sidebar accessibility test timed out)*
- `npm run lint` *(fails: 16 errors, 704 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6892c33134a08329be7899f1f1aa830c