### PR TITLE
feat: add memory bank logs and brand colors

### DIFF
--- a/memory-bank/consolidated_learnings.md
+++ b/memory-bank/consolidated_learnings.md
@@ -1,0 +1,2 @@
+# Consolidated Learnings
+

--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -1,0 +1,2 @@
+# Raw Reflection Log
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,7 +20,16 @@ export default {
 			}
 		},
                 extend: {
-                        colors,
+                        colors: {
+                                ...colors,
+                                brand: {
+                                        dark: colors.gunmetal,
+                                        primary: colors["fern-green"],
+                                        secondary: colors["tea-green"],
+                                        background: colors["anti-flash-white"],
+                                        danger: colors.cinnabar,
+                                },
+                        },
 			backgroundImage: {
 				'gradient-primary': 'var(--gradient-primary)',
 				'gradient-card': 'var(--gradient-card)',


### PR DESCRIPTION
## Summary
- create memory bank for reflections and learnings
- add brand color palette to Tailwind config

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894d88f22708329b7a200439a4262ed