### PR TITLE
feat: separar lista de produtos do formulário

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -79,3 +79,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Criar script de migração automática para tokens, evitando edições manuais extensas em futuras paletas.
 ---
+Date: 2025-08-08
+TaskRef: "Separar ProductForm e ProductList, aplicar useFormVisibility"
+
+Learnings:
+- Ao separar o formulário da listagem foi necessário elevar o estado de edição para a página e expor callbacks.
+- O hook `useFormVisibility` facilita layouts responsivos ao alternar visibilidade do formulário e da tabela.
+
+Difficulties:
+- `pnpm lint` retornou diversos erros relacionados ao plugin Tailwind já existentes no projeto.
+- Testes Vitest executaram arquivos Playwright e falharam; `npx playwright test` requisitou instalação de navegadores.
+
+Successes:
+- Criado componente `ProductList` reutilizando `DataVisualization` e removido código de listagem do `ProductForm`.
+- Página de Produtos agora exibe formulário e lista em colunas controladas por `useFormVisibility`.
+
+Improvements_Identified_For_Consolidation:
+- Padronizar o padrão de lifting state para edição de entidades para reduzir duplicação entre páginas.
+---

--- a/src/components/product/ProductList.tsx
+++ b/src/components/product/ProductList.tsx
@@ -1,0 +1,103 @@
+import { Package, Tag, Edit, Trash2 } from '@/components/ui/icons';
+import { DataVisualization } from '@/components/ui/data-visualization';
+import { CollapsibleCard } from '@/components/ui/collapsible-card';
+import { Badge } from '@/components/ui/badge';
+import { useProductsWithCategories, useDeleteProduct } from '@/hooks/useProducts';
+import { ProductWithCategory } from '@/types/products';
+import { formatarMoeda } from '@/utils/pricing';
+
+interface ProductListProps {
+  onEdit: (product: ProductWithCategory) => void;
+  isListVisible: boolean;
+  toggleList: () => void;
+}
+
+export const ProductList = ({ onEdit, isListVisible, toggleList }: ProductListProps) => {
+  const { data: products = [], isLoading } = useProductsWithCategories();
+  const deleteMutation = useDeleteProduct();
+
+  const columns = [
+    {
+      key: 'name',
+      header: 'Nome',
+      render: (item: ProductWithCategory) => (
+        <div className="flex items-center gap-2">
+          <Package className="w-4 h-4 text-muted-foreground" />
+          <div>
+            <span className="font-medium">{item.name}</span>
+            {item.sku && (
+              <Badge variant="outline" className="ml-2 text-xs">
+                {item.sku}
+              </Badge>
+            )}
+          </div>
+        </div>
+      )
+    },
+    {
+      key: 'categories.name',
+      header: 'Categoria',
+      render: (item: ProductWithCategory) => (
+        <div className="flex items-center gap-1">
+          <Tag className="w-3 h-3 text-muted-foreground" />
+          <span>{item.categories?.name || 'Sem categoria'}</span>
+        </div>
+      )
+    },
+    {
+      key: 'cost_unit',
+      header: 'Custo Unit.',
+      render: (item: ProductWithCategory) => (
+        <span className="font-mono text-sm">{formatarMoeda(item.cost_unit || 0)}</span>
+      )
+    },
+    {
+      key: 'packaging_cost',
+      header: 'Embalagem',
+      render: (item: ProductWithCategory) => (
+        <span className="font-mono text-sm text-muted-foreground">
+          {formatarMoeda(item.packaging_cost || 0)}
+        </span>
+      )
+    }
+  ];
+
+  const actions = [
+    {
+      label: 'Editar',
+      icon: <Edit className="w-4 h-4" />,
+      onClick: (product: ProductWithCategory) => onEdit(product)
+    },
+    {
+      label: 'Excluir',
+      icon: <Trash2 className="w-4 h-4" />,
+      onClick: (product: ProductWithCategory) => deleteMutation.mutate(product.id),
+      variant: 'destructive' as const
+    }
+  ];
+
+  return (
+    <CollapsibleCard
+      title="Produtos Cadastrados"
+      icon={<Package className="w-4 h-4" />}
+      isOpen={isListVisible}
+      onToggle={toggleList}
+    >
+      <DataVisualization
+        title=""
+        data={products}
+        columns={columns}
+        actions={actions}
+        isLoading={isLoading}
+        emptyState={
+          <div className="text-center py-8">
+            <p className="text-muted-foreground">Nenhum produto cadastrado</p>
+            <p className="text-sm text-muted-foreground">
+              Crie seu primeiro produto usando o formulário ao lado
+            </p>
+          </div>
+        }
+      />
+    </CollapsibleCard>
+  );
+};

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -1,14 +1,33 @@
+import { useState } from "react";
 import { ProductForm } from "@/components/forms/ProductForm";
+import { ProductList } from "@/components/product/ProductList";
 import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
 import { Package, Plus } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { useFormVisibility } from "@/hooks/useFormVisibility";
+import { ProductWithCategory } from "@/types/products";
 
 const Products = () => {
-  const { isFormVisible, showForm } = useFormVisibility({
+  const [editingProduct, setEditingProduct] = useState<ProductWithCategory | null>(null);
+  const { isFormVisible, isListVisible, showForm, hideForm, toggleList } = useFormVisibility({
     formStorageKey: 'products-form-visible',
     listStorageKey: 'products-list-visible'
   });
+
+  const handleCreateNew = () => {
+    setEditingProduct(null);
+    showForm();
+  };
+
+  const handleEdit = (product: ProductWithCategory) => {
+    setEditingProduct(product);
+    showForm();
+  };
+
+  const handleCancel = () => {
+    setEditingProduct(null);
+    hideForm();
+  };
 
   const breadcrumbs = [
     { label: "Configurações", href: "/dashboard" },
@@ -17,7 +36,7 @@ const Products = () => {
 
   const headerActions = (
     <div className="flex items-center gap-2">
-      <Button size="sm" onClick={showForm}>
+      <Button size="sm" onClick={handleCreateNew}>
         <Plus className="w-4 h-4 mr-2" />
         Novo Produto
       </Button>
@@ -33,10 +52,18 @@ const Products = () => {
       actions={headerActions}
     >
       {isFormVisible && (
-        <div className="xl:col-span-12">
-          <ProductForm />
+        <div className="xl:col-span-5">
+          <ProductForm editingProduct={editingProduct} onCancel={handleCancel} />
         </div>
       )}
+
+      <div className={isFormVisible ? "xl:col-span-7" : "xl:col-span-12"}>
+        <ProductList
+          onEdit={handleEdit}
+          isListVisible={isListVisible}
+          toggleList={toggleList}
+        />
+      </div>
     </ConfigurationPageLayout>
   );
 };


### PR DESCRIPTION
## Summary
- isola a tabela de produtos em `ProductList`
- ajusta `ProductForm` para receber produto em edição e remove listagem
- organiza página de Produtos com formulário e lista em colunas responsivas

## Testing
- `pnpm lint` *(falhou: tailwindcss/no-custom-classname)*
- `pnpm type-check`
- `pnpm test --run` *(falhou: Test failed. See above for more details.)*
- `npx playwright test tests/a11y.spec.ts` *(falhou: executable doesn't exist, run ‘npx playwright install’)*
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_689662e5764c8329a326ad6df74de879