### PR TITLE
feat: add dynamic design tokens

### DIFF
--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
 import type { ThemeProviderProps } from "next-themes/dist/types";
 import { useEffect } from "react";
+import type { TokenOverrides } from "@/styles/tokens";
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return (
@@ -22,17 +23,48 @@ function ThemeWatcher({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const root = document.documentElement;
-    
+
     // Remove previous theme classes
-    root.classList.remove('light', 'dark', 'corporate', 'windows7');
-    
+    root.classList.remove("light", "dark", "corporate", "windows7");
+
     // Add current theme class
     if (theme) {
       root.classList.add(theme);
     }
+
+    // Load and apply Super Admin token overrides
+    loadSuperAdminTokens().then(applyTokenOverrides);
   }, [theme]);
 
   return <>{children}</>;
+}
+
+// Fetch token overrides saved by the Super Admin.
+// In a real application this could be an API request; here we read from localStorage.
+async function loadSuperAdminTokens(): Promise<TokenOverrides> {
+  try {
+    const raw = localStorage.getItem("super-admin-tokens");
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+// Apply token overrides by updating the corresponding CSS variables.
+function applyTokenOverrides(overrides: TokenOverrides) {
+  const root = document.documentElement;
+
+  Object.entries(overrides.colors ?? {}).forEach(([key, value]) => {
+    root.style.setProperty(`--${key}`, value);
+  });
+
+  Object.entries(overrides.typography ?? {}).forEach(([key, value]) => {
+    root.style.setProperty(`--font-${key}`, value);
+  });
+
+  Object.entries(overrides.spacing ?? {}).forEach(([key, value]) => {
+    root.style.setProperty(`--spacing-${key}`, value);
+  });
 }
 
 export { useTheme };

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -82,3 +82,26 @@ export const spacing = {
   '2xl': 'var(--spacing-2xl)',
 } as const;
 
+/**
+ * Consolidated design tokens used across the application.
+ * These tokens map to CSS variables declared in `index.css`.
+ */
+export const tokens = {
+  colors,
+  typography,
+  spacing,
+} as const;
+
+export type Tokens = typeof tokens;
+
+/**
+ * Structure used to override design tokens at runtime.
+ * Each property accepts raw CSS values which will be assigned to
+ * the corresponding CSS variables (e.g. `colors.primary` -> `--primary`).
+ */
+export type TokenOverrides = {
+  colors?: Record<string, string>;
+  typography?: Record<string, string>;
+  spacing?: Record<string, string>;
+};
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,6 @@
 import type { Config } from "tailwindcss";
 import tailwindcssAnimate from "tailwindcss-animate";
-import { colors, typography, spacing } from "./src/styles/tokens";
+import { tokens } from "./src/styles/tokens";
 
 export default {
 	darkMode: ["class"],
@@ -20,7 +20,7 @@ export default {
 			}
 		},
                 extend: {
-                        colors,
+                        colors: tokens.colors,
 			backgroundImage: {
 				'gradient-primary': 'var(--gradient-primary)',
 				'gradient-card': 'var(--gradient-card)',
@@ -63,8 +63,8 @@ export default {
                         fontFamily: {
                                 playfair: ['"Playfair Display"', 'serif'],
                         },
-                        fontSize: typography,
-                        spacing,
+                        fontSize: tokens.typography,
+                        spacing: tokens.spacing,
                 }
         },
         plugins: [tailwindcssAnimate],


### PR DESCRIPTION
## Summary
- consolidate design tokens and expose typed overrides
- use tokens to configure Tailwind theme
- apply Super Admin token overrides at runtime

## Testing
- `npm test -- --run` *(fails: snapshot mismatched)*
- `npm run lint` *(fails: Unexpected any)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6893a57ecb8c8329a388522a2b007908