### PR TITLE
feat: add Playfair Display font

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,13 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display&display=swap"
+      rel="stylesheet"
+    />
   </head>
 
   <body>

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -6,8 +6,8 @@ import { cn } from "@/lib/utils";
 const headingVariants = cva("font-bold", {
   variants: {
     variant: {
-      h1: "text-h1",
-      h2: "text-h2",
+      h1: "text-h1 font-playfair",
+      h2: "text-h2 font-playfair",
       h3: "text-h3",
       h4: "text-h4",
       h5: "text-h5",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -60,6 +60,9 @@ export default {
                                 'accordion-down': 'accordion-down 0.2s ease-out',
                                 'accordion-up': 'accordion-up 0.2s ease-out'
                         },
+                        fontFamily: {
+                                playfair: ['"Playfair Display"', 'serif'],
+                        },
                         fontSize: typography,
                         spacing,
                 }


### PR DESCRIPTION
## Summary
- load Playfair Display font in index
- register font-playfair in Tailwind config
- apply font-playfair to h1 and h2 Heading variants

## Testing
- `npm test -- --run` *(fails: Snapshot ‘Snapshots das páginas principais > deve renderizar Dashboard corretamente 1’ mismatched)*
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68937b1ba38083298403627fb607672d