### PR TITLE
refactor: add theme design tokens

### DIFF
--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -59,11 +59,24 @@ function applyTokenOverrides(overrides: TokenOverrides) {
   });
 
   Object.entries(overrides.typography ?? {}).forEach(([key, value]) => {
-    root.style.setProperty(`--font-${key}`, value);
+    const variable = key === 'body' ? '--font-size-body' : `--font-${key}`;
+    root.style.setProperty(variable, value);
   });
 
   Object.entries(overrides.spacing ?? {}).forEach(([key, value]) => {
     root.style.setProperty(`--spacing-${key}`, value);
+  });
+
+  Object.entries(overrides.fonts ?? {}).forEach(([key, value]) => {
+    root.style.setProperty(`--font-${key}`, value);
+  });
+
+  Object.entries(overrides.radii ?? {}).forEach(([key, value]) => {
+    root.style.setProperty(`--${key}`, value);
+  });
+
+  Object.entries(overrides.shadows ?? {}).forEach(([key, value]) => {
+    root.style.setProperty(`--${key}`, value);
   });
 }
 

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -3,11 +3,11 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
-const headingVariants = cva("font-bold", {
+const headingVariants = cva("font-bold font-heading", {
   variants: {
     variant: {
-      h1: "text-h1 font-playfair",
-      h2: "text-h2 font-playfair",
+      h1: "text-h1",
+      h2: "text-h2",
       h3: "text-h3",
       h4: "text-h4",
       h5: "text-h5",
@@ -38,7 +38,7 @@ export const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
 );
 Heading.displayName = "Heading";
 
-const textVariants = cva("", {
+const textVariants = cva("font-body", {
   variants: {
     variant: {
       body: "text-body",

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,9 @@ All colors MUST be HSL.
     --input: 220 13% 91%;
     --ring: 258 56% 52%;
     --radius: 0rem; /* Corporate style: no rounding */
+    --color-primary: hsl(var(--primary));
+    --color-secondary: hsl(var(--secondary));
+    --card-radius: var(--radius);
 
     /* Sidebar System (adapted from corporate) */
     --sidebar-background: 258 56% 52%;
@@ -60,6 +63,9 @@ All colors MUST be HSL.
     --shadow-form: 0 2px 10px -2px hsl(258 56% 52% / 0.08);
     --shadow-floating: 0 20px 40px -12px hsl(258 56% 52% / 0.25);
     --shadow-glow: 0 0 40px hsl(258 56% 52% / 0.3);
+    --card-shadow: var(--shadow-card);
+    --font-heading: "Playfair Display", serif;
+    --font-body: ui-sans-serif, system-ui, sans-serif;
 
     /* Animation Timings (from corporate) */
     --transition-fast: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
@@ -81,7 +87,7 @@ All colors MUST be HSL.
     --font-h4: 1.25rem;
     --font-h5: 1.125rem;
     --font-h6: 1rem;
-    --font-body: 0.875rem;
+    --font-size-body: 0.875rem;
     --font-caption: 0.75rem;
 
     /* Spacing System (from corporate) */
@@ -156,7 +162,7 @@ All colors MUST be HSL.
     --font-h4: 1.25rem;
     --font-h5: 1.125rem;
     --font-h6: 1rem;
-    --font-body: 1rem;
+    --font-size-body: 1rem;
     --font-caption: 0.875rem;
 
     /* Spacing */
@@ -247,7 +253,7 @@ All colors MUST be HSL.
     --font-h4: 1.25rem;
     --font-h5: 1.125rem;
     --font-h6: 1rem;
-    --font-body: 0.875rem;
+    --font-size-body: 0.875rem;
     --font-caption: 0.75rem;
 
     /* Spacing System */
@@ -332,7 +338,7 @@ All colors MUST be HSL.
     --font-h4: 1.25rem;
     --font-h5: 1.125rem;
     --font-h6: 1rem;
-    --font-body: 0.875rem;
+    --font-size-body: 0.875rem;
     --font-caption: 0.75rem;
 
     /* Spacing System (from corporate) */
@@ -351,7 +357,7 @@ All colors MUST be HSL.
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-body;
   }
 
   /* Scroll behavior */

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -5,11 +5,11 @@ export const colors = {
   background: 'hsl(var(--background))',
   foreground: 'hsl(var(--foreground))',
   primary: {
-    DEFAULT: 'hsl(var(--primary))',
+    DEFAULT: 'hsl(var(--color-primary))',
     foreground: 'hsl(var(--primary-foreground))',
   },
   secondary: {
-    DEFAULT: 'hsl(var(--secondary))',
+    DEFAULT: 'hsl(var(--color-secondary))',
     foreground: 'hsl(var(--secondary-foreground))',
   },
   destructive: {
@@ -69,7 +69,7 @@ export const typography = {
   h4: 'var(--font-h4)',
   h5: 'var(--font-h5)',
   h6: 'var(--font-h6)',
-  body: 'var(--font-body)',
+  body: 'var(--font-size-body)',
   caption: 'var(--font-caption)',
 } as const;
 
@@ -82,6 +82,19 @@ export const spacing = {
   '2xl': 'var(--spacing-2xl)',
 } as const;
 
+export const fonts = {
+  heading: 'var(--font-heading)',
+  body: 'var(--font-body)',
+} as const;
+
+export const radii = {
+  card: 'var(--card-radius)',
+} as const;
+
+export const shadows = {
+  card: 'var(--card-shadow)',
+} as const;
+
 /**
  * Consolidated design tokens used across the application.
  * These tokens map to CSS variables declared in `index.css`.
@@ -90,6 +103,9 @@ export const tokens = {
   colors,
   typography,
   spacing,
+  fonts,
+  radii,
+  shadows,
 } as const;
 
 export type Tokens = typeof tokens;
@@ -103,5 +119,8 @@ export type TokenOverrides = {
   colors?: Record<string, string>;
   typography?: Record<string, string>;
   spacing?: Record<string, string>;
+  fonts?: Record<string, string>;
+  radii?: Record<string, string>;
+  shadows?: Record<string, string>;
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,23 +21,24 @@ export default {
 		},
                 extend: {
                         colors: tokens.colors,
-			backgroundImage: {
-				'gradient-primary': 'var(--gradient-primary)',
-				'gradient-card': 'var(--gradient-card)',
-				'gradient-config': 'var(--gradient-config)',
-				'gradient-subtle': 'var(--gradient-subtle)'
-			},
-			boxShadow: {
-				'elegant': 'var(--shadow-elegant)',
-				'card': 'var(--shadow-card)',
-				'hover': 'var(--shadow-hover)',
-				'form': 'var(--shadow-form)'
-			},
-			borderRadius: {
-				lg: 'var(--radius)',
-				md: 'calc(var(--radius) - 2px)',
-				sm: 'calc(var(--radius) - 4px)'
-			},
+                        backgroundImage: {
+                                'gradient-primary': 'var(--gradient-primary)',
+                                'gradient-card': 'var(--gradient-card)',
+                                'gradient-config': 'var(--gradient-config)',
+                                'gradient-subtle': 'var(--gradient-subtle)'
+                        },
+                        boxShadow: {
+                                'elegant': 'var(--shadow-elegant)',
+                                'card': 'var(--card-shadow)',
+                                'hover': 'var(--shadow-hover)',
+                                'form': 'var(--shadow-form)'
+                        },
+                        borderRadius: {
+                                lg: 'var(--radius)',
+                                md: 'calc(var(--radius) - 2px)',
+                                sm: 'calc(var(--radius) - 4px)',
+                                card: 'var(--card-radius)'
+                        },
 			keyframes: {
 				'accordion-down': {
 					from: {
@@ -61,7 +62,8 @@ export default {
                                 'accordion-up': 'accordion-up 0.2s ease-out'
                         },
                         fontFamily: {
-                                playfair: ['"Playfair Display"', 'serif'],
+                                heading: [tokens.fonts.heading],
+                                body: [tokens.fonts.body],
                         },
                         fontSize: tokens.typography,
                         spacing: tokens.spacing,


### PR DESCRIPTION
## Summary
- map primary and secondary colors, font families, and card styles to CSS custom properties
- extend ThemeProvider to apply runtime token overrides
- use font-heading and font-body utility classes for headings and text

## Testing
- `npm test` *(fails: Snapshot `Snapshots das páginas principais > deve renderizar AdGenerator corretamente 1` mismatched)*
- `npm run lint` *(fails: Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6893c1344cb0832991550bd613219c0a