### PR TITLE
feat: ajustar tipografia responsiva em páginas

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -155,3 +155,20 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Criar utilitário padrão para grupos de botões responsivos.
 ---
+---
+Date: 2025-08-08
+TaskRef: "Adjust text utilities to responsive variants"
+
+Learnings:
+- `text-base sm:text-lg md:text-xl` evita tipografia exagerada em telas de 375 px.
+- Ripgrep localiza rapidamente tamanhos de texto fixos em páginas.
+
+Difficulties:
+- Saída do lint contém centenas de avisos Tailwind, mas nenhum erro.
+
+Successes:
+- Lint, type-check, testes e servidor de desenvolvimento rodaram sem falhas após os ajustes.
+
+Improvements_Identified_For_Consolidation:
+- Considerar regra de lint para impedir `text-lg`/`text-xl` isolados em novos componentes.
+---

--- a/src/pages/AdGenerator.tsx
+++ b/src/pages/AdGenerator.tsx
@@ -195,7 +195,7 @@ export default function AdGenerator() {
           {selectedProductId && (
             <Card>
               <CardHeader>
-                <CardTitle className="text-lg">Configuração do Chat</CardTitle>
+                <CardTitle className="text-base sm:text-lg md:text-xl">Configuração do Chat</CardTitle>
               </CardHeader>
               <CardContent>
                 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 text-sm mb-4">
@@ -430,7 +430,7 @@ export default function AdGenerator() {
                     className="h-auto p-3 flex items-center justify-start gap-3"
                     onClick={() => setSelectedMarketplace(option.value)}
                   >
-                    <span className="text-xl">{option.icon}</span>
+                    <span className="text-base sm:text-lg md:text-xl">{option.icon}</span>
                     <span className="text-sm font-medium">{option.label}</span>
                   </Button>
                 ))}

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -465,7 +465,7 @@ export default function AdminDashboard() {
               </CardHeader>
               <CardContent className="text-center py-12">
                 <Activity className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
-                <h3 className="text-lg font-semibold mb-2">
+                <h3 className="text-base sm:text-lg md:text-xl font-semibold mb-2">
                   Funcionalidade em Desenvolvimento
                 </h3>
                 <p className="text-muted-foreground">

--- a/src/pages/Marketplaces.tsx
+++ b/src/pages/Marketplaces.tsx
@@ -126,7 +126,7 @@ const Marketplaces = () => {
               {hierarchicalMarketplaces.length === 0 ? (
                 <div className="text-center py-12 border-2 border-dashed border-muted-foreground/25 rounded-lg">
                   <Store className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-                  <h4 className="text-lg font-medium mb-2">Nenhuma plataforma cadastrada</h4>
+                  <h4 className="text-base sm:text-lg md:text-xl font-medium mb-2">Nenhuma plataforma cadastrada</h4>
                   <p className="text-muted-foreground mb-4">
                     Comece criando sua primeira plataforma de marketplace
                   </p>

--- a/src/pages/Subscription.tsx
+++ b/src/pages/Subscription.tsx
@@ -87,7 +87,7 @@ export default function Subscription() {
         <h1 className="text-4xl font-bold bg-gradient-to-r from-brand-primary to-brand-primary bg-clip-text text-transparent mb-4">
           Escolha seu Plano
         </h1>
-        <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+        <p className="text-base sm:text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto">
           Desbloqueie todo o potencial do Peepers Hub com ferramentas avançadas para seu marketplace
         </p>
       </div>
@@ -101,7 +101,7 @@ export default function Subscription() {
                 {getPlanIcon(currentSubscription.plan?.name || '')}
                 {currentSubscription.plan?.display_name}
               </Badge>
-              <span className="text-lg">Plano Atual</span>
+              <span className="text-base sm:text-lg md:text-xl">Plano Atual</span>
             </CardTitle>
             <CardDescription>
               Status: <Badge variant={currentSubscription.status === 'active' ? 'default' : 'secondary'}>
@@ -209,7 +209,7 @@ export default function Subscription() {
                   {getPlanIcon(plan.name)}
                 </div>
                 
-                <CardTitle className="text-xl">{plan.display_name}</CardTitle>
+                <CardTitle className="text-base sm:text-lg md:text-xl">{plan.display_name}</CardTitle>
                 <CardDescription className="text-sm">{plan.description}</CardDescription>
                 
                 <div className="mt-4">


### PR DESCRIPTION
## Summary
- tornar descrições de assinatura responsivas
- aplicar escalas de texto flexíveis no gerador de anúncios
- ajustar tipografia de dashboards e estados vazios

## Testing
- `pnpm lint && pnpm type-check`
- `pnpm test --run`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68954b25bea88329ae691fc6037bcff5