### PR TITLE
fix: adicionar rolagem horizontal às tabelas

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -70,3 +70,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Create a checklist for color token migrations to ensure gradient utilities are lint-compliant.
 ---
+
+---
+Date: 2025-08-07
+TaskRef: "Wrap shadcn Table components with horizontal scroll containers"
+
+Learnings:
+- Adicionando um wrapper `overflow-x-auto` com `w-full` resolve overflow horizontal sem quebrar layout.
+- `min-w-full` nas tabelas evita compressão de colunas em telas estreitas.
+
+Difficulties:
+- Nenhuma complicação significativa ao atualizar múltiplos componentes.
+
+Successes:
+- Lint, type-check e testes passaram após as alterações.
+
+Improvements_Identified_For_Consolidation:
+- Criar utilitário ou wrapper reutilizável para tabelas responsivas evitando repetição de código.
+---

--- a/src/components/forms/SalesForm.tsx
+++ b/src/components/forms/SalesForm.tsx
@@ -189,52 +189,54 @@ export const SalesForm = ({ onCancel }: SalesFormProps) => {
           {isLoading ? (
             <p>Carregando...</p>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Produto</TableHead>
-                  <TableHead>Marketplace</TableHead>
-                  <TableHead>Preço</TableHead>
-                  <TableHead>Qtd</TableHead>
-                  <TableHead>Total</TableHead>
-                  <TableHead>Data</TableHead>
-                  <TableHead>Ações</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sales.map((sale) => (
-                  <TableRow key={sale.id}>
-                    <TableCell className="font-medium">{sale.products?.name}</TableCell>
-                    <TableCell>{sale.marketplaces?.name}</TableCell>
-                    <TableCell>{formatarMoeda(sale.price_charged)}</TableCell>
-                    <TableCell>{sale.quantity}</TableCell>
-                    <TableCell>{formatarMoeda(sale.price_charged * sale.quantity)}</TableCell>
-                    <TableCell>
-                      {format(new Date(sale.sold_at), "dd/MM/yyyy HH:mm", { locale: ptBR })}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex gap-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleEdit(sale)}
-                        >
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="destructive"
-                          onClick={() => deleteMutation.mutate(sale.id)}
-                          disabled={deleteMutation.isPending}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </TableCell>
+            <div className="overflow-x-auto w-full">
+              <Table className="min-w-full">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Produto</TableHead>
+                    <TableHead>Marketplace</TableHead>
+                    <TableHead>Preço</TableHead>
+                    <TableHead>Qtd</TableHead>
+                    <TableHead>Total</TableHead>
+                    <TableHead>Data</TableHead>
+                    <TableHead>Ações</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {sales.map((sale) => (
+                    <TableRow key={sale.id}>
+                      <TableCell className="font-medium">{sale.products?.name}</TableCell>
+                      <TableCell>{sale.marketplaces?.name}</TableCell>
+                      <TableCell>{formatarMoeda(sale.price_charged)}</TableCell>
+                      <TableCell>{sale.quantity}</TableCell>
+                      <TableCell>{formatarMoeda(sale.price_charged * sale.quantity)}</TableCell>
+                      <TableCell>
+                        {format(new Date(sale.sold_at), "dd/MM/yyyy HH:mm", { locale: ptBR })}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex gap-2">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleEdit(sale)}
+                          >
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => deleteMutation.mutate(sale.id)}
+                            disabled={deleteMutation.isPending}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/components/forms/ShippingRuleForm.tsx
+++ b/src/components/forms/ShippingRuleForm.tsx
@@ -318,51 +318,53 @@ export const ShippingRuleForm = ({ onCancel }: ShippingRuleFormProps) => {
           {isLoading ? (
             <p>Carregando...</p>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Produto</TableHead>
-                  <TableHead>Marketplace</TableHead>
-                  <TableHead>Custo Frete</TableHead>
-                  <TableHead>Frete Grátis</TableHead>
-                  <TableHead>Ações</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {shippingRules.map((rule) => (
-                  <TableRow key={rule.id}>
-                    <TableCell className="font-medium">{rule.products?.name}</TableCell>
-                    <TableCell>{rule.marketplaces?.name}</TableCell>
-                    <TableCell>R$ {rule.shipping_cost.toFixed(2)}</TableCell>
-                    <TableCell>
-                      {rule.free_shipping_threshold > 0 
-                        ? `A partir de R$ ${rule.free_shipping_threshold.toFixed(2)}`
-                        : "Não disponível"
-                      }
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex gap-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleEdit(rule)}
-                        >
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="destructive"
-                          onClick={() => deleteMutation.mutate(rule.id)}
-                          disabled={deleteMutation.isPending}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </TableCell>
+            <div className="overflow-x-auto w-full">
+              <Table className="min-w-full">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Produto</TableHead>
+                    <TableHead>Marketplace</TableHead>
+                    <TableHead>Custo Frete</TableHead>
+                    <TableHead>Frete Grátis</TableHead>
+                    <TableHead>Ações</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {shippingRules.map((rule) => (
+                    <TableRow key={rule.id}>
+                      <TableCell className="font-medium">{rule.products?.name}</TableCell>
+                      <TableCell>{rule.marketplaces?.name}</TableCell>
+                      <TableCell>R$ {rule.shipping_cost.toFixed(2)}</TableCell>
+                      <TableCell>
+                        {rule.free_shipping_threshold > 0
+                          ? `A partir de R$ ${rule.free_shipping_threshold.toFixed(2)}`
+                          : "Não disponível"
+                        }
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex gap-2">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleEdit(rule)}
+                          >
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => deleteMutation.mutate(rule.id)}
+                            disabled={deleteMutation.isPending}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/components/ui/data-visualization.tsx
+++ b/src/components/ui/data-visualization.tsx
@@ -101,84 +101,86 @@ export function DataVisualization<T extends { id: string }>({
   };
 
   const renderTableView = () => (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          {columns.map((column) => (
-            <TableHead 
-              key={String(column.key)} 
-              className={cn(
-                column.sortable && "cursor-pointer hover:bg-muted/50 transition-colors",
-                column.className
-              )}
-              onClick={() => column.sortable && handleSort(String(column.key))}
-            >
-              <div className="flex items-center gap-2">
-                {column.header}
-                {column.sortable && sortColumn === String(column.key) && (
-                  sortDirection === "asc" ? 
-                    <SortAsc className="w-4 h-4" /> : 
-                    <SortDesc className="w-4 h-4" />
-                )}
-              </div>
-            </TableHead>
-          ))}
-          {actions.length > 0 && <TableHead>Ações</TableHead>}
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {paginatedData.map((item) => (
-          <TableRow key={item.id} className="hover:bg-muted/50 transition-colors">
+    <div className="overflow-x-auto w-full">
+      <Table className="min-w-full">
+        <TableHeader>
+          <TableRow>
             {columns.map((column) => (
-              <TableCell key={String(column.key)} className={column.className}>
-                {column.render ? 
-                  column.render(item) : 
-                  String(getValue(item, String(column.key)))
-                }
-              </TableCell>
-            ))}
-            {actions.length > 0 && (
-              <TableCell>
+              <TableHead
+                key={String(column.key)}
+                className={cn(
+                  column.sortable && "cursor-pointer hover:bg-muted/50 transition-colors",
+                  column.className
+                )}
+                onClick={() => column.sortable && handleSort(String(column.key))}
+              >
                 <div className="flex items-center gap-2">
-                  {actions.slice(0, 2).map((action, index) => (
-                    <Button
-                      key={index}
-                      size="sm"
-                      variant={action.variant || "outline"}
-                      onClick={() => action.onClick(item)}
-                      disabled={action.disabled?.(item)}
-                    >
-                      {action.icon}
-                    </Button>
-                  ))}
-                  {actions.length > 2 && (
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button size="sm" variant="ghost">
-                          <MoreHorizontal className="w-4 h-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent>
-                        {actions.slice(2).map((action, index) => (
-                          <DropdownMenuItem
-                            key={index}
-                            onClick={() => action.onClick(item)}
-                            disabled={action.disabled?.(item)}
-                          >
-                            {action.icon}
-                            {action.label}
-                          </DropdownMenuItem>
-                        ))}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+                  {column.header}
+                  {column.sortable && sortColumn === String(column.key) && (
+                    sortDirection === "asc" ?
+                      <SortAsc className="w-4 h-4" /> :
+                      <SortDesc className="w-4 h-4" />
                   )}
                 </div>
-              </TableCell>
-            )}
+              </TableHead>
+            ))}
+            {actions.length > 0 && <TableHead>Ações</TableHead>}
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+        <TableBody>
+          {paginatedData.map((item) => (
+            <TableRow key={item.id} className="hover:bg-muted/50 transition-colors">
+              {columns.map((column) => (
+                <TableCell key={String(column.key)} className={column.className}>
+                  {column.render ?
+                    column.render(item) :
+                    String(getValue(item, String(column.key)))
+                  }
+                </TableCell>
+              ))}
+              {actions.length > 0 && (
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    {actions.slice(0, 2).map((action, index) => (
+                      <Button
+                        key={index}
+                        size="sm"
+                        variant={action.variant || "outline"}
+                        onClick={() => action.onClick(item)}
+                        disabled={action.disabled?.(item)}
+                      >
+                        {action.icon}
+                      </Button>
+                    ))}
+                    {actions.length > 2 && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button size="sm" variant="ghost">
+                            <MoreHorizontal className="w-4 h-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent>
+                          {actions.slice(2).map((action, index) => (
+                            <DropdownMenuItem
+                              key={index}
+                              onClick={() => action.onClick(item)}
+                              disabled={action.disabled?.(item)}
+                            >
+                              {action.icon}
+                              {action.label}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+                  </div>
+                </TableCell>
+              )}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
   );
 
   if (isLoading) {

--- a/src/pages/FixedFees.tsx
+++ b/src/pages/FixedFees.tsx
@@ -135,51 +135,53 @@ const FixedFees = () => {
                 <p className="text-sm mt-1">Adicione uma nova taxa para começar</p>
               </div>
             ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Marketplace</TableHead>
-                    <TableHead>Tipo</TableHead>
-                    <TableHead>Faixa</TableHead>
-                    <TableHead>Valor</TableHead>
-                    <TableHead>Ações</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {fixedFeeRules.map((rule) => (
-                    <TableRow key={rule.id}>
-                      <TableCell className="font-medium">{rule.marketplaces?.name}</TableCell>
-                      <TableCell>
-                        {RULE_TYPES.find(t => t.value === rule.rule_type)?.label}
-                      </TableCell>
-                      <TableCell>
-                         {(rule.rule_type === "faixa" || rule.rule_type === "percentual") && rule.range_min !== null && rule.range_max !== null
-                           ? `R$ ${rule.range_min.toFixed(2)} - R$ ${rule.range_max.toFixed(2)}`
-                           : rule.rule_type === "constante" ? "Todas as faixas" : "-"
-                         }
-                       </TableCell>
-                       <TableCell>
-                         {rule.rule_type === "percentual"
-                          ? `${rule.value.toFixed(2)}%`
-                          : `R$ ${rule.value.toFixed(2)}`
-                        }
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex gap-2">
-                          <Button
-                            size="sm"
-                            variant="destructive"
-                            onClick={() => deleteMutation.mutate(rule.id)}
-                            disabled={deleteMutation.isPending}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      </TableCell>
+              <div className="overflow-x-auto w-full">
+                <Table className="min-w-full">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Marketplace</TableHead>
+                      <TableHead>Tipo</TableHead>
+                      <TableHead>Faixa</TableHead>
+                      <TableHead>Valor</TableHead>
+                      <TableHead>Ações</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {fixedFeeRules.map((rule) => (
+                      <TableRow key={rule.id}>
+                        <TableCell className="font-medium">{rule.marketplaces?.name}</TableCell>
+                        <TableCell>
+                          {RULE_TYPES.find(t => t.value === rule.rule_type)?.label}
+                        </TableCell>
+                        <TableCell>
+                           {(rule.rule_type === "faixa" || rule.rule_type === "percentual") && rule.range_min !== null && rule.range_max !== null
+                             ? `R$ ${rule.range_min.toFixed(2)} - R$ ${rule.range_max.toFixed(2)}`
+                             : rule.rule_type === "constante" ? "Todas as faixas" : "-"
+                           }
+                         </TableCell>
+                         <TableCell>
+                           {rule.rule_type === "percentual"
+                            ? `${rule.value.toFixed(2)}%`
+                            : `R$ ${rule.value.toFixed(2)}`
+                          }
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              onClick={() => deleteMutation.mutate(rule.id)}
+                              disabled={deleteMutation.isPending}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
             )}
           </CardContent>
         </Card>


### PR DESCRIPTION
## Resumo
- envolver tabelas com container `overflow-x-auto w-full`
- aplicar `min-w-full` às tabelas para evitar compressão de colunas

## Testes
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_689517f6ec788329af64091e4341cfa6