### PR TITLE
fix: prevent table overflow on small screens

### DIFF
--- a/e2e/no-overflow.spec.ts
+++ b/e2e/no-overflow.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 const sizes = [
+  { name: 'xs', width: 360, height: 800 },
   { name: 'sm', width: 640, height: 800 },
   { name: 'md', width: 768, height: 800 },
   { name: 'lg', width: 1024, height: 800 },

--- a/src/components/forms/SalesForm.tsx
+++ b/src/components/forms/SalesForm.tsx
@@ -189,52 +189,62 @@ export const SalesForm = ({ onCancel }: SalesFormProps) => {
           {isLoading ? (
             <p>Carregando...</p>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Produto</TableHead>
-                  <TableHead>Marketplace</TableHead>
-                  <TableHead>Preço</TableHead>
-                  <TableHead>Qtd</TableHead>
-                  <TableHead>Total</TableHead>
-                  <TableHead>Data</TableHead>
-                  <TableHead>Ações</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sales.map((sale) => (
-                  <TableRow key={sale.id}>
-                    <TableCell className="font-medium">{sale.products?.name}</TableCell>
-                    <TableCell>{sale.marketplaces?.name}</TableCell>
-                    <TableCell>{formatarMoeda(sale.price_charged)}</TableCell>
-                    <TableCell>{sale.quantity}</TableCell>
-                    <TableCell>{formatarMoeda(sale.price_charged * sale.quantity)}</TableCell>
-                    <TableCell>
-                      {format(new Date(sale.sold_at), "dd/MM/yyyy HH:mm", { locale: ptBR })}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex gap-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleEdit(sale)}
-                        >
-                          <Edit className="size-4" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="destructive"
-                          onClick={() => deleteMutation.mutate(sale.id)}
-                          disabled={deleteMutation.isPending}
-                        >
-                          <Trash2 className="size-4" />
-                        </Button>
-                      </div>
-                    </TableCell>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Produto</TableHead>
+                    <TableHead>Marketplace</TableHead>
+                    <TableHead>Preço</TableHead>
+                    <TableHead>Qtd</TableHead>
+                    <TableHead>Total</TableHead>
+                    <TableHead>Data</TableHead>
+                    <TableHead>Ações</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {sales.map((sale) => (
+                    <TableRow key={sale.id}>
+                      <TableCell className="font-medium break-words">
+                        {sale.products?.name}
+                      </TableCell>
+                      <TableCell className="break-words">
+                        {sale.marketplaces?.name}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {formatarMoeda(sale.price_charged)}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">{sale.quantity}</TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {formatarMoeda(sale.price_charged * sale.quantity)}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        {format(new Date(sale.sold_at), "dd/MM/yyyy HH:mm", { locale: ptBR })}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        <div className="flex gap-2">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleEdit(sale)}
+                          >
+                            <Edit className="size-4" />
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => deleteMutation.mutate(sale.id)}
+                            disabled={deleteMutation.isPending}
+                          >
+                            <Trash2 className="size-4" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/components/forms/ShippingRuleForm.tsx
+++ b/src/components/forms/ShippingRuleForm.tsx
@@ -318,51 +318,58 @@ export const ShippingRuleForm = ({ onCancel }: ShippingRuleFormProps) => {
           {isLoading ? (
             <p>Carregando...</p>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Produto</TableHead>
-                  <TableHead>Marketplace</TableHead>
-                  <TableHead>Custo Frete</TableHead>
-                  <TableHead>Frete Grátis</TableHead>
-                  <TableHead>Ações</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {shippingRules.map((rule) => (
-                  <TableRow key={rule.id}>
-                    <TableCell className="font-medium">{rule.products?.name}</TableCell>
-                    <TableCell>{rule.marketplaces?.name}</TableCell>
-                    <TableCell>R$ {rule.shipping_cost.toFixed(2)}</TableCell>
-                    <TableCell>
-                      {rule.free_shipping_threshold > 0 
-                        ? `A partir de R$ ${rule.free_shipping_threshold.toFixed(2)}`
-                        : "Não disponível"
-                      }
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex gap-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleEdit(rule)}
-                        >
-                          <Edit className="size-4" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="destructive"
-                          onClick={() => deleteMutation.mutate(rule.id)}
-                          disabled={deleteMutation.isPending}
-                        >
-                          <Trash2 className="size-4" />
-                        </Button>
-                      </div>
-                    </TableCell>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Produto</TableHead>
+                    <TableHead>Marketplace</TableHead>
+                    <TableHead>Custo Frete</TableHead>
+                    <TableHead>Frete Grátis</TableHead>
+                    <TableHead>Ações</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {shippingRules.map((rule) => (
+                    <TableRow key={rule.id}>
+                      <TableCell className="font-medium break-words">
+                        {rule.products?.name}
+                      </TableCell>
+                      <TableCell className="break-words">
+                        {rule.marketplaces?.name}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        R$ {rule.shipping_cost.toFixed(2)}
+                      </TableCell>
+                      <TableCell className="break-words">
+                        {rule.free_shipping_threshold > 0
+                          ? `A partir de R$ ${rule.free_shipping_threshold.toFixed(2)}`
+                          : "Não disponível"}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap">
+                        <div className="flex gap-2">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleEdit(rule)}
+                          >
+                            <Edit className="size-4" />
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => deleteMutation.mutate(rule.id)}
+                            disabled={deleteMutation.isPending}
+                          >
+                            <Trash2 className="size-4" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/pages/FixedFees.tsx
+++ b/src/pages/FixedFees.tsx
@@ -148,30 +148,32 @@ const FixedFees = () => {
           </CardHeader>
           <CardContent>
             {isLoading ? (
-              <Table>
-                {tableHeader}
-                <TableBody>
-                  {Array.from({ length: 3 }).map((_, i) => (
-                    <TableRow key={i}>
-                      <TableCell>
-                        <Skeleton className="h-4 w-24" />
-                      </TableCell>
-                      <TableCell>
-                        <Skeleton className="h-4 w-20" />
-                      </TableCell>
-                      <TableCell>
-                        <Skeleton className="h-4 w-32" />
-                      </TableCell>
-                      <TableCell>
-                        <Skeleton className="h-4 w-20" />
-                      </TableCell>
-                      <TableCell>
-                        <Skeleton className="size-8 rounded" />
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+              <div className="overflow-x-auto">
+                <Table>
+                  {tableHeader}
+                  <TableBody>
+                    {Array.from({ length: 3 }).map((_, i) => (
+                      <TableRow key={i}>
+                        <TableCell>
+                          <Skeleton className="h-4 w-24" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="h-4 w-20" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="h-4 w-32" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="h-4 w-20" />
+                        </TableCell>
+                        <TableCell>
+                          <Skeleton className="size-8 rounded" />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
             ) : fixedFeeRules.length === 0 ? (
               <EmptyState
                 icon={<Coins className="size-8" />}
@@ -179,47 +181,49 @@ const FixedFees = () => {
                 description="Adicione uma nova taxa para começar"
               />
             ) : (
-              <Table>
-                {tableHeader}
-                <TableBody>
-                  {fixedFeeRules.map((rule) => (
-                    <TableRow key={rule.id}>
-                      <TableCell className="font-medium">
-                        {rule.marketplaces?.name}
-                      </TableCell>
-                      <TableCell>
-                        {RULE_TYPES.find((t) => t.value === rule.rule_type)?.label}
-                      </TableCell>
-                      <TableCell>
-                        {(rule.rule_type === "faixa" || rule.rule_type === "percentual") &&
-                        rule.range_min !== null &&
-                        rule.range_max !== null
-                          ? `R$ ${rule.range_min.toFixed(2)} - R$ ${rule.range_max.toFixed(2)}`
-                          : rule.rule_type === "constante"
-                          ? "Todas as faixas"
-                          : "-"}
-                      </TableCell>
-                      <TableCell>
-                        {rule.rule_type === "percentual"
-                          ? `${rule.value.toFixed(2)}%`
-                          : `R$ ${rule.value.toFixed(2)}`}
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex gap-2">
-                          <Button
-                            size="sm"
-                            variant="destructive"
-                            onClick={() => deleteMutation.mutate(rule.id)}
-                            disabled={deleteMutation.isPending}
-                          >
-                            <Trash2 className="size-4" />
-                          </Button>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+              <div className="overflow-x-auto">
+                <Table>
+                  {tableHeader}
+                  <TableBody>
+                    {fixedFeeRules.map((rule) => (
+                      <TableRow key={rule.id}>
+                        <TableCell className="font-medium break-words">
+                          {rule.marketplaces?.name}
+                        </TableCell>
+                        <TableCell className="break-words">
+                          {RULE_TYPES.find((t) => t.value === rule.rule_type)?.label}
+                        </TableCell>
+                        <TableCell className="break-words">
+                          {(rule.rule_type === "faixa" || rule.rule_type === "percentual") &&
+                          rule.range_min !== null &&
+                          rule.range_max !== null
+                            ? `R$ ${rule.range_min.toFixed(2)} - R$ ${rule.range_max.toFixed(2)}`
+                            : rule.rule_type === "constante"
+                            ? "Todas as faixas"
+                            : "-"}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap">
+                          {rule.rule_type === "percentual"
+                            ? `${rule.value.toFixed(2)}%`
+                            : `R$ ${rule.value.toFixed(2)}`}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap">
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              onClick={() => deleteMutation.mutate(rule.id)}
+                              disabled={deleteMutation.isPending}
+                            >
+                              <Trash2 className="size-4" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
             )}
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- ensure tables scroll within cards on narrow viewports
- add small viewport check in e2e tests

## Testing
- `npm test` *(fails: snapshot mismatches)*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in tests)*
- `npm run test:e2e` *(fails: horizontal overflow checks)*

------
https://chatgpt.com/codex/tasks/task_e_68937fb635fc83298d69ae3bab4bf45b