### PR TITLE
refactor: substituir cores Tailwind por tokens de marca

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -17,3 +17,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Maintain a reusable script for future large-scale class refactors.
 ---
+
+---
+Date: 2025-08-07
+TaskRef: "Replace hard-coded Tailwind color classes with brand utilities across forms and pages"
+
+Learnings:
+- Adding a `warning` token under `brand` in Tailwind config enables consistent semantic yellow usage.
+- Ripgrep patterns with negative lookaheads help detect leftover default color classes.
+
+Difficulties:
+- `pnpm typecheck` script is named `type-check`; initial run failed until corrected.
+
+Successes:
+- Lint, type-check, and unit tests all passed after the color refactor.
+
+Improvements_Identified_For_Consolidation:
+- Remember to verify script names before executing in automation.
+---

--- a/src/components/common/SkeletonLoaders.tsx
+++ b/src/components/common/SkeletonLoaders.tsx
@@ -58,7 +58,7 @@ export function SkeletonForm({ sections = 2, fieldsPerSection = 3 }: SkeletonFor
       <div className="rounded-lg border border-border/50 overflow-hidden">
         {/* Header */}
         <div className="bg-gradient-primary p-lg">
-          <Skeleton className="h-6 w-48 bg-white/20" />
+          <Skeleton className="h-6 w-48 bg-brand-background/20" />
         </div>
         
         {/* Form content */}

--- a/src/components/forms/PricingForm.tsx
+++ b/src/components/forms/PricingForm.tsx
@@ -439,12 +439,12 @@ export const PricingForm = () => {
                 <>
                   <Separator className="my-4" />
                   <div className="bg-muted/30 p-4 rounded-lg">
-                    <h4 className="font-semibold mb-3 text-orange-600 dark:text-orange-400">
+                    <h4 className="font-semibold mb-3 text-brand-primary">
                       Análise do Preço Praticado
                     </h4>
                      <div className="grid grid-cols-2 gap-2 text-sm">
                        <div>Preço Praticado:</div>
-                       <div className="font-medium text-orange-600 dark:text-orange-400">
+                       <div className="font-medium text-brand-primary">
                          {formatarMoeda(margemRealResult.preco_praticado || 0)}
                        </div>
                        
@@ -457,7 +457,7 @@ export const PricingForm = () => {
                        <div className={`font-medium ${
                          (margemRealResult.margem_percentual_real || 0) < 0 
                            ? 'text-destructive' 
-                           : 'text-green-600 dark:text-green-400'
+                           : 'text-brand-primary'
                        }`}>
                          {formatarPercentual(margemRealResult.margem_percentual_real || 0)}
                        </div>
@@ -466,11 +466,11 @@ export const PricingForm = () => {
                        <div className="col-span-2 mt-2 pt-2 border-t">
                          <div className="text-xs text-muted-foreground">
                            {(margemRealResult.margem_percentual_real || 0) < (pricingResult.margem_percentual || 0) ? (
-                             <span className="text-amber-600 dark:text-amber-400">
+                             <span className="text-brand-warning">
                                ⚠️ Margem real é menor que a desejada
                              </span>
                            ) : (
-                             <span className="text-green-600 dark:text-green-400">
+                             <span className="text-brand-primary">
                                ✅ Margem real está dentro do esperado
                              </span>
                            )}

--- a/src/components/forms/StrategyForm.tsx
+++ b/src/components/forms/StrategyForm.tsx
@@ -184,11 +184,11 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
 
   const getQuadrantColor = (quadrant: ProductStrategy["quadrant"]) => {
     switch (quadrant) {
-      case "alta_margem_alto_giro": return "bg-green-100 border-green-300 text-green-800";
-      case "alta_margem_baixo_giro": return "bg-blue-100 border-blue-300 text-blue-800";
-      case "baixa_margem_alto_giro": return "bg-yellow-100 border-yellow-300 text-yellow-800";
-      case "baixa_margem_baixo_giro": return "bg-red-100 border-red-300 text-red-800";
-      default: return "bg-gray-100 border-gray-300 text-gray-800";
+      case "alta_margem_alto_giro": return "bg-brand-primary/10 border-brand-primary/30 text-brand-primary";
+      case "alta_margem_baixo_giro": return "bg-brand-secondary/10 border-brand-secondary/30 text-brand-secondary";
+      case "baixa_margem_alto_giro": return "bg-brand-warning/10 border-brand-warning/30 text-brand-warning";
+      case "baixa_margem_baixo_giro": return "bg-brand-danger/10 border-brand-danger/30 text-brand-danger";
+      default: return "bg-brand-background border-brand-dark/30 text-brand-dark";
     }
   };
 
@@ -294,10 +294,10 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                     { label: "Performance", value: "Excelente", format: "text" }
                   ]}
                 >
-                  <div className="text-center p-3 rounded-lg bg-green-50 border border-green-200 hover:bg-green-100 transition-colors cursor-help">
+                  <div className="text-center p-3 rounded-lg bg-brand-primary/10 border border-brand-primary/20 hover:bg-brand-primary/20 transition-colors cursor-help">
                     <div className="flex items-center justify-center gap-2 mb-1">
-                      <Star className="h-4 w-4 text-green-600" />
-                      <div className="text-2xl font-bold text-green-600">
+                      <Star className="h-4 w-4 text-brand-primary" />
+                      <div className="text-2xl font-bold text-brand-primary">
                         {strategyAnalysis.quadrantCounts.alta_margem_alto_giro}
                       </div>
                     </div>
@@ -312,8 +312,8 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                     { label: "Performance", value: "Boa margem, baixo volume", format: "text" }
                   ]}
                 >
-                  <div className="text-center p-3 rounded-lg bg-blue-50 border border-blue-200 hover:bg-blue-100 transition-colors cursor-help">
-                    <div className="text-2xl font-bold text-blue-600">
+                  <div className="text-center p-3 rounded-lg bg-brand-secondary/10 border border-brand-secondary/20 hover:bg-brand-secondary/20 transition-colors cursor-help">
+                    <div className="text-2xl font-bold text-brand-secondary">
                       {strategyAnalysis.quadrantCounts.alta_margem_baixo_giro}
                     </div>
                     <div className="text-sm text-muted-foreground">💎 Joias</div>
@@ -327,8 +327,8 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                     { label: "Performance", value: "Alto volume, baixa margem", format: "text" }
                   ]}
                 >
-                  <div className="text-center p-3 rounded-lg bg-yellow-50 border border-yellow-200 hover:bg-yellow-100 transition-colors cursor-help">
-                    <div className="text-2xl font-bold text-yellow-600">
+                  <div className="text-center p-3 rounded-lg bg-brand-warning/10 border border-brand-warning/20 hover:bg-brand-warning/20 transition-colors cursor-help">
+                    <div className="text-2xl font-bold text-brand-warning">
                       {strategyAnalysis.quadrantCounts.baixa_margem_alto_giro}
                     </div>
                     <div className="text-sm text-muted-foreground">🔄 Movimento</div>
@@ -342,10 +342,10 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                     { label: "Performance", value: "Crítica", format: "text" }
                   ]}
                 >
-                  <div className="text-center p-3 rounded-lg bg-red-50 border border-red-200 hover:bg-red-100 transition-colors cursor-help">
+                  <div className="text-center p-3 rounded-lg bg-brand-danger/10 border border-brand-danger/20 hover:bg-brand-danger/20 transition-colors cursor-help">
                     <div className="flex items-center justify-center gap-2 mb-1">
-                      <AlertTriangle className="h-4 w-4 text-red-600" />
-                      <div className="text-2xl font-bold text-red-600">
+                      <AlertTriangle className="h-4 w-4 text-brand-danger" />
+                      <div className="text-2xl font-bold text-brand-danger">
                         {strategyAnalysis.quadrantCounts.baixa_margem_baixo_giro}
                       </div>
                     </div>
@@ -409,7 +409,7 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
             <CardContent>
               <div className="grid grid-cols-2 gap-4 h-96">
                 {/* Top Left: Alta Margem + Baixo Giro */}
-                <Card className="bg-blue-50 border-blue-200">
+                <Card className="bg-brand-secondary/10 border-brand-secondary/20">
                   <CardHeader className="pb-2">
                     <div className="flex items-center justify-between">
                       <CardTitle className="text-sm">💎 Joias</CardTitle>
@@ -427,7 +427,7 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                         .filter(p => p.quadrant === "alta_margem_baixo_giro")
                         .slice(0, 5)
                         .map((product, i) => (
-                        <div key={i} className="text-xs p-xs bg-white rounded border">
+                        <div key={i} className="text-xs p-xs bg-brand-background rounded border">
                           <div className="font-medium truncate">{product.product_name}</div>
                           <div className="text-muted-foreground">{product.marketplace_name}</div>
                         </div>
@@ -437,7 +437,7 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                 </Card>
 
                 {/* Top Right: Alta Margem + Alto Giro */}
-                <Card className="bg-green-50 border-green-200">
+                <Card className="bg-brand-primary/10 border-brand-primary/20">
                   <CardHeader className="pb-2">
                     <div className="flex items-center justify-between">
                       <CardTitle className="text-sm">⭐ Estrelas</CardTitle>
@@ -455,7 +455,7 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                         .filter(p => p.quadrant === "alta_margem_alto_giro")
                         .slice(0, 5)
                         .map((product, i) => (
-                        <div key={i} className="text-xs p-xs bg-white rounded border">
+                        <div key={i} className="text-xs p-xs bg-brand-background rounded border">
                           <div className="font-medium truncate">{product.product_name}</div>
                           <div className="text-muted-foreground">{product.marketplace_name}</div>
                         </div>
@@ -465,7 +465,7 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                 </Card>
 
                 {/* Bottom Left: Baixa Margem + Baixo Giro */}
-                <Card className="bg-red-50 border-red-200">
+                <Card className="bg-brand-danger/10 border-brand-danger/20">
                   <CardHeader className="pb-2">
                     <div className="flex items-center justify-between">
                       <CardTitle className="text-sm">❓ Questionáveis</CardTitle>
@@ -483,7 +483,7 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                         .filter(p => p.quadrant === "baixa_margem_baixo_giro")
                         .slice(0, 5)
                         .map((product, i) => (
-                        <div key={i} className="text-xs p-xs bg-white rounded border">
+                        <div key={i} className="text-xs p-xs bg-brand-background rounded border">
                           <div className="font-medium truncate">{product.product_name}</div>
                           <div className="text-muted-foreground">{product.marketplace_name}</div>
                         </div>
@@ -493,7 +493,7 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                 </Card>
 
                 {/* Bottom Right: Baixa Margem + Alto Giro */}
-                <Card className="bg-yellow-50 border-yellow-200">
+                <Card className="bg-brand-warning/10 border-brand-warning/20">
                   <CardHeader className="pb-2">
                     <div className="flex items-center justify-between">
                       <CardTitle className="text-sm">🔄 Movimento</CardTitle>
@@ -511,7 +511,7 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
                         .filter(p => p.quadrant === "baixa_margem_alto_giro")
                         .slice(0, 5)
                         .map((product, i) => (
-                        <div key={i} className="text-xs p-xs bg-white rounded border">
+                        <div key={i} className="text-xs p-xs bg-brand-background rounded border">
                           <div className="font-medium truncate">{product.product_name}</div>
                           <div className="text-muted-foreground">{product.marketplace_name}</div>
                         </div>

--- a/src/components/forms/enhanced/CommissionFormEnhanced.tsx
+++ b/src/components/forms/enhanced/CommissionFormEnhanced.tsx
@@ -103,18 +103,18 @@ export function CommissionFormEnhanced({
   const getImpactPreview = (rate: number) => {
     if (rate === 0) return null;
     
-    let color = "text-green-600";
+    let color = "text-brand-primary";
     let label = "Baixo impacto";
-    let bgColor = "bg-green-50 border-green-200";
+    let bgColor = "bg-brand-primary/10 border-brand-primary/20";
     
     if (rate > 8 && rate <= 15) {
-      color = "text-yellow-600";
+      color = "text-brand-warning";
       label = "Impacto moderado";
-      bgColor = "bg-yellow-50 border-yellow-200";
+      bgColor = "bg-brand-warning/10 border-brand-warning/20";
     } else if (rate > 15) {
-      color = "text-red-600";
+      color = "text-brand-danger";
       label = "Alto impacto";
-      bgColor = "bg-red-50 border-red-200";
+      bgColor = "bg-brand-danger/10 border-brand-danger/20";
     }
     
     return (

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -38,7 +38,7 @@ export function AppHeader() {
           {/* Logo */}
           <div className="flex items-center gap-1 sm:gap-2">
             <div className="flex items-center justify-center w-8 h-8 bg-gradient-primary rounded-lg shadow-card">
-              <Zap className="w-5 h-5 text-white" />
+              <Zap className="w-5 h-5 text-brand-background" />
             </div>
             <span className="font-bold text-base sm:text-lg md:text-xl bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent hidden sm:inline">
               Catalog Maker Hub

--- a/src/components/onboarding/OnboardingTour.tsx
+++ b/src/components/onboarding/OnboardingTour.tsx
@@ -90,7 +90,7 @@ export function OnboardingTour({ onComplete, onSkip }: OnboardingTourProps) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-md">
+    <div className="fixed inset-0 bg-brand-dark/50 backdrop-blur-sm z-50 flex items-center justify-center p-md">
       <Card className="w-full max-w-2xl">
         <CardHeader className="text-center pb-2">
           <div className="flex items-center justify-between mb-4">
@@ -124,7 +124,7 @@ export function OnboardingTour({ onComplete, onSkip }: OnboardingTourProps) {
                   index === currentStep
                     ? 'border-primary bg-primary/5'
                     : index < currentStep
-                    ? 'border-green-500 bg-green-50'
+                    ? 'border-brand-primary bg-brand-primary/10'
                     : 'border-muted'
                 }`}
               >
@@ -132,7 +132,7 @@ export function OnboardingTour({ onComplete, onSkip }: OnboardingTourProps) {
                   index === currentStep
                     ? 'bg-primary text-primary-foreground'
                     : index < currentStep
-                    ? 'bg-green-500 text-white'
+                    ? 'bg-brand-primary text-brand-background'
                     : 'bg-muted text-muted-foreground'
                 }`}>
                   {index < currentStep ? (

--- a/src/pages/AdGenerator.tsx
+++ b/src/pages/AdGenerator.tsx
@@ -30,9 +30,9 @@ import { cn } from "@/lib/utils";
 import { useToast } from "@/components/ui/use-toast";
 
 const MARKETPLACE_OPTIONS = [
-  { value: 'mercado_livre', label: 'Mercado Livre', icon: '🛒', color: 'bg-yellow-500' },
-  { value: 'shopee', label: 'Shopee', icon: '🛍️', color: 'bg-orange-500' },
-  { value: 'instagram', label: 'Instagram', icon: '📸', color: 'bg-pink-500' },
+  { value: 'mercado_livre', label: 'Mercado Livre', icon: '🛒', color: 'bg-brand-primary' },
+  { value: 'shopee', label: 'Shopee', icon: '🛍️', color: 'bg-brand-danger' },
+  { value: 'instagram', label: 'Instagram', icon: '📸', color: 'bg-brand-secondary' },
 ] as const;
 
 export default function AdGenerator() {
@@ -375,7 +375,7 @@ export default function AdGenerator() {
                         alt="Produto"
                         className="w-full h-24 object-cover rounded-md border"
                       />
-                      <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity rounded-md flex items-center justify-center gap-2">
+                      <div className="absolute inset-0 bg-brand-dark/50 opacity-0 group-hover:opacity-100 transition-opacity rounded-md flex items-center justify-center gap-2">
                         <Button
                           size="sm"
                           variant="secondary"

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -204,29 +204,29 @@ export default function AdminDashboard() {
       title: "Total de Usuários",
       value: allUsers?.length || 0,
       icon: Users,
-      color: "text-blue-600",
-      bgColor: "bg-blue-50"
+      color: "text-brand-primary",
+      bgColor: "bg-brand-primary/10"
     },
     {
       title: "Assinaturas Ativas", 
       value: revenue?.activeSubscriptions || 0,
       icon: Crown,
-      color: "text-purple-600",
-      bgColor: "bg-purple-50"
+      color: "text-brand-secondary",
+      bgColor: "bg-brand-secondary/10"
     },
     {
       title: "Receita Mensal",
       value: `R$ ${(revenue?.monthly || 0).toFixed(2)}`,
       icon: DollarSign,
-      color: "text-green-600",
-      bgColor: "bg-green-50"
+      color: "text-brand-warning",
+      bgColor: "bg-brand-warning/10"
     },
     {
       title: "Receita Anual (Proj.)",
       value: `R$ ${(revenue?.yearly || 0).toFixed(2)}`,
       icon: TrendingUp,
-      color: "text-orange-600", 
-      bgColor: "bg-orange-50"
+      color: "text-brand-danger",
+      bgColor: "bg-brand-danger/10"
     }
   ];
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -15,15 +15,15 @@ const NotFound = () => {
   }, [location.pathname, logger]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center bg-brand-background">
       <div className="text-center">
         <Heading variant="h1" className="mb-md">
           404
         </Heading>
-        <Text className="text-gray-600 text-h4 mb-md">
+        <Text className="text-brand-dark text-h4 mb-md">
           Oops! Page not found
         </Text>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <a href="/" className="text-brand-primary hover:text-brand-dark underline">
           Return to Home
         </a>
       </div>

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -56,9 +56,9 @@ export default function Subscription() {
   const getPlanColor = (planName: string) => {
     switch (planName) {
       case 'free': return 'bg-muted text-muted-foreground';
-      case 'basic': return 'bg-blue-500 text-white';
-      case 'pro': return 'bg-purple-500 text-white';
-      case 'enterprise': return 'bg-gradient-to-r from-purple-600 to-blue-600 text-white';
+      case 'basic': return 'bg-brand-primary text-brand-background';
+      case 'pro': return 'bg-brand-secondary text-brand-dark';
+      case 'enterprise': return 'bg-gradient-primary text-brand-background';
       default: return 'bg-muted text-muted-foreground';
     }
   };
@@ -199,7 +199,7 @@ export default function Subscription() {
               )}
               
               {isCurrent && (
-                <Badge className="absolute -top-3 right-4 bg-green-600">
+                <Badge className="absolute -top-3 right-4 bg-brand-primary">
                   Atual
                 </Badge>
               )}
@@ -246,7 +246,7 @@ export default function Subscription() {
                       
                       return (
                         <li key={feature} className="flex items-center gap-2">
-                          <Check className="h-4 w-4 text-green-600" />
+                          <Check className="h-4 w-4 text-brand-primary" />
                           {featureLabels[feature] || feature}
                         </li>
                       );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,6 +28,7 @@ export default {
                                         secondary: colors["tea-green"],
                                         background: colors["anti-flash-white"],
                                         danger: colors.cinnabar,
+                                        warning: colors.warning.DEFAULT,
                                 },
                         },
 			backgroundImage: {


### PR DESCRIPTION
## Summary
- add `brand.warning` to Tailwind theme
- trocar cores hardcoded por utilitários `brand.*` em páginas e formulários

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6894e7bcd5f083298a5fe8f051afffae