### PR TITLE
refactor: substitui cores hex por tokens brand

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -35,3 +35,20 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Remember to verify script names before executing in automation.
 ---
+---
+Date: 2025-08-07
+TaskRef: "Tokenize hex colors in App.css and chart components"
+
+Learnings:
+- Tailwind's `theme()` function injects brand tokens into CSS variables via `@layer base`.
+- Recharts selectors can use Tailwind arbitrary variants to apply brand colors without hex codes.
+
+Difficulties:
+- Vitest's watch mode left a Sidebar accessibility test failing and required manual exit.
+
+Successes:
+- Replaced legacy hex codes with `brand.*`-based variables and utilities.
+
+Improvements_Identified_For_Consolidation:
+- Configure Vitest to run once in CI to avoid hanging on failures.
+---

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,11 @@
+@layer base {
+  :root {
+    --brand-primary: theme(colors.brand.primary);
+    --brand-secondary: theme(colors.brand.secondary);
+    --brand-dark: theme(colors.brand.dark);
+  }
+}
+
 #root {
   max-width: 1280px;
   margin: 0 auto;
@@ -12,10 +20,10 @@
   transition: filter 300ms;
 }
 .logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+  filter: drop-shadow(0 0 2em hsl(var(--brand-primary) / 0.67));
 }
 .logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+  filter: drop-shadow(0 0 2em hsl(var(--brand-secondary) / 0.67));
 }
 
 @keyframes logo-spin {
@@ -38,5 +46,5 @@
 }
 
 .read-the-docs {
-  color: #888;
+  color: hsl(var(--brand-dark) / 0.6);
 }

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -50,7 +50,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-brand-dark [&_.recharts-cartesian-grid_line]:stroke-brand-secondary/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-brand-primary [&_.recharts-dot]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_]:stroke-brand-secondary [&_.recharts-radial-bar-background-sector]:fill-brand-secondary/30 [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-brand-secondary/30 [&_.recharts-reference-line_]:stroke-brand-secondary [&_.recharts-sector]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
- define variáveis `brand.*` no App.css para substituir códigos hex
- aplica utilitários `brand.*` em estilos do gráfico, removendo seletores com `#ccc` e `#fff`

## Testing
- `pnpm lint` (789 warnings, 0 errors)
- `pnpm type-check`
- `pnpm test` *(falha: Sidebar accessibility > allows keyboard navigation through items)*

------
https://chatgpt.com/codex/tasks/task_e_6894ecba4eb08329a6106b1393ef4d76