### PR TITLE
fix: ajustar grids para responsividade

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -104,3 +104,20 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Criar utilitário ou wrapper reutilizável para tabelas responsivas evitando repetição de código.
 ---
+---
+Date: 2025-08-07
+TaskRef: "Refatorar grids fixos para responsivos com breakpoints"
+
+Learnings:
+- Padrão `grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4` mantém legibilidade em 375 px sem sacrificar desktop.
+- `rg "grid-cols-[234]"` identifica grids sem prefixos responsivos.
+
+Difficulties:
+- Diversas formas tinham seções pequenas que exigiram julgamento para definir breakpoints adequados.
+
+Successes:
+- Lint, typecheck, testes e dev server rodaram limpos após ajustes responsivos.
+
+Improvements_Identified_For_Consolidation:
+- Avaliar regra de lint para evitar `grid-cols-*` sem prefixos em novos componentes.
+---

--- a/src/components/forms/DashboardForm.tsx
+++ b/src/components/forms/DashboardForm.tsx
@@ -164,7 +164,7 @@ const SortableCard = ({ result, index }: SortableCardProps) => {
       </CardHeader>
       
       <CardContent className="space-y-3">
-        <div className="grid grid-cols-2 gap-3 text-sm">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
           <div className="space-y-xs">
             <div className="flex items-center gap-1 text-muted-foreground">
               <Package className="h-3 w-3" />
@@ -212,7 +212,7 @@ const SortableCard = ({ result, index }: SortableCardProps) => {
         
         <div className="pt-2 border-t border-border/30 text-xs text-muted-foreground space-y-xs">
           <div className="font-medium text-foreground mb-2">Detalhamento:</div>
-          <div className="grid grid-cols-2 gap-x-2 gap-y-1">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-2 gap-y-1">
             <div>Valor Fixo: R$ {result.valor_fixo.toFixed(2)}</div>
             <div>Frete: R$ {result.frete.toFixed(2)}</div>
             <div>Taxa Cartão: {result.taxa_cartao.toFixed(1)}%</div>

--- a/src/components/forms/PricingForm.tsx
+++ b/src/components/forms/PricingForm.tsx
@@ -401,7 +401,7 @@ export const PricingForm = () => {
           </CardHeader>
           <CardContent className="p-6">
             <div className="space-y-4">
-              <div className="grid grid-cols-2 gap-2 text-sm">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
                 <div>Produto:</div>
                 <div className="font-medium">{pricingResult.product_name || 'N/A'}</div>
                 
@@ -442,7 +442,7 @@ export const PricingForm = () => {
                     <h4 className="font-semibold mb-3 text-brand-primary">
                       Análise do Preço Praticado
                     </h4>
-                     <div className="grid grid-cols-2 gap-2 text-sm">
+                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
                        <div>Preço Praticado:</div>
                        <div className="font-medium text-brand-primary">
                          {formatarMoeda(margemRealResult.preco_praticado || 0)}

--- a/src/components/forms/StrategyForm.tsx
+++ b/src/components/forms/StrategyForm.tsx
@@ -286,7 +286,7 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mb-6">
                 <EnhancedTooltip
                   title="Produtos Estrela"
                   details={[
@@ -407,7 +407,7 @@ export const StrategyForm = ({ onCancel }: StrategyFormProps) => {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <div className="grid grid-cols-2 gap-4 h-96">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 h-96">
                 {/* Top Left: Alta Margem + Baixo Giro */}
                 <Card className="bg-brand-secondary/10 border-brand-secondary/20">
                   <CardHeader className="pb-2">

--- a/src/components/forms/enhanced/SimpleMarketplaceForm.tsx
+++ b/src/components/forms/enhanced/SimpleMarketplaceForm.tsx
@@ -295,7 +295,7 @@ export function SimpleMarketplaceForm({
                       </div>
                       
                       {!allCategoriesSelected && (
-                        <div className="grid grid-cols-2 sm:grid-cols-3 gap-xs max-h-32 overflow-y-auto">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-xs max-h-32 overflow-y-auto">
                           {categories.map((category) => {
                             const isSelected = selectedCategories.includes(category.id);
                             return (

--- a/src/components/onboarding/OnboardingTour.tsx
+++ b/src/components/onboarding/OnboardingTour.tsx
@@ -116,7 +116,7 @@ export function OnboardingTour({ onComplete, onSkip }: OnboardingTourProps) {
 
         <CardContent className="space-y-lg">
           {/* Steps Overview */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
             {steps.map((s, index) => (
               <div
                 key={s.id}

--- a/src/pages/AdGenerator.tsx
+++ b/src/pages/AdGenerator.tsx
@@ -198,7 +198,7 @@ export default function AdGenerator() {
                 <CardTitle className="text-lg">Configuração do Chat</CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm mb-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 text-sm mb-4">
                   <div>
                     <Label htmlFor="chat-product">Produto</Label>
                     <Select value={selectedProductId} onValueChange={setSelectedProductId}>
@@ -369,7 +369,7 @@ export default function AdGenerator() {
 
               {/* Grid de Imagens - Responsivo sem scroll interno */}
               {images.length > 0 && (
-                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
                   {images.map((image: ProductImage) => (
                     <div key={image.id} className="relative group">
                       <img
@@ -536,7 +536,7 @@ export default function AdGenerator() {
                     <Eye className="w-3 h-3 mr-2" />
                     Visualizar Preview
                   </Button>
-                  <div className="grid grid-cols-2 gap-2">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                     <Button size="sm" variant="outline">
                       📋 Copiar Tudo
                     </Button>

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -418,7 +418,7 @@ export default function AdminDashboard() {
 
       {/* Main Content */}
       <Tabs defaultValue="users" className="space-y-lg">
-        <TabsList className="grid w-full grid-cols-3">
+        <TabsList className="grid w-full grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
           <TabsTrigger value="users" className="flex items-center gap-2">
             <Users className="w-4 h-4" />
             Usuários

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -103,7 +103,7 @@ export default function Auth() {
           
           <CardContent>
             <Tabs defaultValue="login" className="w-full">
-              <TabsList className="grid w-full grid-cols-2 mb-6">
+              <TabsList className="grid w-full grid-cols-1 sm:grid-cols-2 mb-6">
                 <TabsTrigger value="login">Entrar</TabsTrigger>
                 <TabsTrigger value="signup">Cadastrar</TabsTrigger>
               </TabsList>

--- a/src/pages/Commissions.tsx
+++ b/src/pages/Commissions.tsx
@@ -157,7 +157,7 @@ const Commissions = () => {
           {/* Quick Stats Card */}
           <div className="bg-card rounded-lg p-lg border">
             <h3 className="font-semibold mb-4">Estatísticas Rápidas</h3>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="text-center">
                 <div className="text-2xl font-bold text-brand-primary">{totalCommissions}</div>
                 <div className="text-sm text-muted-foreground">Total</div>


### PR DESCRIPTION
## Summary
- tornar grids responsivos em páginas e formulários
- registrar aprendizado sobre padronização de breakpoints

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --run`
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68951ea65ddc8329b9af56877f2b5210