### PR TITLE
refactor: streamline card styling and actions

### DIFF
--- a/src/components/forms/CategoryForm.tsx
+++ b/src/components/forms/CategoryForm.tsx
@@ -125,7 +125,7 @@ export const CategoryForm = ({ onCancel, editingCategory }: CategoryFormProps = 
   });
 
   return (
-    <Card className="border border-border/50 shadow-card">
+    <Card className="border-border/50">
       <CardHeader className="bg-card">
         <CardTitle className="flex items-center gap-2 text-xl">
           <FolderOpen className="size-6" />

--- a/src/components/forms/PricingForm.tsx
+++ b/src/components/forms/PricingForm.tsx
@@ -184,7 +184,7 @@ export const PricingForm = () => {
   return (
     <div className="space-y-6">
       {/* Formulário Principal - Layout Coeso */}
-      <Card className="border border-border/50 shadow-card">
+      <Card className="border-border/50">
         <CardHeader className="bg-card">
           <CardTitle className="flex items-center gap-2 text-xl">
             <Calculator className="size-6" />
@@ -207,7 +207,7 @@ export const PricingForm = () => {
                   <SelectTrigger className="relative z-0">
                     <SelectValue placeholder="Selecione um produto" />
                   </SelectTrigger>
-                  <SelectContent className="z-[200] border bg-popover shadow-lg">
+                  <SelectContent className="z-[200]">
                     {loadingProducts ? (
                       <div className="px-2 py-1.5 text-sm text-muted-foreground">Carregando...</div>
                     ) : products.length === 0 ? (
@@ -239,7 +239,7 @@ export const PricingForm = () => {
                   <SelectTrigger className="relative z-0">
                     <SelectValue placeholder="Selecione uma plataforma" />
                   </SelectTrigger>
-                  <SelectContent className="z-[200] border bg-popover shadow-lg">
+                  <SelectContent className="z-[200]">
                     {loadingPlatforms ? (
                       <div className="px-2 py-1.5 text-sm text-muted-foreground">Carregando...</div>
                     ) : platforms.length === 0 ? (
@@ -270,7 +270,7 @@ export const PricingForm = () => {
                   <SelectTrigger className="relative z-0">
                     <SelectValue placeholder="Selecione uma modalidade" />
                   </SelectTrigger>
-                  <SelectContent className="z-[200] border bg-popover shadow-lg">
+                  <SelectContent className="z-[200]">
                     {loadingModalities ? (
                       <div className="px-2 py-1.5 text-sm text-muted-foreground">Carregando...</div>
                     ) : modalities.length === 0 ? (
@@ -392,7 +392,7 @@ export const PricingForm = () => {
 
       {/* Resultados */}
       {pricingResult && (
-        <Card className="border border-border/50 shadow-card">
+        <Card className="border-border/50">
           <CardHeader className="bg-muted/30">
             <CardTitle className="flex items-center gap-2 text-lg text-foreground">
               <Calculator className="size-5" />

--- a/src/components/forms/ProductForm.tsx
+++ b/src/components/forms/ProductForm.tsx
@@ -249,7 +249,7 @@ export const ProductForm = () => {
     <div className="space-y-6">
       {/* Formulário Principal - Layout Coeso */}
       <BaseCard
-        className="border border-border/50 shadow-card"
+        className="border-border/50"
         title={
           <CardTitle className="flex items-center gap-2 text-xl">
             <Package className="size-6" />

--- a/src/components/forms/SalesForm.tsx
+++ b/src/components/forms/SalesForm.tsx
@@ -4,8 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Trash2, Edit } from '@/components/ui/icons';
+import { CardListItem } from "@/components/ui";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
 import { useSales, useCreateSale, useUpdateSale, useDeleteSale } from "@/hooks/useSales";
@@ -185,60 +184,27 @@ export const SalesForm = ({ onCancel }: SalesFormProps) => {
           {isLoading ? (
             <p>Carregando...</p>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Produto</TableHead>
-                  <TableHead>Marketplace</TableHead>
-                  <TableHead>Preço</TableHead>
-                  <TableHead>Qtd</TableHead>
-                  <TableHead>Total</TableHead>
-                  <TableHead>Data</TableHead>
-                  <TableHead>Ações</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sales.map((sale) => (
-                  <TableRow key={sale.id}>
-                    <TableCell className="font-medium break-words">
-                      {sale.products?.name}
-                    </TableCell>
-                      <TableCell className="break-words">
-                        {sale.marketplaces?.name}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        {formatarMoeda(sale.price_charged)}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap">{sale.quantity}</TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        {formatarMoeda(sale.price_charged * sale.quantity)}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        {format(new Date(sale.sold_at), "dd/MM/yyyy HH:mm", { locale: ptBR })}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        <div className="flex gap-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => handleEdit(sale)}
-                          >
-                            <Edit className="size-4" />
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="destructive"
-                            onClick={() => deleteMutation.mutate(sale.id)}
-                            disabled={deleteMutation.isPending}
-                          >
-                            <Trash2 className="size-4" />
-                          </Button>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {sales.map((sale) => (
+                <CardListItem
+                  key={sale.id}
+                  title={sale.products?.name}
+                  subtitle={sale.marketplaces?.name}
+                  status={formatarMoeda(sale.price_charged * sale.quantity)}
+                  onEdit={() => handleEdit(sale)}
+                  onDelete={() => deleteMutation.mutate(sale.id)}
+                >
+                  <div className="flex items-center justify-between text-sm">
+                    <span>
+                      {sale.quantity} x {formatarMoeda(sale.price_charged)}
+                    </span>
+                    <span>
+                      {format(new Date(sale.sold_at), "dd/MM/yyyy HH:mm", { locale: ptBR })}
+                    </span>
+                  </div>
+                </CardListItem>
+              ))}
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/components/forms/ShippingRuleForm.tsx
+++ b/src/components/forms/ShippingRuleForm.tsx
@@ -6,9 +6,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { CardListItem } from "@/components/ui";
 import { useToast } from "@/components/ui/use-toast";
-import { Trash2, Edit } from '@/components/ui/icons';
 import { handleSupabaseError } from "@/utils/errors";
 
 interface ShippingRule {
@@ -318,57 +317,23 @@ export const ShippingRuleForm = ({ onCancel }: ShippingRuleFormProps) => {
           {isLoading ? (
             <p>Carregando...</p>
           ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Produto</TableHead>
-                    <TableHead>Marketplace</TableHead>
-                    <TableHead>Custo Frete</TableHead>
-                    <TableHead>Frete Grátis</TableHead>
-                    <TableHead>Ações</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {shippingRules.map((rule) => (
-                    <TableRow key={rule.id}>
-                      <TableCell className="font-medium break-words">
-                        {rule.products?.name}
-                      </TableCell>
-                      <TableCell className="break-words">
-                        {rule.marketplaces?.name}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        R$ {rule.shipping_cost.toFixed(2)}
-                      </TableCell>
-                      <TableCell className="break-words">
-                        {rule.free_shipping_threshold > 0
-                          ? `A partir de R$ ${rule.free_shipping_threshold.toFixed(2)}`
-                          : "Não disponível"}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        <div className="flex gap-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => handleEdit(rule)}
-                          >
-                            <Edit className="size-4" />
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="destructive"
-                            onClick={() => deleteMutation.mutate(rule.id)}
-                            disabled={deleteMutation.isPending}
-                          >
-                            <Trash2 className="size-4" />
-                          </Button>
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {shippingRules.map((rule) => (
+                <CardListItem
+                  key={rule.id}
+                  title={rule.products?.name}
+                  subtitle={rule.marketplaces?.name}
+                  status={`R$ ${rule.shipping_cost.toFixed(2)}`}
+                  onEdit={() => handleEdit(rule)}
+                  onDelete={() => deleteMutation.mutate(rule.id)}
+                >
+                  {rule.free_shipping_threshold > 0 && (
+                    <span className="text-sm text-muted-foreground">
+                      A partir de R$ {rule.free_shipping_threshold.toFixed(2)}
+                    </span>
+                  )}
+                </CardListItem>
+              ))}
             </div>
           )}
         </CardContent>

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -37,7 +37,7 @@ export function AppHeader() {
 
           {/* Logo */}
           <div className="flex items-center gap-1 sm:gap-2">
-            <div className="flex size-8 items-center justify-center rounded-lg bg-gradient-primary shadow-card">
+            <div className="flex size-8 items-center justify-center rounded-lg bg-gradient-primary">
               <Zap className="size-5 text-white" />
             </div>
             <span className="hidden bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-base font-bold text-transparent sm:inline sm:text-lg md:text-xl">

--- a/src/components/ui/card-list-item.tsx
+++ b/src/components/ui/card-list-item.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import { BaseCard, BaseCardProps } from "@/components/ui/base-card"
 import { Button } from "@/components/ui/button"
-import { Edit, Trash2 } from "@/components/ui/icons"
+import { Edit, Trash2 } from "lucide-react"
 import { toast } from "@/components/ui/use-toast"
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/collapsible-card.tsx
+++ b/src/components/ui/collapsible-card.tsx
@@ -24,7 +24,7 @@ export const CollapsibleCard: React.FC<CollapsibleCardProps> = ({
 }) => {
   return (
     <Collapsible open={isOpen} onOpenChange={onToggle}>
-      <Card className={cn("shadow-card border border-border/20", className)}>
+      <Card className={cn("border-border/20", className)}>
         <CollapsibleTrigger asChild>
           <CardHeader className="cursor-pointer py-3 transition-colors hover:bg-muted/30">
             <CardTitle className="flex items-center justify-between text-base font-medium">

--- a/src/components/ui/smart-form.tsx
+++ b/src/components/ui/smart-form.tsx
@@ -45,7 +45,7 @@ export function SmartForm({
   const hasRequiredSections = sections.some(section => section.required);
 
   return (
-    <Card className={cn("shadow-card", className)}>
+    <Card className={cn(className)}>
       <CardHeader className="bg-card">
         <div className="flex items-center justify-between">
           <div>


### PR DESCRIPTION
## Summary
- remove redundant border/shadow classes from cards and form components
- unify card list actions with lucide-react icons inside CardListItem
- replace table-based lists in forms with card grids

## Testing
- `npm test` (fails: Button component tests and snapshot mismatches)
- `npm run lint` (fails: Unexpected any in tests)


------
https://chatgpt.com/codex/tasks/task_e_6893d0e9a7308329882254227cc44984