### PR TITLE
feat: add card component with variants

### DIFF
--- a/src/components/ui/Card.stories.tsx
+++ b/src/components/ui/Card.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react"
+
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from "./Card"
+
+const meta: Meta<typeof Card> = {
+  title: "UI/Card",
+  component: Card,
+  tags: ["autodocs"],
+}
+
+export default meta
+
+type Story = StoryObj<typeof Card>
+
+export const Default: Story = {
+  render: () => (
+    <Card className="w-64">
+      <CardHeader>
+        <CardTitle>Default Card</CardTitle>
+      </CardHeader>
+      <CardContent>Conteúdo padrão do card.</CardContent>
+    </Card>
+  ),
+}
+
+export const Highlight: Story = {
+  render: () => (
+    <Card variant="highlight" className="w-64">
+      <CardHeader>
+        <CardTitle>Card em Destaque</CardTitle>
+      </CardHeader>
+      <CardContent>Informação importante.</CardContent>
+    </Card>
+  ),
+}
+
+export const Pricing: Story = {
+  render: () => (
+    <Card variant="pricing" className="w-64">
+      <CardHeader className="text-center">
+        <CardTitle>Plano Pro</CardTitle>
+      </CardHeader>
+      <CardContent className="text-center">
+        R$29/mês
+      </CardContent>
+    </Card>
+  ),
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,51 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import {
+  Card as PrimitiveCard,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "./card"
+import { cn } from "@/lib/utils"
+
+const cardVariants = cva("", {
+  variants: {
+    variant: {
+      default: "",
+      highlight:
+        "border-primary/20 bg-gradient-to-r from-primary/5 to-primary/10",
+      pricing: "border-2 border-primary/30",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+})
+
+export interface CardProps
+  extends React.ComponentPropsWithoutRef<typeof PrimitiveCard>,
+    VariantProps<typeof cardVariants> {}
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, variant, ...props }, ref) => (
+    <PrimitiveCard
+      ref={ref}
+      className={cn(cardVariants({ variant }), className)}
+      {...props}
+    />
+  )
+)
+Card.displayName = "Card"
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+}
+

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 // Export all new UI components
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent } from "./Card"
 export { StatusBadge } from "./status-badge"
 export { SmartForm } from "./smart-form"
 export { DataVisualization } from "./data-visualization"

--- a/src/pages/AdGenerator.tsx
+++ b/src/pages/AdGenerator.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@/contexts/AuthContext';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Eye, EyeOff, Zap } from '@/components/ui/icons';
 import { Heading, Text } from "@/components/ui/typography";

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
@@ -114,7 +114,7 @@ export default function Subscription() {
 
       {/* Current Subscription Status */}
       {currentSubscription && (
-        <Card className="mb-8 border-primary/20 bg-gradient-to-r from-primary/5 to-primary/10">
+        <Card variant="highlight" className="mb-8">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Badge className={getPlanColor(currentSubscription.plan?.name || '')}>
@@ -206,8 +206,9 @@ export default function Subscription() {
           const isRecommended = plan.name === 'pro';
           
           return (
-            <Card 
+            <Card
               key={plan.id}
+              variant="pricing"
               className={`relative ${isRecommended ? 'scale-105 border-primary shadow-card' : ''} ${
                 isCurrent ? 'ring-2 ring-primary/50' : ''
               }`}

--- a/src/pages/admin/AssistantsManagement.tsx
+++ b/src/pages/admin/AssistantsManagement.tsx
@@ -7,7 +7,7 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
+} from "@/components/ui/Card";
 import { DataVisualization } from "@/components/ui/data-visualization";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";

--- a/src/pages/admin/ThemeSettings.tsx
+++ b/src/pages/admin/ThemeSettings.tsx
@@ -5,7 +5,7 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
+} from "@/components/ui/Card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
## Summary
- add Card component with default, highlight and pricing variants
- update pages to use new Card component
- document Card variants in Storybook

## Testing
- `npm test` *(fails: 14 failed, 111 passed)*
- `npm run lint` *(fails: 25 errors, 31 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6894a0929af483299743f385fbfa5898