### PR TITLE
feat: add design system tokens

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,41 @@
+# Design System
+
+Este documento descreve os tokens de design utilizados na aplicação. Os tokens estão definidos em `src/styles/design-system.ts` e padronizam cores, tipografia e espaçamento.
+
+## Tokens
+
+### Cores
+```ts
+import { colors } from '@/styles/design-system'
+
+<div className={colors.primary}>Botão Primário</div>
+```
+
+### Tipografia
+```ts
+import { typography } from '@/styles/design-system'
+
+<h1 className={typography.h1}>Título</h1>
+<p className={typography.body}>Texto padrão</p>
+```
+
+### Espaçamento
+```ts
+import { spacing } from '@/styles/design-system'
+
+<div className={spacing.px.md}>Conteúdo com padding horizontal médio</div>
+```
+
+## Exemplo Completo
+```tsx
+import { colors, spacing, typography } from '@/styles/design-system'
+
+export function ExampleCard() {
+  return (
+    <div className={`${colors.card} ${spacing.p.lg}`}>
+      <h2 className={typography.h3}>Título do card</h2>
+      <p className={typography.body}>Descrição do conteúdo.</p>
+    </div>
+  )
+}
+```

--- a/src/components/layout/ConfigurationHeader.tsx
+++ b/src/components/layout/ConfigurationHeader.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from "react";
 import { ChevronRight, Home } from '@/components/ui/icons';
 import { Link } from "react-router-dom";
 import { Heading, Text } from "@/components/ui/typography";
+import { colors, spacing, typography } from "@/styles/design-system";
+import { cn } from "@/lib/utils";
 
 interface Breadcrumb {
   label: string;
@@ -25,16 +27,16 @@ export function ConfigurationHeader({
 }: ConfigurationHeaderProps) {
 
   return (
-    <header className="border-b border-border bg-card">
-      <div className="container mx-auto px-4 py-6">
+    <header className={cn("border-b border-border", colors.card)}>
+      <div className={cn("container mx-auto", spacing.px.md, spacing.py.lg)}>
         {/* Breadcrumbs */}
         {breadcrumbs.length > 0 && (
-          <nav className="mb-4 flex items-center space-x-1 text-sm text-muted-foreground">
+          <nav className={cn(spacing.mb.md, "flex items-center", spacing.spaceX.xs, typography.body, colors.muted)}>
             <Link to="/dashboard" className="transition-colors hover:text-foreground">
               <Home className="size-4" />
             </Link>
             {breadcrumbs.map((crumb, index) => (
-              <div key={index} className="flex items-center space-x-1">
+            <div key={index} className={cn("flex items-center", spacing.spaceX.xs)}>
                 <ChevronRight className="size-4" />
                 {crumb.href ? (
                   <Link 
@@ -44,7 +46,7 @@ export function ConfigurationHeader({
                     {crumb.label}
                   </Link>
                 ) : (
-                  <span className="font-medium text-foreground">{crumb.label}</span>
+                  <span className={cn("font-medium", colors.foreground)}>{crumb.label}</span>
                 )}
               </div>
             ))}
@@ -53,7 +55,7 @@ export function ConfigurationHeader({
 
         <div className="flex items-start justify-between">
           <div className="flex-1">
-            <div className="mb-2 flex items-center gap-3">
+            <div className={cn(spacing.mb.sm, "flex items-center", spacing.gap.sm)}>
               {icon && (
                 <div className="rounded-lg bg-primary/10 p-sm text-primary">
                   {icon}
@@ -71,7 +73,7 @@ export function ConfigurationHeader({
           </div>
 
           {actions && (
-            <div className="flex items-center gap-2">
+            <div className={cn("flex items-center", spacing.gap.sm)}>
               {actions}
             </div>
           )}

--- a/src/components/layout/ConfigurationPageLayout.tsx
+++ b/src/components/layout/ConfigurationPageLayout.tsx
@@ -1,6 +1,8 @@
 import { ReactNode } from "react";
 import { ConfigurationHeader } from "./ConfigurationHeader";
 import { PageTransition } from "@/components/common/PageTransition";
+import { spacing } from "@/styles/design-system";
+import { cn } from "@/lib/utils";
 
 interface ConfigurationPageLayoutProps {
   title: string;
@@ -28,10 +30,11 @@ export function ConfigurationPageLayout({
         actions={actions}
         breadcrumbs={breadcrumbs}
       />
-      
-      <main className="container mx-auto px-4 py-6 sm:px-6">
+
+      <main className={cn("container mx-auto", spacing.px.md, spacing.py.lg, `sm:${spacing.px.lg}`)}>
         <PageTransition>
-          <div className="grid grid-cols-1 gap-6 lg:grid-cols-12 xl:grid-cols-12">
+          <div className={cn("grid grid-cols-1", spacing.gap.lg, "lg:grid-cols-12 xl:grid-cols-12")}
+          >
             {children}
           </div>
         </PageTransition>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,26 +3,29 @@ import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
+import { colors, spacing, typography } from "@/styles/design-system"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all hover:shadow-md active:scale-95 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  cn(
+    "inline-flex items-center justify-center whitespace-nowrap rounded-md ring-offset-background transition-all hover:shadow-md active:scale-95 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+    typography.body,
+    spacing.gap.sm
+  ),
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        default: cn(colors.primary, "hover:bg-primary/90"),
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
           "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        secondary: cn(colors.secondary, "hover:bg-secondary/80"),
         ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: cn(colors.primaryText, "underline-offset-4 hover:underline"),
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        default: cn("h-10", spacing.px.md, spacing.py.sm),
+        sm: cn("h-9 rounded-md", spacing.px.sm),
+        lg: cn("h-11 rounded-md", spacing.px.lg),
         icon: "size-10",
       },
     },

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { colors, spacing, typography } from "@/styles/design-system"
 
 const Card = React.forwardRef<
   HTMLDivElement,
@@ -9,7 +10,8 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border shadow-sm",
+      colors.card,
       className
     )}
     {...props}
@@ -23,7 +25,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-lg", className)}
+    className={cn("flex flex-col", spacing.spaceY.sm, spacing.p.lg, className)}
     {...props}
   />
 ))
@@ -36,7 +38,8 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      typography.h3,
+      "font-semibold leading-none tracking-tight",
       className
     )}
     {...props}
@@ -50,7 +53,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn(typography.body, colors.muted, className)}
     {...props}
   />
 ))
@@ -60,7 +63,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-lg pt-0", className)} {...props} />
+  <div ref={ref} className={cn(spacing.p.lg, "pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -70,7 +73,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-lg pt-0", className)}
+    className={cn("flex items-center", spacing.p.lg, "pt-0", className)}
     {...props}
   />
 ))

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { colors, spacing, typography } from "@/styles/design-system"
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {
@@ -8,7 +9,13 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-md border border-input ring-offset-background file:border-0 file:bg-transparent file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          colors.background,
+          spacing.px.md,
+          spacing.py.sm,
+          typography.body,
+          `file:${typography.body}`,
+          `md:${typography.body}`,
           className
         )}
         ref={ref}

--- a/src/styles/design-system.ts
+++ b/src/styles/design-system.ts
@@ -1,0 +1,73 @@
+export const colors = {
+  background: 'bg-background',
+  foreground: 'text-foreground',
+  card: 'bg-card text-card-foreground',
+  primary: 'bg-primary text-primary-foreground',
+  secondary: 'bg-secondary text-secondary-foreground',
+  muted: 'text-muted-foreground',
+  primaryText: 'text-primary',
+} as const;
+
+export const typography = {
+  h1: 'text-h1 font-heading',
+  h2: 'text-h2 font-heading',
+  h3: 'text-h3 font-heading',
+  h4: 'text-h4 font-heading',
+  h5: 'text-h5 font-heading',
+  h6: 'text-h6 font-heading',
+  body: 'text-body font-body',
+  caption: 'text-caption font-body',
+} as const;
+
+export const spacing = {
+  p: {
+    sm: 'p-sm',
+    md: 'p-md',
+    lg: 'p-lg',
+    xl: 'p-xl',
+  },
+  px: {
+    sm: 'px-sm',
+    md: 'px-md',
+    lg: 'px-lg',
+  },
+  py: {
+    sm: 'py-sm',
+    md: 'py-md',
+    lg: 'py-lg',
+    xl: 'py-xl',
+  },
+  mb: {
+    xs: 'mb-xs',
+    sm: 'mb-sm',
+    md: 'mb-md',
+    lg: 'mb-lg',
+  },
+  gap: {
+    xs: 'gap-xs',
+    sm: 'gap-sm',
+    md: 'gap-md',
+    lg: 'gap-lg',
+    xl: 'gap-xl',
+  },
+  spaceX: {
+    xs: 'space-x-xs',
+    sm: 'space-x-sm',
+    md: 'space-x-md',
+    lg: 'space-x-lg',
+  },
+  spaceY: {
+    xs: 'space-y-xs',
+    sm: 'space-y-sm',
+    md: 'space-y-md',
+    lg: 'space-y-lg',
+  },
+} as const;
+
+export const designSystem = {
+  colors,
+  typography,
+  spacing,
+} as const;
+
+export type DesignSystem = typeof designSystem;


### PR DESCRIPTION
## Summary
- introduce design system tokens for colors, typography, and spacing
- refactor core components to use centralized tokens
- document usage examples for the design system

## Testing
- `npm test` *(fails: class and snapshot assertions)*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68940a17dccc83298fef8aafa6ea0e5a