### PR TITLE
fix: ajustar larguras responsivas

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -2,6 +2,22 @@
 
 ---
 Date: 2025-08-07
+TaskRef: "Refatorar utilitários de largura fixos para classes responsivas"
+
+Learnings:
+- `w-full max-w-sm md:w-96` evita overflow em telas de 375 px mantendo largura controlada em breakpoints maiores.
+- Testes com `pnpm test --run` encerram corretamente o Vitest sem ficar em modo watch.
+
+Difficulties:
+- Identificar quais classes `w-*` eram containers e quais eram ícones exigiu revisão manual.
+
+Successes:
+- Lint, type-check, testes e dev server rodaram sem erros após os ajustes de largura.
+
+Improvements_Identified_For_Consolidation:
+- Criar regra de lint para evitar `w-[0-9]+` em novos componentes.
+---
+Date: 2025-08-07
 TaskRef: "Swap Tailwind color tokens for brand equivalents in shadcn components"
 
 Learnings:

--- a/src/components/common/SkeletonLoaders.tsx
+++ b/src/components/common/SkeletonLoaders.tsx
@@ -10,9 +10,9 @@ export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
     <div className="space-y-md">
       {/* Header skeleton */}
       <div className="flex items-center justify-between">
-        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-6 w-full max-w-sm md:w-96" />
         <div className="flex items-center gap-3">
-          <Skeleton className="h-10 w-64" />
+          <Skeleton className="h-10 w-full max-w-sm md:w-96" />
           <Skeleton className="h-10 w-24" />
         </div>
       </div>
@@ -58,7 +58,7 @@ export function SkeletonForm({ sections = 2, fieldsPerSection = 3 }: SkeletonFor
       <div className="rounded-lg border border-border/50 overflow-hidden">
         {/* Header */}
         <div className="bg-gradient-primary p-lg">
-          <Skeleton className="h-6 w-48 bg-brand-background/20" />
+          <Skeleton className="h-6 w-full max-w-sm md:w-96 bg-brand-background/20" />
         </div>
         
         {/* Form content */}
@@ -98,7 +98,7 @@ export function SkeletonCard({ count = 1 }: SkeletonCardProps) {
       {Array.from({ length: count }).map((_, index) => (
         <div key={index} className="rounded-lg border border-border/50 p-lg space-y-md">
           <div className="flex items-center justify-between">
-            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-6 w-full max-w-sm md:w-96" />
             <Skeleton className="h-8 w-8 rounded" />
           </div>
           <Skeleton className="h-4 w-full" />

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -349,7 +349,7 @@ export default function AdminDashboard() {
 
         {/* Content skeleton */}
         <div className="space-y-4">
-          <div className="h-10 w-96 bg-muted rounded animate-pulse" />
+          <div className="h-10 w-full max-w-sm md:w-96 bg-muted rounded animate-pulse" />
           <div className="bg-card rounded-lg border p-6">
             <div className="space-y-4">
               <div className="h-6 w-48 bg-muted rounded animate-pulse" />


### PR DESCRIPTION
## Summary
- substituir `w-96` do skeleton do AdminDashboard por `w-full max-w-sm md:w-96`
- tornar loaders esqueléticos responsivos ao remover larguras fixas
- registrar aprendizados sobre classes de largura e execução de testes

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --run`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68951a4adca88329ad431b7c3eb582d2