### PR TITLE
refactor: substituir styles inline por utilitários Tailwind

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -207,3 +207,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Avaliar remoção periódica de referências a arquivos obsoletos na base de código.
 ---
+
+---
+Date: 2025-08-08
+TaskRef: "Migrate inline styles to Tailwind utilities"
+
+Learnings:
+- Tailwind arbitrary properties `[--var:value]` substituem `<style>` dinâmicas mantendo temas.
+- Transforms do `dnd-kit` exigem variáveis CSS para refletir `translate` em tempo real.
+
+Difficulties:
+- Testes de acessibilidade Playwright falharam por falta de navegadores instalados.
+
+Successes:
+- Componentes de gráficos e formulários agora usam classes utilitárias sem `style=` direto.
+
+Improvements_Identified_For_Consolidation:
+- Documentar padrão de uso de variáveis CSS via Tailwind para futuros componentes.
+---

--- a/src/components/charts/QuadrantDonutChart.tsx
+++ b/src/components/charts/QuadrantDonutChart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
 import { ChartTooltipProps, ChartLegendProps } from '@/types/charts';
 import { colors } from "@/styles/tokens";
+import { cn } from "@/lib/utils";
 
 interface QuadrantCounts {
   alta_margem_alto_giro: number;
@@ -19,6 +20,7 @@ const QUADRANT_DATA = [
     name: "Estrelas",
     key: "alta_margem_alto_giro",
     color: colors.success.DEFAULT,
+    bgClass: "bg-[hsl(var(--success))]",
     emoji: "⭐",
     description: "Alta Margem + Alto Giro",
   },
@@ -26,6 +28,7 @@ const QUADRANT_DATA = [
     name: "Joias",
     key: "alta_margem_baixo_giro",
     color: colors.primary.DEFAULT,
+    bgClass: "bg-[hsl(var(--primary))]",
     emoji: "💎",
     description: "Alta Margem + Baixo Giro",
   },
@@ -33,6 +36,7 @@ const QUADRANT_DATA = [
     name: "Movimento",
     key: "baixa_margem_alto_giro",
     color: colors.warning.DEFAULT,
+    bgClass: "bg-[hsl(var(--warning))]",
     emoji: "🔄",
     description: "Baixa Margem + Alto Giro",
   },
@@ -40,6 +44,7 @@ const QUADRANT_DATA = [
     name: "Questionáveis",
     key: "baixa_margem_baixo_giro",
     color: colors.destructive.DEFAULT,
+    bgClass: "bg-[hsl(var(--destructive))]",
     emoji: "❓",
     description: "Baixa Margem + Baixo Giro",
   },
@@ -50,6 +55,7 @@ export const QuadrantDonutChart: React.FC<QuadrantDonutChartProps> = ({ quadrant
     name: quadrant.name,
     value: quadrantCounts[quadrant.key as keyof QuadrantCounts],
     color: quadrant.color,
+    bgClass: quadrant.bgClass,
     emoji: quadrant.emoji,
     description: quadrant.description,
   })).filter(item => item.value > 0);
@@ -79,10 +85,7 @@ export const QuadrantDonutChart: React.FC<QuadrantDonutChartProps> = ({ quadrant
       <div className="flex flex-wrap justify-center gap-4 mt-4">
         {payload?.map((entry, index: number) => (
           <div key={index} className="flex items-center gap-2 text-sm">
-            <div
-              className="w-3 h-3 rounded-full"
-              style={{ backgroundColor: entry.color }}
-            />
+            <div className={cn("w-3 h-3 rounded-full", entry.payload?.bgClass)} />
             <span>{String(entry.payload?.emoji || '')} {entry.value}</span>
             <span className="text-muted-foreground">
               ({String(entry.payload?.value || '')})

--- a/src/components/common/SkeletonLoaders.tsx
+++ b/src/components/common/SkeletonLoaders.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 
 interface SkeletonTableProps {
   rows?: number;
@@ -6,6 +7,15 @@ interface SkeletonTableProps {
 }
 
 export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
+  const gridTemplates: Record<number, string> = {
+    1: "[grid-template-columns:1fr_auto]",
+    2: "[grid-template-columns:repeat(2,1fr)_auto]",
+    3: "[grid-template-columns:repeat(3,1fr)_auto]",
+    4: "[grid-template-columns:repeat(4,1fr)_auto]",
+    5: "[grid-template-columns:repeat(5,1fr)_auto]",
+    6: "[grid-template-columns:repeat(6,1fr)_auto]",
+  };
+  const gridTemplate = gridTemplates[columns] ?? gridTemplates[4];
   return (
     <div className="space-y-md">
       {/* Header skeleton */}
@@ -21,7 +31,7 @@ export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
       <div className="rounded-lg border border-border/50 overflow-hidden">
         {/* Table header */}
         <div className="bg-muted/50 p-md border-b">
-          <div className="grid gap-4" style={{ gridTemplateColumns: `repeat(${columns}, 1fr) auto` }}>
+          <div className={cn("grid gap-4", gridTemplate)}>
             {Array.from({ length: columns }).map((_, i) => (
               <Skeleton key={i} className="h-4 w-20" />
             ))}
@@ -33,7 +43,7 @@ export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
         <div className="space-y-0">
           {Array.from({ length: rows }).map((_, rowIndex) => (
             <div key={rowIndex} className="p-md border-b last:border-b-0">
-              <div className="grid gap-4" style={{ gridTemplateColumns: `repeat(${columns}, 1fr) auto` }}>
+              <div className={cn("grid gap-4", gridTemplate)}>
                 {Array.from({ length: columns }).map((_, colIndex) => (
                   <Skeleton key={colIndex} className="h-4 w-full" />
                 ))}

--- a/src/components/forms/DashboardForm.tsx
+++ b/src/components/forms/DashboardForm.tsx
@@ -16,6 +16,7 @@ import { useAutomaticPricingUpdate } from "@/hooks/useAutomaticPricingUpdate";
 import { PRICING_CONFIG } from "@/lib/config";
 import { useLogger } from "@/utils/logger";
 import { colors } from "@/styles/tokens";
+import { cn } from "@/lib/utils";
 import { 
   DndContext, 
   closestCenter, 
@@ -101,24 +102,21 @@ const SortableCard = ({ result, index }: SortableCardProps) => {
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.5 : 1,
-    cursor: isDragging ? 'grabbing' : 'grab',
-  };
+  } as React.CSSProperties;
 
   // Simular dados históricos para sparkline (em um app real, viriam do banco)
   const sparklineData = Array.from({ length: 7 }, () => Math.random() * 10 + result.margem_percentual);
 
   return (
-    <Card 
-      ref={setNodeRef} 
-      style={style} 
-      className={`
-        group relative bg-gradient-to-br from-card to-card/50
-        transition-all duration-300 ease-in-out
-        hover:shadow-elegant hover:border-brand-primary/30
-        hover:scale-[1.02] hover:bg-gradient-to-br hover:from-card hover:to-brand-primary
-        ${isDragging ? 'z-50 rotate-1 scale-105 shadow-elegant' : ''}
-      `}
+    <Card
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "group relative bg-gradient-to-br from-card to-card/50 transition-all duration-300 ease-in-out hover:shadow-elegant hover:border-brand-primary/30 hover:scale-[1.02] hover:bg-gradient-to-br hover:from-card hover:to-brand-primary",
+        isDragging
+          ? "z-50 rotate-1 scale-105 shadow-elegant opacity-50 cursor-grabbing"
+          : "cursor-grab"
+      )}
       {...attributes}
     >
         {index === 0 && (

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -16,8 +16,8 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-brand-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      className="h-full w-full flex-1 bg-brand-primary transition-all [transform:translateX(calc(-100%+var(--progress)))]"
+      style={{ "--progress": `${value || 0}%` } as React.CSSProperties}
     />
   </ProgressPrimitive.Root>
 ))

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -19,9 +19,6 @@ import {
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
-const SIDEBAR_WIDTH = "16rem"
-const SIDEBAR_WIDTH_MOBILE = "18rem"
-const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
 type SidebarContext = {
@@ -59,7 +56,6 @@ const SidebarProvider = React.forwardRef<
       open: openProp,
       onOpenChange: setOpenProp,
       className,
-      style,
       children,
       ...props
     },
@@ -140,15 +136,8 @@ const SidebarProvider = React.forwardRef<
       <SidebarContext.Provider value={contextValue}>
         <TooltipProvider delayDuration={0}>
           <div
-            style={
-              {
-                "--sidebar-width": SIDEBAR_WIDTH,
-                "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-                ...style,
-              } as React.CSSProperties
-            }
             className={cn(
-              "group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+              "group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar [--sidebar-width:16rem] [--sidebar-width-icon:3rem]",
               className
             )}
             ref={ref}
@@ -205,12 +194,7 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
-            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
-            style={
-              {
-                "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
-              } as React.CSSProperties
-            }
+            className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden [--sidebar-width:18rem]"
             side={side}
           >
             <nav className="flex h-full w-full flex-col">{children}</nav>
@@ -658,8 +642,15 @@ const SidebarMenuSkeleton = React.forwardRef<
   }
 >(({ className, showIcon = false, ...props }, ref) => {
   // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
+  const widthClasses = [
+    "max-w-[50%]",
+    "max-w-[60%]",
+    "max-w-[70%]",
+    "max-w-[80%]",
+    "max-w-[90%]",
+  ]
+  const widthClass = React.useMemo(() => {
+    return widthClasses[Math.floor(Math.random() * widthClasses.length)]
   }, [])
 
   return (
@@ -676,13 +667,8 @@ const SidebarMenuSkeleton = React.forwardRef<
         />
       )}
       <Skeleton
-        className="h-4 flex-1 max-w-[--skeleton-width]"
+        className={cn("h-4 flex-1", widthClass)}
         data-sidebar="menu-skeleton-text"
-        style={
-          {
-            "--skeleton-width": width,
-          } as React.CSSProperties
-        }
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- remove `<style>` injection in chart container and leverage CSS variables via Tailwind
- refactor inline styles in components to utility classes
- document learnings in reflection log

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --run`
- `npx playwright test tests/a11y.spec.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`

------
https://chatgpt.com/codex/tasks/task_e_68961188bcec8329b0587ca8ccae0016