### PR TITLE
feat: introduce reusable responsive grid

### DIFF
--- a/src/components/layout/ResponsiveGrid.tsx
+++ b/src/components/layout/ResponsiveGrid.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+import { ReactNode } from "react";
+
+interface ResponsiveGridProps {
+  children: ReactNode;
+  cols?: {
+    default?: number;
+    sm?: number;
+    md?: number;
+    lg?: number;
+    xl?: number;
+  };
+  gap?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+export function ResponsiveGrid({
+  children,
+  cols = { default: 1, md: 2, lg: 3 },
+  gap = "md",
+  className,
+}: ResponsiveGridProps) {
+  const gapClasses = {
+    sm: "gap-2",
+    md: "gap-4",
+    lg: "gap-6",
+  } as const;
+
+  const gridClasses = cn(
+    "grid",
+    gapClasses[gap],
+    cols.default && `grid-cols-${cols.default}`,
+    cols.sm && `sm:grid-cols-${cols.sm}`,
+    cols.md && `md:grid-cols-${cols.md}`,
+    cols.lg && `lg:grid-cols-${cols.lg}`,
+    cols.xl && `xl:grid-cols-${cols.xl}`,
+    className,
+  );
+
+  return <div className={gridClasses}>{children}</div>;
+}
+
+export default ResponsiveGrid;

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -5,3 +5,5 @@ export { MainLayout } from "./MainLayout";
 export { SharedLayout } from "./SharedLayout";
 export { AppSidebar } from "./AppSidebar";
 export { AppHeader } from "./AppHeader";
+export { ResponsiveGrid } from "./ResponsiveGrid";
+

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -1,5 +1,5 @@
 import { CategoryForm } from "@/components/forms/CategoryForm";
-import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
+import { ConfigurationPageLayout, ResponsiveGrid } from "@/components/layout";
 import { FolderTree, Plus } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { BaseCard, CardListItem } from "@/components/ui";
@@ -77,11 +77,11 @@ const Categories = () => {
           contentPadding="px-6 pb-4 pt-0"
         >
           {isLoading ? (
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            <ResponsiveGrid cols={{ default: 1, sm: 2, lg: 3, xl: 4 }} gap="md">
               {Array.from({ length: 4 }).map((_, i) => (
                 <Skeleton key={i} className="h-24 w-full" />
               ))}
-            </div>
+            </ResponsiveGrid>
           ) : categories.length === 0 ? (
             <EmptyState
               icon={<FolderTree className="size-8" />}
@@ -94,7 +94,7 @@ const Categories = () => {
               }}
             />
           ) : (
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            <ResponsiveGrid cols={{ default: 1, sm: 2, lg: 3, xl: 4 }} gap="md">
               {categories.map((category) => (
                 <CardListItem
                   key={category.id}
@@ -104,7 +104,7 @@ const Categories = () => {
                   onDelete={() => deleteMutation.mutate(category.id)}
                 />
               ))}
-            </div>
+            </ResponsiveGrid>
           )}
         </BaseCard>
       </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,13 +3,14 @@ import { OnboardingTour } from "@/components/onboarding/OnboardingTour";
 import { useOnboarding } from "@/hooks/useOnboarding";
 import { BaseCard } from "@/components/ui";
 import { Heading, Text } from "@/components/ui/typography";
+import { ResponsiveGrid } from "@/components/layout";
 
 const Dashboard = () => {
   const { showOnboarding, completeOnboarding, skipOnboarding } = useOnboarding();
 
   return (
     <>
-      <div className="space-y-lg">
+      <ResponsiveGrid cols={{ default: 1 }} gap="lg">
         {/* Page Header */}
         <div className="space-y-sm">
           <Heading
@@ -30,7 +31,7 @@ const Dashboard = () => {
         >
           <DashboardForm />
         </BaseCard>
-      </div>
+      </ResponsiveGrid>
       
       {showOnboarding && (
         <OnboardingTour 


### PR DESCRIPTION
## Summary
- add ResponsiveGrid layout component for configurable columns and gaps
- use new grid in Categories and Dashboard pages for consistent responsiveness

## Testing
- `npm test` *(fails: Unexpected token Sidebar; snapshot and button class mismatches)*
- `npm run lint` *(fails: Unexpected any in tests)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6894a3e61b648329b9f1c38346805c98