### PR TITLE
refactor: use BaseCard for common layouts

### DIFF
--- a/src/components/forms/ProductForm.tsx
+++ b/src/components/forms/ProductForm.tsx
@@ -4,7 +4,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardTitle } from "@/components/ui/card";
+import { BaseCard } from "@/components/ui";
 import { Badge } from "@/components/ui/badge";
 import { Trash2, Edit, Package, Tag, Save, X, AlertCircle } from '@/components/ui/icons';
 import { useProductsWithCategories, useCreateProduct, useUpdateProduct, useDeleteProduct } from "@/hooks/useProducts";
@@ -247,15 +248,18 @@ export const ProductForm = () => {
   return (
     <div className="space-y-6">
       {/* Formulário Principal - Layout Coeso */}
-      <Card className="border border-border/50 shadow-card">
-        <CardHeader className="bg-card">
+      <BaseCard
+        className="border border-border/50 shadow-card"
+        title={
           <CardTitle className="flex items-center gap-2 text-xl">
             <Package className="size-6" />
             {editingId ? "Editar Produto" : "Novo Produto"}
           </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-6 p-6">
-          <form onSubmit={handleSubmit} className="space-y-6">
+        }
+        contentPadding="p-6"
+        contentSpacing="space-y-6"
+      >
+        <form onSubmit={handleSubmit} className="space-y-6">
             {/* Informações Básicas */}
             <div className="space-y-4">
               <h3 className="border-b border-border pb-2 text-lg font-semibold text-foreground">
@@ -452,8 +456,7 @@ export const ProductForm = () => {
               )}
             </div>
           </form>
-        </CardContent>
-      </Card>
+      </BaseCard>
 
       {/* Lista de Produtos */}
       <CollapsibleCard

--- a/src/index.css
+++ b/src/index.css
@@ -423,3 +423,9 @@ All colors MUST be HSL.
     @apply transition-all duration-200 hover:scale-[1.02] active:scale-[0.98];
   }
 }
+
+@layer components {
+  .highlight {
+    @apply col-span-full;
+  }
+}

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -2,7 +2,7 @@ import { CategoryForm } from "@/components/forms/CategoryForm";
 import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
 import { FolderTree, Plus, Edit, Trash2 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BaseCard } from "@/components/ui";
 import { useFormVisibility } from "@/hooks/useFormVisibility";
 import { useCategories, useDeleteCategory } from "@/hooks/useCategories";
 import { CategoryType } from "@/types/categories";
@@ -103,31 +103,32 @@ const Categories = () => {
             : "lg:col-span-12 xl:col-span-12"
         }
       >
-        <Card className="border border-border/20 shadow-card">
-          <CardHeader className="py-3">
-            <CardTitle className="flex items-center gap-2 text-base font-medium text-muted-foreground">
+        <BaseCard
+          className="border border-border/20 shadow-card"
+          title={
+            <div className="flex items-center gap-2 text-base font-medium text-muted-foreground">
               <FolderTree className="size-4" />
               <span>Categorias Cadastradas</span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="px-6 pb-4 pt-0">
-            <DataVisualization
-              title=""
-              data={categories}
-              columns={columns}
-              actions={actions}
-              isLoading={isLoading}
-              emptyState={
-                <div className="py-8 text-center">
-                  <Text className="text-muted-foreground">Nenhuma categoria cadastrada</Text>
-                  <Text variant="caption" className="text-muted-foreground">
-                    Crie sua primeira categoria usando o formulário ao lado
-                  </Text>
-                </div>
-              }
-            />
-          </CardContent>
-        </Card>
+            </div>
+          }
+          contentPadding="px-6 pb-4 pt-0"
+        >
+          <DataVisualization
+            title=""
+            data={categories}
+            columns={columns}
+            actions={actions}
+            isLoading={isLoading}
+            emptyState={
+              <div className="py-8 text-center">
+                <Text className="text-muted-foreground">Nenhuma categoria cadastrada</Text>
+                <Text variant="caption" className="text-muted-foreground">
+                  Crie sua primeira categoria usando o formulário ao lado
+                </Text>
+              </div>
+            }
+          />
+        </BaseCard>
       </div>
     </ConfigurationPageLayout>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { DashboardForm } from "@/components/forms/DashboardForm";
 import { OnboardingTour } from "@/components/onboarding/OnboardingTour";
 import { useOnboarding } from "@/hooks/useOnboarding";
-import { Card, CardContent } from "@/components/ui/card";
+import { BaseCard } from "@/components/ui";
 import { Heading, Text } from "@/components/ui/typography";
 
 const Dashboard = () => {
@@ -24,11 +24,12 @@ const Dashboard = () => {
         </div>
 
         {/* Main Content */}
-        <Card className="border-0 bg-gradient-subtle shadow-card">
-          <CardContent className="p-lg">
-            <DashboardForm />
-          </CardContent>
-        </Card>
+        <BaseCard
+          className="border-0 bg-gradient-subtle shadow-card"
+          contentPadding="p-lg"
+        >
+          <DashboardForm />
+        </BaseCard>
       </div>
       
       {showOnboarding && (


### PR DESCRIPTION
## Summary
- add `.highlight` utility to span full card width
- refactor dashboard and product form to use `BaseCard`
- use `BaseCard` for categories list

## Testing
- `npm test` *(fails: Snapshot mismatched, query data undefined)*

------
https://chatgpt.com/codex/tasks/task_e_689390fccd8083298ce6d61f2230d3b2