### PR TITLE
fix: evitar overflow em descrições de tabelas

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -121,3 +121,20 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Avaliar regra de lint para evitar `grid-cols-*` sem prefixos em novos componentes.
 ---
+---
+Date: 2025-08-07
+TaskRef: "Aplicar break-words em descrições de tabelas"
+
+Learnings:
+- `DataVisualization` aplica a mesma `className` ao cabeçalho e à célula; ao usar `break-words` evita overflow de descrições longas.
+- Um teste com string contínua valida que a classe é realmente renderizada.
+
+Difficulties:
+- `pnpm test` inicia em modo watch; é necessário usar `--run` para encerrar.
+
+Successes:
+- Lint, type-check, testes unitários e servidor de desenvolvimento funcionaram sem erros.
+
+Improvements_Identified_For_Consolidation:
+- Futuramente separar `cellClassName` de `className` em `DataVisualization` para estilizar cabeçalhos e células de forma independente.
+---

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -44,6 +44,7 @@ const Categories = () => {
     {
       key: 'description',
       header: 'Descrição',
+      className: 'break-words',
       render: (item: CategoryType) => (
         <span className="text-muted-foreground">
           {item.description || "Sem descrição"}

--- a/src/pages/Commissions.tsx
+++ b/src/pages/Commissions.tsx
@@ -39,6 +39,7 @@ const Commissions = () => {
     {
       key: "category",
       header: "Categoria",
+      className: "break-words",
       render: (commission: CommissionWithDetails) => (
         <div className="flex items-center gap-2">
           <span>{commission.categories?.name || 'Padrão'}</span>

--- a/src/pages/FixedFees.tsx
+++ b/src/pages/FixedFees.tsx
@@ -150,7 +150,7 @@ const FixedFees = () => {
                     {fixedFeeRules.map((rule) => (
                       <TableRow key={rule.id}>
                         <TableCell className="font-medium">{rule.marketplaces?.name}</TableCell>
-                        <TableCell>
+                        <TableCell className="break-words">
                           {RULE_TYPES.find(t => t.value === rule.rule_type)?.label}
                         </TableCell>
                         <TableCell>

--- a/tests/description-break-words.test.tsx
+++ b/tests/description-break-words.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import { DataVisualization } from '@/components/ui/data-visualization';
+
+test('description cells break long strings', () => {
+  const longDescription = 'L'.repeat(200);
+  const data = [{ id: '1', description: longDescription }];
+  const columns = [
+    { key: 'description', header: 'Descrição', className: 'break-words' }
+  ];
+
+  const { getByText } = render(
+    <DataVisualization title="" data={data} columns={columns} />
+  );
+
+  const cell = getByText(longDescription).closest('td');
+  expect(cell).toHaveClass('break-words');
+});


### PR DESCRIPTION
## Resumo
- aplicar `break-words` nas descrições de categorias, taxas fixas e comissões
- adicionar teste garantindo quebra de palavras com strings longas

## Testes
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --run`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68953891988483299d7f23615ae77d5b