### PR TITLE
fix: melhorar acessibilidade de ícones e tabelas

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -261,3 +261,23 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Automatizar login de teste para validar rotas protegidas em verificação de overflow.
 ---
+---
+Date: 2025-08-08
+TaskRef: "Add accessibility labels to interactive icons"
+
+Learnings:
+- Botões com ícones precisam de `aria-label` e ícones decorativos devem usar `aria-hidden`.
+- `TableHead` interativo requer um `<button>` interno para suporte a teclado e leitor de tela.
+- Instalação de dependências do Playwright (`apt-get install` + `npx playwright install`) é necessária para executar testes de acessibilidade.
+
+Difficulties:
+- `pnpm test --run` incluiu arquivos Playwright e falhou; exclusão via CLI não funcionou.
+- `npx playwright test` exigiu bibliotecas do sistema e servidor local, resultando em erros de conexão.
+
+Successes:
+- Lint e type-check passaram sem erros após ajustes.
+- Adicionados `aria-label` e `aria-hidden` em vários componentes e páginas, melhorando a acessibilidade.
+
+Improvements_Identified_For_Consolidation:
+- Documentar comandos corretos para executar apenas testes Vitest e configurar ambiente do Playwright.
+---

--- a/src/components/forms/SalesForm.tsx
+++ b/src/components/forms/SalesForm.tsx
@@ -219,16 +219,18 @@ export const SalesForm = ({ onCancel }: SalesFormProps) => {
                             size="sm"
                             variant="outline"
                             onClick={() => handleEdit(sale)}
+                            aria-label="Editar venda"
                           >
-                            <Edit className="h-4 w-4" />
+                            <Edit className="h-4 w-4" aria-hidden="true" />
                           </Button>
                           <Button
                             size="sm"
                             variant="destructive"
                             onClick={() => deleteMutation.mutate(sale.id)}
                             disabled={deleteMutation.isPending}
+                            aria-label="Excluir venda"
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </Button>
                         </div>
                       </TableCell>

--- a/src/components/forms/ShippingRuleForm.tsx
+++ b/src/components/forms/ShippingRuleForm.tsx
@@ -347,16 +347,18 @@ export const ShippingRuleForm = ({ onCancel }: ShippingRuleFormProps) => {
                             size="sm"
                             variant="outline"
                             onClick={() => handleEdit(rule)}
+                            aria-label="Editar regra de frete"
                           >
-                            <Edit className="h-4 w-4" />
+                            <Edit className="h-4 w-4" aria-hidden="true" />
                           </Button>
                           <Button
                             size="sm"
                             variant="destructive"
                             onClick={() => deleteMutation.mutate(rule.id)}
                             disabled={deleteMutation.isPending}
+                            aria-label="Excluir regra de frete"
                           >
-                            <Trash2 className="h-4 w-4" />
+                            <Trash2 className="h-4 w-4" aria-hidden="true" />
                           </Button>
                         </div>
                       </TableCell>

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -47,9 +47,10 @@ export function AppHeader() {
 
           {/* Global Search with improved styling */}
           <div role="search" className="relative max-w-lg flex-1 hidden md:block">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
-            <Command className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" aria-hidden="true" />
+            <Command className="absolute right-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" aria-hidden="true" />
             <Input
+              aria-label="Buscar"
               placeholder="Buscar produtos, categorias, marketplaces... (Ctrl+K)"
               value={searchValue}
               onChange={(e) => setSearchValue(e.target.value)}
@@ -76,9 +77,10 @@ export function AppHeader() {
               tabIndex={-1}
             >
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" aria-hidden="true" />
                 <Input
                   autoFocus
+                  aria-label="Buscar"
                   placeholder="Buscar produtos, categorias, marketplaces..."
                   value={searchValue}
                   onChange={(e) => setSearchValue(e.target.value)}

--- a/src/components/marketplace/MarketplaceHierarchyCard.tsx
+++ b/src/components/marketplace/MarketplaceHierarchyCard.tsx
@@ -52,15 +52,17 @@ export const MarketplaceHierarchyCard = ({
               variant="outline"
               size="sm"
               onClick={() => onEditPlatform(platform)}
+              aria-label="Editar plataforma"
             >
-              <Settings className="w-4 h-4" />
+              <Settings className="w-4 h-4" aria-hidden="true" />
             </Button>
             <Button
               variant="destructive"
               size="sm"
               onClick={() => onDeletePlatform(platform.id)}
+              aria-label="Excluir plataforma"
             >
-              <Trash2 className="w-4 h-4" />
+              <Trash2 className="w-4 h-4" aria-hidden="true" />
             </Button>
           </div>
         </div>
@@ -121,16 +123,18 @@ export const MarketplaceHierarchyCard = ({
                         size="sm"
                         onClick={() => onEditModality(modality)}
                         className="h-8 w-8 p-0"
+                        aria-label="Editar modalidade"
                       >
-                        <Settings className="w-3 h-3" />
+                        <Settings className="w-3 h-3" aria-hidden="true" />
                       </Button>
                       <Button
                         variant="ghost"
                         size="sm"
                         onClick={() => onDeleteModality(modality.id)}
                         className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                        aria-label="Excluir modalidade"
                       >
-                        <Trash2 className="w-3 h-3" />
+                        <Trash2 className="w-3 h-3" aria-hidden="true" />
                       </Button>
                     </div>
                   </div>

--- a/src/components/ui/data-visualization.tsx
+++ b/src/components/ui/data-visualization.tsx
@@ -6,7 +6,6 @@ import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Search, SortAsc, SortDesc, Grid, List, MoreHorizontal } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { cn } from "@/lib/utils";
 
 export interface DataColumn<T> {
   key: keyof T | string;
@@ -106,22 +105,28 @@ export function DataVisualization<T extends { id: string }>({
         <TableHeader>
           <TableRow>
             {columns.map((column) => (
-              <TableHead
-                key={String(column.key)}
-                className={cn(
-                  column.sortable && "cursor-pointer hover:bg-muted/50 transition-colors",
-                  column.className
+              <TableHead key={String(column.key)} className={column.className}>
+                {column.sortable ? (
+                  <button
+                    type="button"
+                    onClick={() => handleSort(String(column.key))}
+                    className="flex items-center gap-2 cursor-pointer hover:bg-muted/50 transition-colors w-full text-left"
+                    aria-label={`Ordenar por ${column.header}`}
+                  >
+                    <span>{column.header}</span>
+                    {sortColumn === String(column.key) && (
+                      sortDirection === "asc" ? (
+                        <SortAsc className="w-4 h-4" aria-hidden="true" />
+                      ) : (
+                        <SortDesc className="w-4 h-4" aria-hidden="true" />
+                      )
+                    )}
+                  </button>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    {column.header}
+                  </div>
                 )}
-                onClick={() => column.sortable && handleSort(String(column.key))}
-              >
-                <div className="flex items-center gap-2">
-                  {column.header}
-                  {column.sortable && sortColumn === String(column.key) && (
-                    sortDirection === "asc" ?
-                      <SortAsc className="w-4 h-4" /> :
-                      <SortDesc className="w-4 h-4" />
-                  )}
-                </div>
               </TableHead>
             ))}
             {actions.length > 0 && <TableHead>Ações</TableHead>}
@@ -148,15 +153,18 @@ export function DataVisualization<T extends { id: string }>({
                         variant={action.variant || "outline"}
                         onClick={() => action.onClick(item)}
                         disabled={action.disabled?.(item)}
+                        aria-label={action.label}
                       >
-                        {action.icon}
+                        {action.icon && (
+                          <span aria-hidden="true">{action.icon}</span>
+                        )}
                       </Button>
                     ))}
                     {actions.length > 2 && (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
-                          <Button size="sm" variant="ghost">
-                            <MoreHorizontal className="w-4 h-4" />
+                          <Button size="sm" variant="ghost" aria-label="Mais ações">
+                            <MoreHorizontal className="w-4 h-4" aria-hidden="true" />
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent>
@@ -166,7 +174,9 @@ export function DataVisualization<T extends { id: string }>({
                               onClick={() => action.onClick(item)}
                               disabled={action.disabled?.(item)}
                             >
-                              {action.icon}
+                              {action.icon && (
+                                <span className="mr-2" aria-hidden="true">{action.icon}</span>
+                              )}
                               {action.label}
                             </DropdownMenuItem>
                           ))}
@@ -213,8 +223,12 @@ export function DataVisualization<T extends { id: string }>({
           <div className="flex flex-wrap items-center gap-2">
             {searchable && (
               <div className="relative w-full sm:w-auto">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
+                <Search
+                  className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4"
+                  aria-hidden="true"
+                />
                 <Input
+                  aria-label="Buscar"
                   placeholder="Buscar..."
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
@@ -230,16 +244,18 @@ export function DataVisualization<T extends { id: string }>({
                   variant={viewMode === "table" ? "default" : "ghost"}
                   onClick={() => onViewModeChange("table")}
                   className="rounded-r-none"
+                  aria-label="Visualizar como tabela"
                 >
-                  <List className="w-4 h-4" />
+                  <List className="w-4 h-4" aria-hidden="true" />
                 </Button>
                 <Button
                   size="sm"
                   variant={viewMode === "grid" ? "default" : "ghost"}
                   onClick={() => onViewModeChange("grid")}
                   className="rounded-l-none border-l"
+                  aria-label="Visualizar como grade"
                 >
-                  <Grid className="w-4 h-4" />
+                  <Grid className="w-4 h-4" aria-hidden="true" />
                 </Button>
               </div>
             )}

--- a/src/pages/AdGenerator.tsx
+++ b/src/pages/AdGenerator.tsx
@@ -378,20 +378,22 @@ export default function AdGenerator() {
                         className="w-full h-24 object-cover rounded-md border"
                       />
                       <div className="absolute inset-0 bg-brand-dark/50 opacity-0 group-hover:opacity-100 transition-opacity rounded-md flex flex-wrap items-center justify-center gap-2">
-                        <Button
-                          size="sm"
-                          variant="secondary"
-                          onClick={() => window.open(image.image_url, '_blank')}
-                        >
-                          <Eye className="w-3 h-3" />
-                        </Button>
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            onClick={() => window.open(image.image_url, '_blank')}
+                            aria-label="Visualizar imagem"
+                          >
+                            <Eye className="w-3 h-3" aria-hidden="true" />
+                          </Button>
                         <Button
                           size="sm"
                           variant="destructive"
                           onClick={() => deleteMutation.mutate(image.id)}
                           disabled={deleteMutation.isPending}
+                          aria-label="Excluir imagem"
                         >
-                          <Trash2 className="w-3 h-3" />
+                          <Trash2 className="w-3 h-3" aria-hidden="true" />
                         </Button>
                       </div>
                       <Badge 
@@ -488,8 +490,9 @@ export default function AdGenerator() {
                       size="sm"
                       variant="ghost"
                       onClick={() => navigator.clipboard.writeText(generatedResult.title)}
+                      aria-label="Copiar título"
                     >
-                      📋
+                      <span aria-hidden="true">📋</span>
                     </Button>
                   </div>
                   <div className="p-3 bg-muted/30 rounded-md text-sm">
@@ -505,8 +508,9 @@ export default function AdGenerator() {
                       size="sm"
                       variant="ghost"
                       onClick={() => navigator.clipboard.writeText(generatedResult.description)}
+                      aria-label="Copiar descrição"
                     >
-                      📋
+                      <span aria-hidden="true">📋</span>
                     </Button>
                   </div>
                   <div className="p-3 bg-muted/30 rounded-md text-sm whitespace-pre-wrap max-h-32 overflow-y-auto">

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -143,11 +143,12 @@ export default function Auth() {
                         size="sm"
                         className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
                         onClick={() => setShowPassword(!showPassword)}
+                        aria-label={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
                       >
                         {showPassword ? (
-                          <EyeOff className="h-4 w-4 text-muted-foreground" />
+                          <EyeOff className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                         ) : (
-                          <Eye className="h-4 w-4 text-muted-foreground" />
+                          <Eye className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                         )}
                       </Button>
                     </div>
@@ -225,11 +226,12 @@ export default function Auth() {
                         size="sm"
                         className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
                         onClick={() => setShowPassword(!showPassword)}
+                        aria-label={showPassword ? 'Ocultar senha' : 'Mostrar senha'}
                       >
                         {showPassword ? (
-                          <EyeOff className="h-4 w-4 text-muted-foreground" />
+                          <EyeOff className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                         ) : (
-                          <Eye className="h-4 w-4 text-muted-foreground" />
+                          <Eye className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                         )}
                       </Button>
                     </div>

--- a/src/pages/FixedFees.tsx
+++ b/src/pages/FixedFees.tsx
@@ -172,8 +172,9 @@ const FixedFees = () => {
                               variant="destructive"
                               onClick={() => deleteMutation.mutate(rule.id)}
                               disabled={deleteMutation.isPending}
+                              aria-label="Excluir regra"
                             >
-                              <Trash2 className="h-4 w-4" />
+                              <Trash2 className="h-4 w-4" aria-hidden="true" />
                             </Button>
                           </div>
                         </TableCell>

--- a/src/pages/Marketplaces.tsx
+++ b/src/pages/Marketplaces.tsx
@@ -114,12 +114,17 @@ const Marketplaces = () => {
                 <div className="text-sm text-muted-foreground">
                   {totalPlatforms} plataformas, {totalModalities} modalidades
                 </div>
-                <Button 
-                  variant="ghost" 
+                <Button
+                  variant="ghost"
                   size="sm"
                   onClick={toggleList}
+                  aria-label={isListVisible ? 'Ocultar lista' : 'Mostrar lista'}
                 >
-                  {isListVisible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  {isListVisible ? (
+                    <EyeOff className="w-4 h-4" aria-hidden="true" />
+                  ) : (
+                    <Eye className="w-4 h-4" aria-hidden="true" />
+                  )}
                 </Button>
               </div>
               


### PR DESCRIPTION
## Summary
- adicionar `<button>` em cabeçalhos ordenáveis
- rotular botões icônicos com `aria-label`
- identificar inputs de busca e alternância de visualização

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --run` *(falha: inclui testes Playwright e timeout)*
- `npx playwright test tests/a11y.spec.ts` *(falha: conexão recusada em http://localhost:5173)*

------
https://chatgpt.com/codex/tasks/task_e_689632a71fd08329b9bd84e259aa05b9