### PR TITLE
optimize queries and lazy load charts

### DIFF
--- a/src/components/charts/QuadrantDonutChart.tsx
+++ b/src/components/charts/QuadrantDonutChart.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { ChartTooltipProps, ChartLegendProps } from '@/types/charts';
 import { colors } from "@/styles/tokens";
@@ -45,16 +45,23 @@ const QUADRANT_DATA = [
   },
 ];
 
-export const QuadrantDonutChart: React.FC<QuadrantDonutChartProps> = ({ quadrantCounts }) => {
-  const data = QUADRANT_DATA.map(quadrant => ({
-    name: quadrant.name,
-    value: quadrantCounts[quadrant.key as keyof QuadrantCounts],
-    color: quadrant.color,
-    emoji: quadrant.emoji,
-    description: quadrant.description,
-  })).filter(item => item.value > 0);
+const QuadrantDonutChartComponent: React.FC<QuadrantDonutChartProps> = ({ quadrantCounts }) => {
+  const data = useMemo(
+    () =>
+      QUADRANT_DATA.map(quadrant => ({
+        name: quadrant.name,
+        value: quadrantCounts[quadrant.key as keyof QuadrantCounts],
+        color: quadrant.color,
+        emoji: quadrant.emoji,
+        description: quadrant.description,
+      })).filter(item => item.value > 0),
+    [quadrantCounts]
+  );
 
-  const total = data.reduce((sum, item) => sum + item.value, 0);
+  const total = useMemo(
+    () => data.reduce((sum, item) => sum + item.value, 0),
+    [data]
+  );
 
   const CustomTooltip = ({ active, payload }: ChartTooltipProps) => {
     if (active && payload && payload.length) {
@@ -125,3 +132,5 @@ export const QuadrantDonutChart: React.FC<QuadrantDonutChartProps> = ({ quadrant
     </div>
   );
 };
+
+export const QuadrantDonutChart = React.memo(QuadrantDonutChartComponent);

--- a/src/components/charts/QuadrantScatterChart.tsx
+++ b/src/components/charts/QuadrantScatterChart.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from "recharts";
 import { ChartTooltipProps } from '@/types/charts';
 import { colors } from "@/styles/tokens";
@@ -34,21 +34,30 @@ const getQuadrantColor = (quadrant: ProductStrategy["quadrant"]) => {
   }
 };
 
-export const QuadrantScatterChart: React.FC<QuadrantScatterChartProps> = ({
+const QuadrantScatterChartComponent: React.FC<QuadrantScatterChartProps> = ({
   data,
   margeLimitAlta,
   giroLimitAlto,
 }) => {
-  const scatterData = data.map((item, index) => ({
-    x: item.giro_percentage,
-    y: item.margin_percentage,
-    z: Math.log(item.total_revenue + 1) * 5, // Size based on revenue
-    name: item.product_name,
-    marketplace: item.marketplace_name,
-    quadrant: item.quadrant,
-    revenue: item.total_revenue,
-    index,
-  }));
+  const scatterData = useMemo(
+    () =>
+      data.map((item, index) => ({
+        x: item.giro_percentage,
+        y: item.margin_percentage,
+        z: Math.log(item.total_revenue + 1) * 5, // Size based on revenue
+        name: item.product_name,
+        marketplace: item.marketplace_name,
+        quadrant: item.quadrant,
+        revenue: item.total_revenue,
+        index,
+      })),
+    [data]
+  );
+
+  const maxMargin = useMemo(
+    () => Math.max(...data.map(d => d.margin_percentage)),
+    [data]
+  );
 
   const CustomTooltip = ({ active, payload }: ChartTooltipProps) => {
     if (active && payload && payload.length) {
@@ -108,22 +117,22 @@ export const QuadrantScatterChart: React.FC<QuadrantScatterChartProps> = ({
           />
           
           {/* Quadrant dividers */}
-          <line 
-            x1={`${giroLimitAlto}%`} 
-            y1="0%" 
-            x2={`${giroLimitAlto}%`} 
-            y2="100%" 
+          <line
+            x1={`${giroLimitAlto}%`}
+            y1="0%"
+            x2={`${giroLimitAlto}%`}
+            y2="100%"
             stroke={colors.muted.foreground}
-            strokeDasharray="5,5" 
+            strokeDasharray="5,5"
             opacity={0.5}
           />
-          <line 
-            x1="0%" 
-            y1={`${100 - (margeLimitAlta / Math.max(...data.map(d => d.margin_percentage)) * 100)}%`} 
-            x2="100%" 
-            y2={`${100 - (margeLimitAlta / Math.max(...data.map(d => d.margin_percentage)) * 100)}%`} 
+          <line
+            x1="0%"
+            y1={`${100 - (margeLimitAlta / maxMargin * 100)}%`}
+            x2="100%"
+            y2={`${100 - (margeLimitAlta / maxMargin * 100)}%`}
             stroke={colors.muted.foreground}
-            strokeDasharray="5,5" 
+            strokeDasharray="5,5"
             opacity={0.5}
           />
           
@@ -143,3 +152,5 @@ export const QuadrantScatterChart: React.FC<QuadrantScatterChartProps> = ({
     </div>
   );
 };
+
+export const QuadrantScatterChart = React.memo(QuadrantScatterChartComponent);

--- a/src/components/charts/RevenueByQuadrantChart.tsx
+++ b/src/components/charts/RevenueByQuadrantChart.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from "recharts";
 import { formatarMoeda } from "@/utils/pricing";
 import { ChartTooltipProps } from '@/types/charts';
@@ -25,23 +25,29 @@ const QUADRANT_CONFIG = {
   baixa_margem_baixo_giro: { name: "❓ Questionáveis", color: colors.destructive.DEFAULT },
 };
 
-export const RevenueByQuadrantChart: React.FC<RevenueByQuadrantChartProps> = ({ data }) => {
+const RevenueByQuadrantChartComponent: React.FC<RevenueByQuadrantChartProps> = ({ data }) => {
   // Aggregate revenue by quadrant
-  const chartData = Object.entries(QUADRANT_CONFIG).map(([quadrant, config]) => {
-    const quadrantProducts = data.filter(p => p.quadrant === quadrant);
-    const totalRevenue = quadrantProducts.reduce((sum, p) => sum + p.total_revenue, 0);
-    const productCount = quadrantProducts.length;
-    const avgRevenue = productCount > 0 ? totalRevenue / productCount : 0;
-    
-    return {
-      name: config.name,
-      quadrant,
-      totalRevenue,
-      avgRevenue,
-      productCount,
-      color: config.color,
-    };
-  }).filter(item => item.productCount > 0);
+  const chartData = useMemo(
+    () =>
+      Object.entries(QUADRANT_CONFIG)
+        .map(([quadrant, config]) => {
+          const quadrantProducts = data.filter(p => p.quadrant === quadrant);
+          const totalRevenue = quadrantProducts.reduce((sum, p) => sum + p.total_revenue, 0);
+          const productCount = quadrantProducts.length;
+          const avgRevenue = productCount > 0 ? totalRevenue / productCount : 0;
+
+          return {
+            name: config.name,
+            quadrant,
+            totalRevenue,
+            avgRevenue,
+            productCount,
+            color: config.color,
+          };
+        })
+        .filter(item => item.productCount > 0),
+    [data]
+  );
 
   const CustomTooltip = ({ active, payload, label }: ChartTooltipProps) => {
     if (active && payload && payload.length) {
@@ -98,3 +104,5 @@ export const RevenueByQuadrantChart: React.FC<RevenueByQuadrantChartProps> = ({ 
     </div>
   );
 };
+
+export const RevenueByQuadrantChart = React.memo(RevenueByQuadrantChartComponent);

--- a/src/components/forms/StrategyForm.tsx
+++ b/src/components/forms/StrategyForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, Suspense, lazy } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -9,9 +9,9 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { TrendingUp, BarChart3, Target, Package, PieChart, ScatterChart, AlertTriangle, Star } from '@/components/ui/icons';
 import { EnhancedTooltip } from "@/components/common/EnhancedTooltip";
-import { QuadrantScatterChart } from "@/components/charts/QuadrantScatterChart";
-import { QuadrantDonutChart } from "@/components/charts/QuadrantDonutChart";
-import { RevenueByQuadrantChart } from "@/components/charts/RevenueByQuadrantChart";
+const QuadrantScatterChart = lazy(() => import("@/components/charts/QuadrantScatterChart"));
+const QuadrantDonutChart = lazy(() => import("@/components/charts/QuadrantDonutChart"));
+const RevenueByQuadrantChart = lazy(() => import("@/components/charts/RevenueByQuadrantChart"));
 
 interface SalesData {
   product_id: string;
@@ -362,7 +362,9 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                     Distribuição dos Quadrantes
                   </h4>
                   <div className="rounded-lg border bg-gradient-to-br from-card to-card/50 p-md">
-                    <QuadrantDonutChart quadrantCounts={strategyAnalysis.quadrantCounts} />
+                    <Suspense fallback={<div>Carregando gráfico...</div>}>
+                      <QuadrantDonutChart quadrantCounts={strategyAnalysis.quadrantCounts} />
+                    </Suspense>
                   </div>
                 </div>
                 <div className="transition-all duration-300 hover:scale-[1.02]">
@@ -371,7 +373,9 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                     Receita por Quadrante
                   </h4>
                   <div className="rounded-lg border bg-gradient-to-br from-card to-card/50 p-md">
-                    <RevenueByQuadrantChart data={strategyAnalysis.products} />
+                    <Suspense fallback={<div>Carregando gráfico...</div>}>
+                      <RevenueByQuadrantChart data={strategyAnalysis.products} />
+                    </Suspense>
                   </div>
                 </div>
               </div>
@@ -390,11 +394,13 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
               </CardDescription>
             </CardHeader>
             <CardContent className="bg-gradient-to-br from-card to-card/50">
-              <QuadrantScatterChart 
-                data={strategyAnalysis.products}
-                margeLimitAlta={margeLimitAlta}
-                giroLimitAlto={giroLimitAlto}
-              />
+              <Suspense fallback={<div>Carregando gráfico...</div>}>
+                <QuadrantScatterChart
+                  data={strategyAnalysis.products}
+                  margeLimitAlta={margeLimitAlta}
+                  giroLimitAlto={giroLimitAlto}
+                />
+              </Suspense>
             </CardContent>
           </Card>
 

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -9,6 +9,8 @@ export function useCategories() {
   return useQuery({
     queryKey: [CATEGORIES_QUERY_KEY],
     queryFn: () => categoriesService.getAll(),
+    select: (data) =>
+      data.sort((a, b) => a.name.localeCompare(b.name)),
     staleTime: 5 * 60 * 1000,
   });
 }
@@ -18,6 +20,7 @@ export function useCategory(id: string) {
     queryKey: [CATEGORIES_QUERY_KEY, id],
     queryFn: () => categoriesService.getById(id),
     enabled: !!id,
+    staleTime: 5 * 60 * 1000,
   });
 }
 

--- a/src/hooks/useMarketplaces.ts
+++ b/src/hooks/useMarketplaces.ts
@@ -9,6 +9,8 @@ export function useMarketplaces() {
   return useQuery({
     queryKey: [MARKETPLACES_QUERY_KEY],
     queryFn: () => marketplacesService.getAll(),
+    select: (data) =>
+      data.sort((a, b) => a.name.localeCompare(b.name)),
     staleTime: 5 * 60 * 1000,
   });
 }
@@ -25,6 +27,8 @@ export function useMarketplacePlatforms() {
   return useQuery({
     queryKey: [MARKETPLACES_QUERY_KEY, 'platforms'],
     queryFn: () => marketplacesService.getPlatforms(),
+    select: (data) =>
+      data.sort((a, b) => a.name.localeCompare(b.name)),
     staleTime: 5 * 60 * 1000,
   });
 }
@@ -43,6 +47,7 @@ export function useMarketplace(id: string) {
     queryKey: [MARKETPLACES_QUERY_KEY, id],
     queryFn: () => marketplacesService.getById(id),
     enabled: !!id,
+    staleTime: 5 * 60 * 1000,
   });
 }
 

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -9,6 +9,8 @@ export function useProducts() {
   return useQuery({
     queryKey: [PRODUCTS_QUERY_KEY],
     queryFn: () => productsService.getAll(),
+    select: (data) =>
+      data.sort((a, b) => a.name.localeCompare(b.name)),
     staleTime: 5 * 60 * 1000, // 5 minutos
   });
 }
@@ -17,6 +19,8 @@ export function useProductsWithCategories() {
   return useQuery({
     queryKey: [PRODUCTS_QUERY_KEY, "with-categories"],
     queryFn: () => productsService.getAllWithCategories(),
+    select: (data) =>
+      data.sort((a, b) => a.name.localeCompare(b.name)),
     staleTime: 5 * 60 * 1000,
   });
 }
@@ -26,6 +30,7 @@ export function useProduct(id: string) {
     queryKey: [PRODUCTS_QUERY_KEY, id],
     queryFn: () => productsService.getById(id),
     enabled: !!id,
+    staleTime: 5 * 60 * 1000,
   });
 }
 


### PR DESCRIPTION
## Summary
- add select and staleTime to product, category and marketplace queries
- memoize heavy chart components
- lazy load strategy charts using React.lazy and Suspense

## Testing
- `npm run lint` *(fails: eslint: not found)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894b331343c8329a7f3db3f235ded50