### PR TITLE
fix: tornar componentes responsivos

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -243,3 +243,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Preparar scripts que instalam navegadores do Playwright para evitar falhas nos testes.
 ---
+
+---
+Date: 2025-08-08
+TaskRef: "Replace fixed widths with responsive utilities"
+
+Learnings:
+- `flex-wrap` combinado com `w-full sm:w-*` elimina overflow em cabeçalhos de tabelas.
+- Verificação com Playwright a 320 px e 768 px assegura que a página de login não possui scroll horizontal.
+
+Difficulties:
+- `pnpm test --run` e `npx playwright test` falharam por testes existentes dependentes de autenticação.
+
+Successes:
+- Lint e type-check executaram sem erros após ajustes responsivos.
+
+Improvements_Identified_For_Consolidation:
+- Automatizar login de teste para validar rotas protegidas em verificação de overflow.
+---

--- a/src/components/common/SkeletonLoaders.tsx
+++ b/src/components/common/SkeletonLoaders.tsx
@@ -19,11 +19,11 @@ export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
   return (
     <div className="space-y-md">
       {/* Header skeleton */}
-      <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
         <Skeleton className="h-6 w-full max-w-sm md:w-96" />
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap w-full sm:w-auto">
           <Skeleton className="h-10 w-full max-w-sm md:w-96" />
-          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-10 w-full sm:w-24" />
         </div>
       </div>
 
@@ -33,9 +33,9 @@ export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
         <div className="bg-muted/50 p-md border-b">
           <div className={cn("grid gap-4", gridTemplate)}>
             {Array.from({ length: columns }).map((_, i) => (
-              <Skeleton key={i} className="h-4 w-20" />
+              <Skeleton key={i} className="h-4 w-full sm:w-20" />
             ))}
-            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-full sm:w-16" />
           </div>
         </div>
         
@@ -75,11 +75,11 @@ export function SkeletonForm({ sections = 2, fieldsPerSection = 3 }: SkeletonFor
         <div className="p-lg space-y-lg">
           {Array.from({ length: sections }).map((_, sectionIndex) => (
             <div key={sectionIndex} className="space-y-md">
-              <Skeleton className="h-5 w-32" />
+              <Skeleton className="h-5 w-full sm:w-32" />
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {Array.from({ length: fieldsPerSection }).map((_, fieldIndex) => (
                   <div key={fieldIndex} className="space-y-sm">
-                    <Skeleton className="h-4 w-20" />
+                    <Skeleton className="h-4 w-full sm:w-20" />
                     <Skeleton className="h-10 w-full" />
                   </div>
                 ))}
@@ -88,9 +88,9 @@ export function SkeletonForm({ sections = 2, fieldsPerSection = 3 }: SkeletonFor
           ))}
           
           {/* Buttons */}
-          <div className="flex gap-3 pt-4 border-t">
+          <div className="flex gap-3 pt-4 border-t flex-wrap">
             <Skeleton className="h-11 flex-1" />
-            <Skeleton className="h-11 w-24" />
+            <Skeleton className="h-11 w-full sm:w-24" />
           </div>
         </div>
       </div>
@@ -107,15 +107,15 @@ export function SkeletonCard({ count = 1 }: SkeletonCardProps) {
     <div className="space-y-md">
       {Array.from({ length: count }).map((_, index) => (
         <div key={index} className="rounded-lg border border-border/50 p-lg space-y-md">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between flex-wrap gap-2">
             <Skeleton className="h-6 w-full max-w-sm md:w-96" />
             <Skeleton className="h-8 w-8 rounded" />
           </div>
           <Skeleton className="h-4 w-full" />
           <Skeleton className="h-4 w-2/3" />
-          <div className="flex gap-2">
-            <Skeleton className="h-6 w-16" />
-            <Skeleton className="h-6 w-20" />
+          <div className="flex gap-2 flex-wrap">
+            <Skeleton className="h-6 w-full sm:w-16" />
+            <Skeleton className="h-6 w-full sm:w-20" />
           </div>
         </div>
       ))}

--- a/src/components/ui/data-visualization.tsx
+++ b/src/components/ui/data-visualization.tsx
@@ -199,7 +199,7 @@ export function DataVisualization<T extends { id: string }>({
   return (
     <Card className={className}>
       <CardHeader>
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <div>
             <CardTitle className="flex items-center gap-2">
               {title}
@@ -210,19 +210,19 @@ export function DataVisualization<T extends { id: string }>({
             )}
           </div>
           
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {searchable && (
-              <div className="relative">
+              <div className="relative w-full sm:w-auto">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
                 <Input
                   placeholder="Buscar..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-9 w-64"
+                  className="pl-9 w-full sm:w-64"
                 />
               </div>
             )}
-            
+
             {onViewModeChange && (
               <div className="flex rounded-md border">
                 <Button

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -321,14 +321,14 @@ export default function AdminDashboard() {
     return (
       <div className="container mx-auto py-8 px-4 max-w-7xl">
         {/* Header skeleton */}
-        <div className="flex items-center justify-between mb-8">
-          <div className="space-y-2">
-            <div className="h-8 w-64 bg-muted rounded animate-pulse" />
-            <div className="h-4 w-48 bg-muted rounded animate-pulse" />
+        <div className="flex flex-wrap items-center justify-between gap-4 mb-8">
+          <div className="space-y-2 flex-1">
+            <div className="h-8 w-full sm:w-64 bg-muted rounded animate-pulse" />
+            <div className="h-4 w-full sm:w-48 bg-muted rounded animate-pulse" />
           </div>
-          <div className="flex gap-2">
-            <div className="h-9 w-32 bg-muted rounded animate-pulse" />
-            <div className="h-9 w-36 bg-muted rounded animate-pulse" />
+          <div className="flex gap-2 flex-wrap">
+            <div className="h-9 w-full sm:w-32 bg-muted rounded animate-pulse" />
+            <div className="h-9 w-full sm:w-36 bg-muted rounded animate-pulse" />
           </div>
         </div>
 
@@ -338,8 +338,8 @@ export default function AdminDashboard() {
             <div key={i} className="bg-card rounded-lg border p-6">
               <div className="flex items-center justify-between">
                 <div className="space-y-2">
-                  <div className="h-4 w-24 bg-muted rounded animate-pulse" />
-                  <div className="h-8 w-16 bg-muted rounded animate-pulse" />
+                  <div className="h-4 w-full sm:w-24 bg-muted rounded animate-pulse" />
+                  <div className="h-8 w-full sm:w-16 bg-muted rounded animate-pulse" />
                 </div>
                 <div className="h-12 w-12 bg-muted rounded-full animate-pulse" />
               </div>
@@ -352,7 +352,7 @@ export default function AdminDashboard() {
           <div className="h-10 w-full max-w-sm md:w-96 bg-muted rounded animate-pulse" />
           <div className="bg-card rounded-lg border p-6">
             <div className="space-y-4">
-              <div className="h-6 w-48 bg-muted rounded animate-pulse" />
+              <div className="h-6 w-full sm:w-48 bg-muted rounded animate-pulse" />
               <div className="space-y-2">
                 {[...Array(5)].map((_, i) => (
                   <div key={i} className="h-12 bg-muted rounded animate-pulse" />


### PR DESCRIPTION
## Summary
- ajustar cabeçalho de tabelas para usar `flex-wrap` e larguras fluidas
- adaptar skeletons e dashboard admin para `w-full sm:w-*`
- registrar aprendizado sobre verificação responsiva

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test tests/**/*.{test.ts,test.tsx} --run` *(falhou: AppSidebar accessibility)*
- `npx playwright test tests/a11y.spec.ts` *(falhou: 13 testes)*
- `node play script` `/auth` 320/768 overflow false


------
https://chatgpt.com/codex/tasks/task_e_68962f15ad9483298ac486b472567f07