### PR TITLE
refactor: update BaseCard spacing tokens

### DIFF
--- a/src/components/ui/base-card.tsx
+++ b/src/components/ui/base-card.tsx
@@ -29,8 +29,8 @@ const BaseCard = React.forwardRef<HTMLDivElement, BaseCardProps>(
       status,
       actions,
       children,
-      contentPadding = "p-4",
-      contentSpacing = "space-y-4",
+      contentPadding = "p-md",
+      contentSpacing = "space-y-md",
       collapsible = false,
       open,
       defaultOpen,
@@ -43,7 +43,7 @@ const BaseCard = React.forwardRef<HTMLDivElement, BaseCardProps>(
     const contentClasses = cn(contentPadding, contentSpacing)
 
     const header = (
-      <CardHeader className="flex flex-row items-center justify-between p-4">
+      <CardHeader className="flex flex-row items-center justify-between p-md">
         {collapsible ? (
           <>
             <CollapsibleTrigger asChild>


### PR DESCRIPTION
## Summary
- replace `p-4` with design-token-based `p-md`
- use `space-y-md` for default content spacing
- adjust card header padding to `p-md`

## Testing
- `npm test` *(fails: 13 failed)*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_6893dbf50f248329bbabf26c5ac0c456