### PR TITLE
feat: adicionar tabela de taxas fixas

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -115,3 +115,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Registrar no repositório como preparar ambiente para testes Playwright.
 ---
+---
+Date: 2025-08-09
+TaskRef: "Criar FixedFeesTable com DataVisualization e CollapsibleCard"
+
+Learnings:
+- Reutilizar DataVisualization facilita padronizar tabelas com ações configuráveis.
+- useFormVisibility combinado com CollapsibleCard fornece controle de exibição para mobile.
+
+Difficulties:
+- `pnpm lint` possui diversos erros preexistentes de Tailwind que impedem passagem do linter.
+- Testes Vitest/Playwright falharam por ausência de configuração e browsers.
+
+Successes:
+- Componente FixedFeesTable criado com edição/remoção e página FixedFees ajustada para colapsar lista.
+
+Improvements_Identified_For_Consolidation:
+- Investigar estratégia para executar lint e testes isolando arquivos tocados para evitar ruído.
+---

--- a/src/components/fixed-fees/FixedFeesTable.tsx
+++ b/src/components/fixed-fees/FixedFeesTable.tsx
@@ -1,0 +1,126 @@
+import { Edit, Trash2, Coins } from "@/components/ui/icons";
+import { DataVisualization } from "@/components/ui/data-visualization";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/components/ui/use-toast";
+import { FixedFeeRule } from "@/types/fixed-fees";
+import { formatarMoeda } from "@/utils/pricing";
+
+interface FixedFeesTableProps {
+  onEdit: (rule: FixedFeeRule) => void;
+}
+
+const RULE_TYPES: Record<string, string> = {
+  constante: "Constante",
+  faixa: "Faixa",
+  percentual: "Percentual",
+};
+
+export const FixedFeesTable = ({ onEdit }: FixedFeesTableProps) => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: fixedFeeRules = [], isLoading } = useQuery<FixedFeeRule[]>({
+    queryKey: ["marketplace_fixed_fee_rules"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("marketplace_fixed_fee_rules")
+        .select(`*, marketplaces (name)`).order("created_at", { ascending: false });
+      if (error) throw error;
+      return data as FixedFeeRule[];
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase
+        .from("marketplace_fixed_fee_rules")
+        .delete()
+        .eq("id", id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["marketplace_fixed_fee_rules"] });
+      toast({ title: "Taxa fixa excluída com sucesso!" });
+    },
+    onError: (error) => {
+      toast({
+        title: "Erro ao excluir taxa fixa",
+        description: String(error),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const columns = [
+    {
+      key: "marketplaces.name",
+      header: "Marketplace",
+      render: (item: FixedFeeRule) => (
+        <div className="flex items-center gap-2">
+          <Coins className="w-4 h-4 text-muted-foreground" />
+          <span className="font-medium">{item.marketplaces?.name}</span>
+        </div>
+      ),
+    },
+    {
+      key: "rule_type",
+      header: "Tipo",
+      render: (item: FixedFeeRule) => RULE_TYPES[item.rule_type] || item.rule_type,
+      className: "break-words",
+    },
+    {
+      key: "range_min",
+      header: "Faixa",
+      render: (item: FixedFeeRule) => {
+        if ((item.rule_type === "faixa" || item.rule_type === "percentual") &&
+            item.range_min !== null && item.range_max !== null) {
+          return `${formatarMoeda(item.range_min)} - ${formatarMoeda(item.range_max)}`;
+        }
+        return item.rule_type === "constante" ? "Todas as faixas" : "-";
+      },
+    },
+    {
+      key: "value",
+      header: "Valor",
+      render: (item: FixedFeeRule) =>
+        item.rule_type === "percentual"
+          ? `${item.value.toFixed(2)}%`
+          : formatarMoeda(item.value),
+    },
+  ];
+
+  const actions = [
+    {
+      label: "Editar",
+      icon: <Edit className="w-4 h-4" />,
+      onClick: (rule: FixedFeeRule) => onEdit(rule),
+    },
+    {
+      label: "Excluir",
+      icon: <Trash2 className="w-4 h-4" />,
+      onClick: (rule: FixedFeeRule) => deleteMutation.mutate(rule.id),
+      variant: "destructive" as const,
+      disabled: () => deleteMutation.isPending,
+    },
+  ];
+
+  return (
+    <DataVisualization
+      title=""
+      data={fixedFeeRules}
+      columns={columns}
+      actions={actions}
+      isLoading={isLoading}
+      emptyState={
+        <div className="text-center py-8">
+          <p className="text-muted-foreground">Nenhuma taxa fixa configurada</p>
+          <p className="text-sm text-muted-foreground">
+            Adicione uma nova taxa para começar
+          </p>
+        </div>
+      }
+    />
+  );
+};
+

--- a/src/components/forms/FixedFeeRuleForm.tsx
+++ b/src/components/forms/FixedFeeRuleForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -10,6 +10,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { useToast } from "@/components/ui/use-toast";
 import { Info } from '@/components/ui/icons';
 import { handleSupabaseError } from "@/utils/errors";
+import { FixedFeeRule } from "@/types/fixed-fees";
 
 interface Marketplace {
   id: string;
@@ -36,9 +37,10 @@ const RULE_TYPES = [
 
 interface FixedFeeRuleFormProps {
   onCancel?: () => void;
+  editingRule?: FixedFeeRule | null;
 }
 
-export const FixedFeeRuleForm = ({ onCancel }: FixedFeeRuleFormProps) => {
+export const FixedFeeRuleForm = ({ onCancel, editingRule }: FixedFeeRuleFormProps) => {
   interface FixedFeeRuleFormData {
     marketplace_id: string;
     rule_type: string;
@@ -154,7 +156,7 @@ export const FixedFeeRuleForm = ({ onCancel }: FixedFeeRuleFormProps) => {
     }
   };
 
-  const handleCancelEdit = () => {
+const handleCancelEdit = () => {
     setFormData({
       marketplace_id: "",
       rule_type: "",
@@ -163,7 +165,22 @@ export const FixedFeeRuleForm = ({ onCancel }: FixedFeeRuleFormProps) => {
       value: ""
     });
     setEditingId(null);
-  };
+};
+
+  useEffect(() => {
+    if (editingRule) {
+      setFormData({
+        marketplace_id: editingRule.marketplace_id,
+        rule_type: editingRule.rule_type,
+        range_min: editingRule.range_min !== null ? editingRule.range_min.toString() : "",
+        range_max: editingRule.range_max !== null ? editingRule.range_max.toString() : "",
+        value: editingRule.value.toString(),
+      });
+      setEditingId(editingRule.id);
+    } else {
+      handleCancelEdit();
+    }
+  }, [editingRule]);
 
   const showRangeFields = formData.rule_type === "faixa" || formData.rule_type === "percentual";
 

--- a/src/pages/FixedFees.tsx
+++ b/src/pages/FixedFees.tsx
@@ -1,94 +1,29 @@
+import { useState } from "react";
 import { FixedFeeRuleForm } from "@/components/forms/FixedFeeRuleForm";
 import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
-import { Coins, Plus, Trash2 } from "@/components/ui/icons";
+import { Coins, Plus, Eye, EyeOff } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { useFormVisibility } from "@/hooks/useFormVisibility";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
-import { useToast } from "@/components/ui/use-toast";
-import { handleSupabaseError } from "@/utils/errors";
+import { CollapsibleCard } from "@/components/ui/collapsible-card";
+import { FixedFeesTable } from "@/components/fixed-fees/FixedFeesTable";
+import { FixedFeeRule } from "@/types/fixed-fees";
 
 const FixedFees = () => {
-  const { isFormVisible, showForm, hideForm } = useFormVisibility({
+  const [editingRule, setEditingRule] = useState<FixedFeeRule | null>(null);
+  const { isFormVisible, isListVisible, showForm, hideForm, toggleList } = useFormVisibility({
     formStorageKey: 'fixed-fees-form-visible',
     listStorageKey: 'fixed-fees-list-visible'
   });
 
-  const { toast } = useToast();
-  const queryClient = useQueryClient();
+  const handleEdit = (rule: FixedFeeRule) => {
+    setEditingRule(rule);
+    showForm();
+  };
 
-  interface FixedFeeRule {
-    id: string;
-    marketplace_id: string;
-    rule_type: string;
-    range_min: number | null;
-    range_max: number | null;
-    value: number;
-    created_at: string;
-    updated_at: string;
-    marketplaces?: {
-      name: string;
-    };
-  }
-
-  const RULE_TYPES = [
-    { 
-      value: "constante", 
-      label: "Constante",
-      description: "Valor fixo aplicado independente do preço do produto"
-    },
-    { 
-      value: "faixa", 
-      label: "Faixa",
-      description: "Valor aplicado quando o preço estiver dentro de uma faixa específica"
-    },
-    { 
-      value: "percentual", 
-      label: "Percentual",
-      description: "Percentual aplicado sobre o valor do produto dentro de uma faixa específica"
-    }
-  ];
-
-  const { data: fixedFeeRules = [], isLoading } = useQuery({
-    queryKey: ["marketplace_fixed_fee_rules"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("marketplace_fixed_fee_rules")
-        .select(`
-          *,
-          marketplaces (name)
-        `)
-        .order("created_at", { ascending: false });
-      
-      if (error) throw error;
-      return data as FixedFeeRule[];
-    }
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const { error } = await supabase
-        .from("marketplace_fixed_fee_rules")
-        .delete()
-        .eq("id", id);
-      
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["marketplace_fixed_fee_rules"] });
-      toast({ title: "Taxa fixa excluída com sucesso!" });
-    },
-    onError: (error) => {
-      const friendlyMessage = handleSupabaseError(error);
-      toast({ 
-        title: "Erro ao excluir taxa fixa", 
-        description: friendlyMessage, 
-        variant: "destructive" 
-      });
-    }
-  });
+  const handleFormCancel = () => {
+    setEditingRule(null);
+    hideForm();
+  };
 
   const breadcrumbs = [
     { label: "Configurações", href: "/dashboard" },
@@ -97,6 +32,18 @@ const FixedFees = () => {
 
   const headerActions = (
     <div className="flex items-center gap-2">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={toggleList}
+        aria-label={isListVisible ? 'Ocultar lista' : 'Mostrar lista'}
+      >
+        {isListVisible ? (
+          <EyeOff className="w-4 h-4" aria-hidden="true" />
+        ) : (
+          <Eye className="w-4 h-4" aria-hidden="true" />
+        )}
+      </Button>
       <Button size="sm" onClick={showForm}>
         <Plus className="w-4 h-4 mr-2" />
         Nova Taxa
@@ -114,78 +61,19 @@ const FixedFees = () => {
     >
       {isFormVisible && (
         <div className="xl:col-span-6">
-          <FixedFeeRuleForm onCancel={hideForm} />
+          <FixedFeeRuleForm onCancel={handleFormCancel} editingRule={editingRule} />
         </div>
       )}
 
       <div className={isFormVisible ? "xl:col-span-6" : "xl:col-span-12"}>
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Coins className="w-5 h-5" />
-              Taxas Fixas Configuradas
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <p>Carregando...</p>
-            ) : fixedFeeRules.length === 0 ? (
-              <div className="p-4 text-center text-muted-foreground">
-                <p>Nenhuma taxa fixa configurada</p>
-                <p className="text-sm mt-1">Adicione uma nova taxa para começar</p>
-              </div>
-            ) : (
-              <div className="overflow-x-auto w-full">
-                <Table className="min-w-full">
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Marketplace</TableHead>
-                      <TableHead>Tipo</TableHead>
-                      <TableHead>Faixa</TableHead>
-                      <TableHead>Valor</TableHead>
-                      <TableHead>Ações</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {fixedFeeRules.map((rule) => (
-                      <TableRow key={rule.id}>
-                        <TableCell className="font-medium">{rule.marketplaces?.name}</TableCell>
-                        <TableCell className="break-words">
-                          {RULE_TYPES.find(t => t.value === rule.rule_type)?.label}
-                        </TableCell>
-                        <TableCell>
-                           {(rule.rule_type === "faixa" || rule.rule_type === "percentual") && rule.range_min !== null && rule.range_max !== null
-                             ? `R$ ${rule.range_min.toFixed(2)} - R$ ${rule.range_max.toFixed(2)}`
-                             : rule.rule_type === "constante" ? "Todas as faixas" : "-"
-                           }
-                         </TableCell>
-                         <TableCell>
-                           {rule.rule_type === "percentual"
-                            ? `${rule.value.toFixed(2)}%`
-                            : `R$ ${rule.value.toFixed(2)}`
-                          }
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex gap-2">
-                            <Button
-                              size="sm"
-                              variant="destructive"
-                              onClick={() => deleteMutation.mutate(rule.id)}
-                              disabled={deleteMutation.isPending}
-                              aria-label="Excluir regra"
-                            >
-                              <Trash2 className="h-4 w-4" aria-hidden="true" />
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <CollapsibleCard
+          title="Taxas Fixas Configuradas"
+          icon={<Coins className="w-4 h-4" />}
+          isOpen={isListVisible}
+          onToggle={toggleList}
+        >
+          <FixedFeesTable onEdit={handleEdit} />
+        </CollapsibleCard>
       </div>
     </ConfigurationPageLayout>
   );

--- a/src/types/fixed-fees.ts
+++ b/src/types/fixed-fees.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export interface FixedFeeRule {
+  id: string;
+  marketplace_id: string;
+  rule_type: string;
+  range_min: number | null;
+  range_max: number | null;
+  value: number;
+  created_at: string;
+  updated_at: string;
+  marketplaces?: {
+    name: string;
+  };
+}
+
+export const fixedFeeRuleSchema = z.object({
+  marketplace_id: z.string(),
+  rule_type: z.string(),
+  range_min: z.number().nullable(),
+  range_max: z.number().nullable(),
+  value: z.number(),
+});
+
+export type FixedFeeRuleFormData = z.infer<typeof fixedFeeRuleSchema>;


### PR DESCRIPTION
## Sumário
- cria componente `FixedFeesTable` baseado em `DataVisualization`
- utiliza `CollapsibleCard` e botão de visibilidade na página de taxas fixas
- habilita edição no formulário de taxas fixas

## Testes
- `pnpm lint` *(falhou: Classname 'text-brand-primary' is not a Tailwind CSS class)*
- `pnpm type-check`
- `pnpm test --run` *(falhou: Playwright Test did not expect test.describe to be called here)*
- `npx playwright test tests/a11y.spec.ts` *(falhou: playwright install required)*
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`


------
https://chatgpt.com/codex/tasks/task_e_68977ca01d608329aff48d6d51123678