### PR TITLE
feat: allow configurable theme provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <ThemeProvider attribute="class">
       <TooltipProvider>
         <Toaster />
         <BrowserRouter>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -4,17 +4,20 @@ import { useEffect } from "react";
 import type { TokenOverrides } from "@/styles/tokens";
 import { supabase } from "@/integrations/supabase/client";
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+export function ThemeProvider({
+  children,
+  defaultTheme,
+  enableSystem,
+  ...props
+}: ThemeProviderProps) {
   return (
-    <NextThemesProvider 
-      {...props}
+    <NextThemesProvider
       themes={["light", "dark", "corporate", "windows7"]}
-      defaultTheme="corporate"
-      enableSystem={false}
+      defaultTheme={defaultTheme ?? "corporate"}
+      enableSystem={enableSystem ?? false}
+      {...props}
     >
-      <ThemeWatcher>
-        {children}
-      </ThemeWatcher>
+      <ThemeWatcher>{children}</ThemeWatcher>
     </NextThemesProvider>
   );
 }


### PR DESCRIPTION
## Summary
- use `defaultTheme` and `enableSystem` from props with sensible fallbacks
- remove unused theme props in app setup

## Testing
- `npm test` *(fails: 13 failed tests)*
- `npm run lint` *(fails: Unexpected any errors in test files)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6893da3373248329abff70fc435eaaa1