### PR TITLE
Replace shipping placeholders with EmptyState

### DIFF
--- a/src/pages/Shipping.tsx
+++ b/src/pages/Shipping.tsx
@@ -4,6 +4,7 @@ import { Truck, Plus } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { useFormVisibility } from "@/hooks/useFormVisibility";
 import { CollapsibleCard } from "@/components/ui/collapsible-card";
+import { EmptyState } from "@/components/ui/empty-state";
 
 const Shipping = () => {
   const { isFormVisible, isListVisible, showForm, hideForm, toggleList } = useFormVisibility({
@@ -53,10 +54,16 @@ const Shipping = () => {
           isOpen={isListVisible}
           onToggle={toggleList}
         >
-          <div className="p-4 text-center text-muted-foreground">
-            <p>Lista de regras de frete será exibida aqui</p>
-            <p className="text-sm mt-1">Adicione uma nova regra para começar</p>
-          </div>
+          <EmptyState
+            icon={<Truck className="h-8 w-8" />}
+            title="Nenhuma regra de frete configurada"
+            description="Adicione uma nova regra para começar"
+            action={{
+              label: "Nova Regra",
+              onClick: showForm,
+              icon: <Plus className="w-4 h-4 mr-2" />,
+            }}
+          />
         </CollapsibleCard>
       </div>
     </ConfigurationPageLayout>


### PR DESCRIPTION
## Summary
- replace placeholder shipping list paragraphs with EmptyState

## Testing
- `npm test -- --run` (fails: tests/components/Sidebar.test.tsx > AppSidebar accessibility > allows keyboard navigation through items)
- `npm run lint` (errors: 15, warnings: 710)
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6893617ab93483298fdaa3f2b8cdfa62