### PR TITLE
refactor: use BaseCard for marketplace views

### DIFF
--- a/src/components/marketplace/MarketplaceHierarchyCard.tsx
+++ b/src/components/marketplace/MarketplaceHierarchyCard.tsx
@@ -1,8 +1,9 @@
 import { Plus, Store, Settings, Trash2 } from '@/components/ui/icons';
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { StatusBadge } from "@/components/ui/status-badge";
+import { BaseCard } from "@/components/ui";
+import { CardTitle } from "@/components/ui/card";
 import { MarketplaceHierarchy, MarketplaceType } from "@/types/marketplaces";
 
 interface MarketplaceHierarchyCardProps {
@@ -27,134 +28,130 @@ export const MarketplaceHierarchyCard = ({
   const isConfigured = platform.url && platform.description;
 
   return (
-    <Card className="overflow-hidden">
-      <CardHeader className="bg-muted/50">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Store className="size-5 text-primary" />
-            <div>
-              <CardTitle className="text-lg">{platform.name}</CardTitle>
-              <div className="mt-1 flex items-center gap-2">
-                <Badge variant="secondary" className="text-xs">
-                  Plataforma
-                </Badge>
-                <StatusBadge
-                  status={isConfigured ? "configured" : "pending"}
-                  label={isConfigured ? "Configurada" : "Pendente"}
-                  size="sm"
-                />
-              </div>
-            </div>
-          </div>
-          
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
+    <BaseCard
+      className="overflow-hidden [&>div:first-child]:bg-muted/50"
+      icon={<Store className="size-5 text-primary" />}
+      title={
+        <div>
+          <CardTitle className="text-lg">{platform.name}</CardTitle>
+          <div className="mt-1 flex items-center gap-2">
+            <Badge variant="secondary" className="text-xs">
+              Plataforma
+            </Badge>
+            <StatusBadge
+              status={isConfigured ? "configured" : "pending"}
+              label={isConfigured ? "Configurada" : "Pendente"}
               size="sm"
-              onClick={() => onEditPlatform(platform)}
-            >
-              <Settings className="size-4" />
-            </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={() => onDeletePlatform(platform.id)}
-            >
-              <Trash2 className="size-4" />
-            </Button>
+            />
           </div>
+          {platform.description && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              {platform.description}
+            </p>
+          )}
         </div>
-        
-        {platform.description && (
-          <p className="mt-2 text-sm text-muted-foreground">
-            {platform.description}
-          </p>
-        )}
-      </CardHeader>
+      }
+      actions={
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onEditPlatform(platform)}
+          >
+            <Settings className="size-4" />
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => onDeletePlatform(platform.id)}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
+      }
+      contentSpacing="space-y-0"
+    >
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h4 className="text-sm font-medium">Modalidades</h4>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onAddModality(platform.id)}
+            className="h-8"
+          >
+            <Plus className="mr-1 size-4" />
+            Nova Modalidade
+          </Button>
+        </div>
 
-      <CardContent className="p-4">
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h4 className="text-sm font-medium">Modalidades</h4>
+        {hasModalities ? (
+          <div className="space-y-2">
+            {modalities.map((modality) => {
+              const modalityConfigured = modality.url && modality.description;
+              return (
+                <div
+                  key={modality.id}
+                  className="flex items-center justify-between rounded-lg border bg-card p-3 transition-colors hover:bg-accent/50"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="text-sm text-muted-foreground">└</div>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{modality.name}</span>
+                        <StatusBadge
+                          status={modalityConfigured ? "configured" : "pending"}
+                          label={modalityConfigured ? "Configurada" : "Pendente"}
+                          size="sm"
+                        />
+                      </div>
+                      {modality.description && (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {modality.description}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onEditModality(modality)}
+                      className="size-8 p-0"
+                    >
+                      <Settings className="size-3" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onDeleteModality(modality.id)}
+                      className="size-8 p-0 text-destructive hover:text-destructive"
+                    >
+                      <Trash2 className="size-3" />
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="rounded-lg border-2 border-dashed border-muted-foreground/25 bg-muted/25 py-6 text-center">
+            <Store className="mx-auto mb-2 size-8 text-muted-foreground" />
+            <p className="mb-3 text-sm text-muted-foreground">
+              Nenhuma modalidade cadastrada para esta plataforma
+            </p>
             <Button
               variant="outline"
               size="sm"
               onClick={() => onAddModality(platform.id)}
-              className="h-8"
             >
-              <Plus className="mr-1 size-4" />
-              Nova Modalidade
+              <Plus className="mr-2 size-4" />
+              Adicionar Primeira Modalidade
             </Button>
           </div>
-
-          {hasModalities ? (
-            <div className="space-y-2">
-              {modalities.map((modality) => {
-                const modalityConfigured = modality.url && modality.description;
-                return (
-                  <div
-                    key={modality.id}
-                    className="flex items-center justify-between rounded-lg border bg-card p-3 transition-colors hover:bg-accent/50"
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="text-sm text-muted-foreground">└</div>
-                      <div>
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium">{modality.name}</span>
-                          <StatusBadge
-                            status={modalityConfigured ? "configured" : "pending"}
-                            label={modalityConfigured ? "Configurada" : "Pendente"}
-                            size="sm"
-                          />
-                        </div>
-                        {modality.description && (
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            {modality.description}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                    
-                    <div className="flex items-center gap-1">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => onEditModality(modality)}
-                        className="size-8 p-0"
-                      >
-                        <Settings className="size-3" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => onDeleteModality(modality.id)}
-                        className="size-8 p-0 text-destructive hover:text-destructive"
-                      >
-                        <Trash2 className="size-3" />
-                      </Button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="rounded-lg border-2 border-dashed border-muted-foreground/25 bg-muted/25 py-6 text-center">
-              <Store className="mx-auto mb-2 size-8 text-muted-foreground" />
-              <p className="mb-3 text-sm text-muted-foreground">
-                Nenhuma modalidade cadastrada para esta plataforma
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => onAddModality(platform.id)}
-              >
-                <Plus className="mr-2 size-4" />
-                Adicionar Primeira Modalidade
-              </Button>
-            </div>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+        )}
+      </div>
+    </BaseCard>
   );
 };

--- a/src/pages/Marketplaces.tsx
+++ b/src/pages/Marketplaces.tsx
@@ -1,4 +1,4 @@
-import { Store, Plus, Eye, EyeOff } from '@/components/ui/icons';
+import { Store, Plus, Eye, EyeOff, ChevronDown, ChevronUp } from '@/components/ui/icons';
 import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
 import { Button } from "@/components/ui/button";
 import { SimpleMarketplaceForm } from "@/components/forms/enhanced/SimpleMarketplaceForm";
@@ -7,7 +7,7 @@ import { useMarketplacesHierarchical, useDeleteMarketplace } from "@/hooks/useMa
 import { MarketplaceType } from "@/types/marketplaces";
 import { useState } from "react";
 import { useFormVisibility } from "@/hooks/useFormVisibility";
-import { CollapsibleCard } from "@/components/ui/collapsible-card";
+import { BaseCard } from "@/components/ui";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -105,11 +105,21 @@ const Marketplaces = () => {
             : "lg:col-span-12 xl:col-span-12"
         }
       >
-        <CollapsibleCard
+        <BaseCard
           title="Plataformas e Modalidades"
           icon={<Store className="size-4" />}
-          isOpen={isListVisible}
-          onToggle={toggleList}
+          status={
+            isListVisible ? (
+              <ChevronUp className="size-4" />
+            ) : (
+              <ChevronDown className="size-4" />
+            )
+          }
+          collapsible
+          open={isListVisible}
+          onOpenChange={() => toggleList()}
+          className="shadow-card border border-border/20"
+          contentPadding="px-6 pb-4 pt-0"
         >
           {isLoading ? (
             <div className="space-y-4 py-12">
@@ -160,7 +170,7 @@ const Marketplaces = () => {
               )}
             </div>
           )}
-        </CollapsibleCard>
+        </BaseCard>
       </div>
     </ConfigurationPageLayout>
   );


### PR DESCRIPTION
## Summary
- refactor marketplace hierarchy cards to use shared BaseCard
- switch marketplace page list to collapsible BaseCard

## Testing
- `npm run type-check`
- `npm test` *(fails: 4 snapshot mismatches)*
- `npm run lint` *(fails: Unexpected any in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68938dfe3d7883299025bd0af740250a