### PR TITLE
feat: show empty states across list pages

### DIFF
--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -16,31 +16,40 @@ interface EmptyStateProps {
   title: string;
   description?: string;
   action?: EmptyStateAction;
+  children?: React.ReactNode;
 }
 
-export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  children,
+}: EmptyStateProps) {
   return (
-    <Card className="flex flex-col items-center justify-center px-md py-2xl text-center">
-      <div className="mb-md rounded-full bg-muted p-md">
+    <Card className="flex flex-col items-center justify-center space-y-md px-md py-2xl text-center">
+      <div className="rounded-full bg-muted p-md">
         {icon || <PackageOpen className="size-8 text-muted-foreground" />}
       </div>
 
-      <Heading variant="h3" className="mb-sm text-foreground">
+      <Heading variant="h3" className="text-foreground">
         {title}
       </Heading>
 
       {description && (
-        <Text variant="caption" className="mb-lg max-w-sm text-muted-foreground">
+        <Text variant="caption" className="max-w-sm text-muted-foreground">
           {description}
         </Text>
       )}
 
       {action && (
-        <Button onClick={action.onClick} className={cn("mt-md", action.className)}>
+        <Button onClick={action.onClick} className={cn(action.className)}>
           {action.icon}
           {action.label}
         </Button>
       )}
+
+      {children}
     </Card>
   );
 }

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -7,8 +7,8 @@ import { useFormVisibility } from "@/hooks/useFormVisibility";
 import { useCategories, useDeleteCategory } from "@/hooks/useCategories";
 import { CategoryType } from "@/types/categories";
 import { useState } from "react";
-import { Text } from "@/components/ui/typography";
 import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
 
 const Categories = () => {
   const [editingCategory, setEditingCategory] = useState<CategoryType | null>(null);
@@ -83,12 +83,16 @@ const Categories = () => {
               ))}
             </div>
           ) : categories.length === 0 ? (
-            <div className="py-8 text-center">
-              <Text className="text-muted-foreground">Nenhuma categoria cadastrada</Text>
-              <Text variant="caption" className="text-muted-foreground">
-                Crie sua primeira categoria usando o formulário ao lado
-              </Text>
-            </div>
+            <EmptyState
+              icon={<FolderTree className="size-8" />}
+              title="Nenhuma categoria cadastrada"
+              description="Crie sua primeira categoria para começar"
+              action={{
+                label: "Nova Categoria",
+                onClick: showForm,
+                icon: <Plus className="mr-2 size-4" />,
+              }}
+            />
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {categories.map((category) => (

--- a/src/pages/Commissions.tsx
+++ b/src/pages/Commissions.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { useFormVisibility } from "@/hooks/useFormVisibility";
 import { CollapsibleCard } from "@/components/ui/collapsible-card";
 import { CardListItem } from "@/components/ui";
+import { EmptyState } from "@/components/ui/empty-state";
 
 const Commissions = () => {
   const { data: commissions = [], isLoading } = useCommissionsWithDetails();
@@ -99,9 +100,16 @@ const Commissions = () => {
               ))}
             </div>
           ) : commissions.length === 0 ? (
-            <div className="py-8 text-center text-muted-foreground">
-              Nenhuma comissão configurada
-            </div>
+            <EmptyState
+              icon={<Percent className="size-8" />}
+              title="Nenhuma comissão configurada"
+              description="Adicione uma nova comissão para começar"
+              action={{
+                label: "Nova Comissão",
+                onClick: showForm,
+                icon: <Plus className="mr-2 size-4" />,
+              }}
+            />
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {commissions.map((commission) => {

--- a/src/pages/FixedFees.tsx
+++ b/src/pages/FixedFees.tsx
@@ -145,6 +145,11 @@ const FixedFees = () => {
               icon={<Coins className="size-8" />}
               title="Nenhuma taxa fixa configurada"
               description="Adicione uma nova taxa para começar"
+              action={{
+                label: "Nova Taxa",
+                onClick: showForm,
+                icon: <Plus className="mr-2 size-4" />,
+              }}
             />
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -2,9 +2,14 @@ import { ProductForm } from "@/components/forms/ProductForm";
 import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
 import { Package, Plus } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
+import { BaseCard, CardListItem } from "@/components/ui";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
+import { useProducts } from "@/hooks/useProducts";
 import { useFormVisibility } from "@/hooks/useFormVisibility";
 
 const Products = () => {
+  const { data: products = [], isLoading } = useProducts();
   const { isFormVisible, showForm } = useFormVisibility({
     formStorageKey: 'products-form-visible',
     listStorageKey: 'products-list-visible'
@@ -35,6 +40,48 @@ const Products = () => {
       {isFormVisible && (
         <div className="w-full max-w-4xl lg:col-span-12 xl:col-span-12">
           <ProductForm />
+        </div>
+      )}
+
+      {!isFormVisible && (
+        <div className="lg:col-span-12 xl:col-span-12">
+          <BaseCard
+            title={
+              <div className="flex items-center gap-2">
+                <Package className="size-5" />
+                <span>Produtos Cadastrados</span>
+              </div>
+            }
+          >
+            {isLoading ? (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-24 w-full" />
+                ))}
+              </div>
+            ) : products.length === 0 ? (
+              <EmptyState
+                icon={<Package className="size-8" />}
+                title="Nenhum produto cadastrado"
+                description="Cadastre seu primeiro produto para começar"
+                action={{
+                  label: "Novo Produto",
+                  onClick: showForm,
+                  icon: <Plus className="mr-2 size-4" />,
+                }}
+              />
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {products.map((product: any) => (
+                  <CardListItem
+                    key={product.id}
+                    title={product.name}
+                    subtitle={product.categories?.name || "Sem categoria"}
+                  />
+                ))}
+              </div>
+            )}
+          </BaseCard>
         </div>
       )}
     </ConfigurationPageLayout>


### PR DESCRIPTION
## Summary
- enhance EmptyState to support optional children and spacing tokens
- show EmptyState on empty list pages with action buttons

## Testing
- `npm run lint` *(fails: Unexpected any in tests)*
- `npm test` *(fails: 13 failed, 114 passed)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6893d5f8c990832991822876c0f82e91