### PR TITLE
refactor: align form layouts and page containers

### DIFF
--- a/src/components/forms/AssistantForm.tsx
+++ b/src/components/forms/AssistantForm.tsx
@@ -145,30 +145,32 @@ export function AssistantForm({ open, onOpenChange, assistant, onSuccess }: Assi
               control={form.control}
               name="name"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="grid md:grid-cols-[2fr_3fr] gap-6 space-y-0">
                   <FormLabel>Nome do Assistente</FormLabel>
-                  <FormControl>
-                    <Input 
-                      placeholder="Ex: Assistente Mercado Livre Premium" 
-                      {...field} 
-                      disabled={isLoading}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Nome descritivo para identificar o assistente.
-                  </FormDescription>
-                  <FormMessage />
+                  <div className="space-y-1">
+                    <FormControl>
+                      <Input
+                        placeholder="Ex: Assistente Mercado Livre Premium"
+                        {...field}
+                        disabled={isLoading}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Nome descritivo para identificar o assistente.
+                    </FormDescription>
+                    <FormMessage />
+                  </div>
                 </FormItem>
               )}
             />
 
-            <div className="grid grid-cols-2 gap-4">
-              <FormField
-                control={form.control}
-                name="marketplace"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Marketplace</FormLabel>
+            <FormField
+              control={form.control}
+              name="marketplace"
+              render={({ field }) => (
+                <FormItem className="grid md:grid-cols-[2fr_3fr] gap-6 space-y-0">
+                  <FormLabel>Marketplace</FormLabel>
+                  <div className="space-y-1">
                     <Select onValueChange={field.onChange} value={field.value} disabled={isLoading}>
                       <FormControl>
                         <SelectTrigger>
@@ -187,16 +189,18 @@ export function AssistantForm({ open, onOpenChange, assistant, onSuccess }: Assi
                       Marketplace para o qual este assistente será usado.
                     </FormDescription>
                     <FormMessage />
-                  </FormItem>
-                )}
-              />
+                  </div>
+                </FormItem>
+              )}
+            />
 
-              <FormField
-                control={form.control}
-                name="mode"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Modo</FormLabel>
+            <FormField
+              control={form.control}
+              name="mode"
+              render={({ field }) => (
+                <FormItem className="grid md:grid-cols-[2fr_3fr] gap-6 space-y-0">
+                  <FormLabel>Modo</FormLabel>
+                  <div className="space-y-1">
                     <Select onValueChange={field.onChange} value={field.value} disabled={isLoading}>
                       <FormControl>
                         <SelectTrigger>
@@ -215,35 +219,37 @@ export function AssistantForm({ open, onOpenChange, assistant, onSuccess }: Assi
                       Modo de geração do assistente.
                     </FormDescription>
                     <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+                  </div>
+                </FormItem>
+              )}
+            />
 
             <FormField
               control={form.control}
               name="model"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="grid md:grid-cols-[2fr_3fr] gap-6 space-y-0">
                   <FormLabel>Modelo OpenAI</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value} disabled={isLoading}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Selecione o modelo" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {AVAILABLE_MODELS.map((model) => (
-                        <SelectItem key={model.value} value={model.value}>
-                          {model.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormDescription>
-                    Modelo da OpenAI que será usado pelo assistente.
-                  </FormDescription>
-                  <FormMessage />
+                  <div className="space-y-1">
+                    <Select onValueChange={field.onChange} value={field.value} disabled={isLoading}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Selecione o modelo" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {AVAILABLE_MODELS.map((model) => (
+                          <SelectItem key={model.value} value={model.value}>
+                            {model.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormDescription>
+                      Modelo da OpenAI que será usado pelo assistente.
+                    </FormDescription>
+                    <FormMessage />
+                  </div>
                 </FormItem>
               )}
             />
@@ -252,20 +258,22 @@ export function AssistantForm({ open, onOpenChange, assistant, onSuccess }: Assi
               control={form.control}
               name="instructions"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="grid md:grid-cols-[2fr_3fr] gap-6 space-y-0">
                   <FormLabel>Instruções</FormLabel>
-                  <FormControl>
-                    <Textarea 
-                      placeholder="Descreva detalhadamente como o assistente deve se comportar..."
-                      className="min-h-[120px] resize-none"
-                      {...field}
-                      disabled={isLoading}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Instruções detalhadas para o comportamento do assistente. ({characterCount} caracteres, mínimo 50)
-                  </FormDescription>
-                  <FormMessage />
+                  <div className="space-y-1">
+                    <FormControl>
+                      <Textarea
+                        placeholder="Descreva detalhadamente como o assistente deve se comportar..."
+                        className="min-h-[120px] resize-none"
+                        {...field}
+                        disabled={isLoading}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Instruções detalhadas para o comportamento do assistente. ({characterCount} caracteres, mínimo 50)
+                    </FormDescription>
+                    <FormMessage />
+                  </div>
                 </FormItem>
               )}
             />

--- a/src/components/forms/ProductForm.tsx
+++ b/src/components/forms/ProductForm.tsx
@@ -266,18 +266,17 @@ export const ProductForm = () => {
                 Informações Básicas
               </h3>
               
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+                <Label htmlFor="name" className="text-sm font-medium">
+                  Nome *
+                </Label>
                 <div>
-                  <Label htmlFor="name" className="text-sm font-medium">
-                    Nome *
-                  </Label>
                   <Input
                     id="name"
                     value={formData.name}
                     onChange={(e) => handleInputChange("name", e.target.value)}
                     placeholder="Ex: Smartphone Samsung Galaxy"
                     className={cn(
-                      "mt-1",
                       errors.name && touched.name ? "border-destructive focus-visible:ring-destructive" : ""
                     )}
                     required
@@ -289,26 +288,26 @@ export const ProductForm = () => {
                     </div>
                   )}
                 </div>
-                
-                <div>
-                  <Label htmlFor="category" className="text-sm font-medium">Categoria</Label>
-                  <Select 
-                    value={formData.category_id} 
-                    onValueChange={(value) => handleInputChange("category_id", value)}
-                  >
-                    <SelectTrigger className="mt-1">
-                      <SelectValue placeholder="Selecione uma categoria" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">Nenhuma categoria</SelectItem>
-                      {categories.map((category) => (
-                        <SelectItem key={category.id} value={category.id}>
-                          {category.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
+              </div>
+
+              <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+                <Label htmlFor="category" className="text-sm font-medium">Categoria</Label>
+                <Select
+                  value={formData.category_id}
+                  onValueChange={(value) => handleInputChange("category_id", value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecione uma categoria" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">Nenhuma categoria</SelectItem>
+                    {categories.map((category) => (
+                      <SelectItem key={category.id} value={category.id}>
+                        {category.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             </div>
 
@@ -318,11 +317,11 @@ export const ProductForm = () => {
                 Configuração de Custos
               </h3>
               
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+              <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+                <Label htmlFor="cost_unit" className="text-sm font-medium">
+                  Custo Unitário (R$) *
+                </Label>
                 <div>
-                  <Label htmlFor="cost_unit" className="text-sm font-medium">
-                    Custo Unitário (R$) *
-                  </Label>
                   <Input
                     id="cost_unit"
                     type="number"
@@ -332,7 +331,6 @@ export const ProductForm = () => {
                     onChange={(e) => handleInputChange("cost_unit", parseFloat(e.target.value) || 0)}
                     placeholder="0,00"
                     className={cn(
-                      "mt-1",
                       errors.cost_unit && touched.cost_unit ? "border-destructive focus-visible:ring-destructive" : ""
                     )}
                     required
@@ -344,27 +342,28 @@ export const ProductForm = () => {
                     </div>
                   )}
                 </div>
-                
+              </div>
+
+              <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+                <Label htmlFor="packaging_cost" className="text-sm font-medium">
+                  Custo da Embalagem (R$)
+                </Label>
+                <Input
+                  id="packaging_cost"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={formData.packaging_cost}
+                  onChange={(e) => handleInputChange("packaging_cost", parseFloat(e.target.value) || 0)}
+                  placeholder="0,00"
+                />
+              </div>
+
+              <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+                <Label htmlFor="tax_rate" className="text-sm font-medium">
+                  Alíquota de Imposto (%)
+                </Label>
                 <div>
-                  <Label htmlFor="packaging_cost" className="text-sm font-medium">
-                    Custo da Embalagem (R$)
-                  </Label>
-                  <Input
-                    id="packaging_cost"
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    value={formData.packaging_cost}
-                    onChange={(e) => handleInputChange("packaging_cost", parseFloat(e.target.value) || 0)}
-                    placeholder="0,00"
-                    className="mt-1"
-                  />
-                </div>
-                
-                <div>
-                  <Label htmlFor="tax_rate" className="text-sm font-medium">
-                    Alíquota de Imposto (%)
-                  </Label>
                   <Input
                     id="tax_rate"
                     type="number"
@@ -375,7 +374,6 @@ export const ProductForm = () => {
                     onChange={(e) => handleInputChange("tax_rate", parseFloat(e.target.value) || 0)}
                     placeholder="0,00"
                     className={cn(
-                      "mt-1",
                       errors.tax_rate && touched.tax_rate ? "border-destructive focus-visible:ring-destructive" : ""
                     )}
                   />
@@ -409,25 +407,24 @@ export const ProductForm = () => {
               onToggle={optionalFields.toggle}
             >
               <div className="space-y-4">
-                <div>
+                <div className="grid md:grid-cols-[2fr_3fr] gap-6">
                   <Label htmlFor="sku" className="text-sm font-medium">SKU</Label>
                   <Input
                     id="sku"
                     value={formData.sku}
                     onChange={(e) => handleInputChange("sku", e.target.value)}
                     placeholder="Ex: SM-G991B"
-                    className="mt-1"
                   />
                 </div>
-                
-                <div>
+
+                <div className="grid md:grid-cols-[2fr_3fr] gap-6">
                   <Label htmlFor="description" className="text-sm font-medium">Descrição</Label>
                   <Textarea
                     id="description"
                     value={formData.description}
                     onChange={(e) => handleInputChange("description", e.target.value)}
                     placeholder="Descrição detalhada do produto..."
-                    className="mt-1 min-h-[80px]"
+                    className="min-h-[80px]"
                   />
                 </div>
               </div>

--- a/src/components/forms/SalesForm.tsx
+++ b/src/components/forms/SalesForm.tsx
@@ -92,83 +92,79 @@ export const SalesForm = ({ onCancel }: SalesFormProps) => {
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-md">
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <div>
-                <Label htmlFor="product">Produto *</Label>
-                <Select 
-                  value={formData.product_id} 
-                  onValueChange={(value) => setFormData(prev => ({ ...prev, product_id: value }))}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione um produto" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {products.map((product) => (
-                      <SelectItem key={product.id} value={product.id}>
-                        {product.name} {product.sku ? `(${product.sku})` : ''}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              
-              <div>
-                <Label htmlFor="marketplace">Marketplace *</Label>
-                <Select 
-                  value={formData.marketplace_id} 
-                  onValueChange={(value) => setFormData(prev => ({ ...prev, marketplace_id: value }))}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione um marketplace" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {marketplaces.map((marketplace) => (
-                      <SelectItem key={marketplace.id} value={marketplace.id}>
-                        {marketplace.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+            <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+              <Label htmlFor="product">Produto *</Label>
+              <Select
+                value={formData.product_id}
+                onValueChange={(value) => setFormData(prev => ({ ...prev, product_id: value }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecione um produto" />
+                </SelectTrigger>
+                <SelectContent>
+                  {products.map((product) => (
+                    <SelectItem key={product.id} value={product.id}>
+                      {product.name} {product.sku ? `(${product.sku})` : ''}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
-            
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-              <div>
-                <Label htmlFor="price_charged">Preço Cobrado (R$) *</Label>
-                <Input
-                  id="price_charged"
-                  type="number"
-                  step="0.01"
-                  value={formData.price_charged}
-                  onChange={(e) => setFormData(prev => ({ ...prev, price_charged: parseFloat(e.target.value) || 0 }))}
-                  required
-                />
-              </div>
-              
-              <div>
-                <Label htmlFor="quantity">Quantidade *</Label>
-                <Input
-                  id="quantity"
-                  type="number"
-                  min="1"
-                  value={formData.quantity}
-                  onChange={(e) => setFormData(prev => ({ ...prev, quantity: parseInt(e.target.value) || 1 }))}
-                  required
-                />
-              </div>
-              
-              <div>
-                <Label htmlFor="sold_at">Data/Hora da Venda *</Label>
-                <Input
-                  id="sold_at"
-                  type="datetime-local"
-                  value={formatDateForInput(formData.sold_at)}
-                  onChange={(e) => setFormData(prev => ({ ...prev, sold_at: formatDateFromInput(e.target.value) }))}
-                  required
-                />
-              </div>
+
+            <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+              <Label htmlFor="marketplace">Marketplace *</Label>
+              <Select
+                value={formData.marketplace_id}
+                onValueChange={(value) => setFormData(prev => ({ ...prev, marketplace_id: value }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecione um marketplace" />
+                </SelectTrigger>
+                <SelectContent>
+                  {marketplaces.map((marketplace) => (
+                    <SelectItem key={marketplace.id} value={marketplace.id}>
+                      {marketplace.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
-            
+
+            <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+              <Label htmlFor="price_charged">Preço Cobrado (R$) *</Label>
+              <Input
+                id="price_charged"
+                type="number"
+                step="0.01"
+                value={formData.price_charged}
+                onChange={(e) => setFormData(prev => ({ ...prev, price_charged: parseFloat(e.target.value) || 0 }))}
+                required
+              />
+            </div>
+
+            <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+              <Label htmlFor="quantity">Quantidade *</Label>
+              <Input
+                id="quantity"
+                type="number"
+                min="1"
+                value={formData.quantity}
+                onChange={(e) => setFormData(prev => ({ ...prev, quantity: parseInt(e.target.value) || 1 }))}
+                required
+              />
+            </div>
+
+            <div className="grid md:grid-cols-[2fr_3fr] gap-6">
+              <Label htmlFor="sold_at">Data/Hora da Venda *</Label>
+              <Input
+                id="sold_at"
+                type="datetime-local"
+                value={formatDateForInput(formData.sold_at)}
+                onChange={(e) => setFormData(prev => ({ ...prev, sold_at: formatDateFromInput(e.target.value) }))}
+                required
+              />
+            </div>
+
             <div className="flex gap-2">
               <Button type="submit" disabled={createMutation.isPending || updateMutation.isPending}>
                 {editingId ? "Atualizar" : "Registrar"}
@@ -189,25 +185,24 @@ export const SalesForm = ({ onCancel }: SalesFormProps) => {
           {isLoading ? (
             <p>Carregando...</p>
           ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Produto</TableHead>
-                    <TableHead>Marketplace</TableHead>
-                    <TableHead>Preço</TableHead>
-                    <TableHead>Qtd</TableHead>
-                    <TableHead>Total</TableHead>
-                    <TableHead>Data</TableHead>
-                    <TableHead>Ações</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {sales.map((sale) => (
-                    <TableRow key={sale.id}>
-                      <TableCell className="font-medium break-words">
-                        {sale.products?.name}
-                      </TableCell>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Produto</TableHead>
+                  <TableHead>Marketplace</TableHead>
+                  <TableHead>Preço</TableHead>
+                  <TableHead>Qtd</TableHead>
+                  <TableHead>Total</TableHead>
+                  <TableHead>Data</TableHead>
+                  <TableHead>Ações</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sales.map((sale) => (
+                  <TableRow key={sale.id}>
+                    <TableCell className="font-medium break-words">
+                      {sale.products?.name}
+                    </TableCell>
                       <TableCell className="break-words">
                         {sale.marketplaces?.name}
                       </TableCell>
@@ -244,7 +239,6 @@ export const SalesForm = ({ onCancel }: SalesFormProps) => {
                   ))}
                 </TableBody>
               </Table>
-            </div>
           )}
         </CardContent>
       </Card>

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -33,7 +33,7 @@ const Products = () => {
       actions={headerActions}
     >
       {isFormVisible && (
-        <div className="lg:col-span-12 xl:col-span-12">
+        <div className="w-full max-w-4xl lg:col-span-12 xl:col-span-12">
           <ProductForm />
         </div>
       )}

--- a/src/pages/Sales.tsx
+++ b/src/pages/Sales.tsx
@@ -33,7 +33,7 @@ const Sales = () => {
       actions={headerActions}
     >
       {isFormVisible && (
-        <div className="lg:col-span-8 xl:col-span-8">
+        <div className="w-full max-w-4xl lg:col-span-8 xl:col-span-8">
           <SalesForm onCancel={hideForm} />
         </div>
       )}

--- a/src/pages/admin/AssistantsManagement.tsx
+++ b/src/pages/admin/AssistantsManagement.tsx
@@ -127,7 +127,7 @@ export default function AssistantsManagement() {
         breadcrumbs={breadcrumbs}
         actions={headerActions}
       >
-        <div className="lg:col-span-12">
+        <div className="w-full max-w-5xl lg:col-span-12">
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-sm">


### PR DESCRIPTION
## Summary
- unify field layout in sales, assistant, and product forms
- remove horizontal overflow wrapper and polish page container widths

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6893ca8462a48329b9e0f960719f3d17