### PR TITLE
feat: listar regras de frete com tabela

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -133,3 +133,20 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Investigar estratégia para executar lint e testes isolando arquivos tocados para evitar ruído.
 ---
+---
+Date: 2025-08-09
+TaskRef: "Implement ShippingRulesTable with useShippingRules"
+
+Learnings:
+- Reutilizar DataVisualization para regras de frete padroniza ações e layout.
+- Hook dedicado `useShippingRules` centraliza acesso ao Supabase e facilita invalidação de cache.
+
+Difficulties:
+- Lint e testes apresentam erros pré-existentes de Tailwind e Playwright.
+
+Successes:
+- Tabela de regras de frete criada com suporte a exclusão e listagem colapsável.
+
+Improvements_Identified_For_Consolidation:
+- Definir estratégia para execução isolada de testes de unidade e Playwright.
+---

--- a/src/components/shipping/ShippingRulesTable.tsx
+++ b/src/components/shipping/ShippingRulesTable.tsx
@@ -1,0 +1,87 @@
+import { Trash2, Truck } from "@/components/ui/icons";
+import { DataVisualization } from "@/components/ui/data-visualization";
+import { useShippingRules, SHIPPING_RULES_QUERY_KEY } from "@/hooks/useShippingRules";
+import { shippingRulesService } from "@/services/shipping-rules";
+import { ShippingRuleType } from "@/types/shipping";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useToast } from "@/components/ui/use-toast";
+import { formatarMoeda } from "@/utils/pricing";
+
+export function ShippingRulesTable() {
+  const { data: shippingRules = [], isLoading } = useShippingRules();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => shippingRulesService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SHIPPING_RULES_QUERY_KEY });
+      toast({ title: "Regra de frete excluída" });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: "Erro ao excluir regra de frete",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const columns = [
+    {
+      key: "products.name",
+      header: "Produto",
+      render: (item: ShippingRuleType) => (
+        <div className="flex items-center gap-2">
+          <Truck className="w-4 h-4 text-muted-foreground" />
+          <span className="font-medium">{item.products?.name}</span>
+        </div>
+      ),
+    },
+    {
+      key: "marketplaces.name",
+      header: "Marketplace",
+      render: (item: ShippingRuleType) => item.marketplaces?.name,
+    },
+    {
+      key: "shipping_cost",
+      header: "Custo Frete",
+      render: (item: ShippingRuleType) => formatarMoeda(item.shipping_cost),
+    },
+    {
+      key: "free_shipping_threshold",
+      header: "Frete Grátis",
+      render: (item: ShippingRuleType) =>
+        item.free_shipping_threshold
+          ? `A partir de ${formatarMoeda(item.free_shipping_threshold)}`
+          : "Não disponível",
+      className: "break-words",
+    },
+  ];
+
+  const actions = [
+    {
+      label: "Excluir",
+      icon: <Trash2 className="w-4 h-4" />,
+      onClick: (rule: ShippingRuleType) => deleteMutation.mutate(rule.id),
+      variant: "destructive" as const,
+      disabled: () => deleteMutation.isPending,
+    },
+  ];
+
+  return (
+    <DataVisualization
+      title=""
+      data={shippingRules}
+      columns={columns}
+      actions={actions}
+      isLoading={isLoading}
+      emptyState={
+        <div className="text-center py-8">
+          <p className="text-muted-foreground">Nenhuma regra de frete configurada</p>
+          <p className="text-sm text-muted-foreground">Adicione uma nova regra para começar</p>
+        </div>
+      }
+    />
+  );
+}

--- a/src/hooks/useShippingRules.ts
+++ b/src/hooks/useShippingRules.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { shippingRulesService } from "@/services/shipping-rules";
+import { ShippingRuleType } from "@/types/shipping";
+
+export const SHIPPING_RULES_QUERY_KEY = ["shipping_rules"] as const;
+
+export function useShippingRules() {
+  return useQuery<ShippingRuleType[]>({
+    queryKey: SHIPPING_RULES_QUERY_KEY,
+    queryFn: () => shippingRulesService.getAllWithDetails(),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/pages/Shipping.tsx
+++ b/src/pages/Shipping.tsx
@@ -4,6 +4,7 @@ import { Truck, Plus } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { useFormVisibility } from "@/hooks/useFormVisibility";
 import { CollapsibleCard } from "@/components/ui/collapsible-card";
+import { ShippingRulesTable } from "@/components/shipping/ShippingRulesTable";
 
 const Shipping = () => {
   const { isFormVisible, isListVisible, showForm, hideForm, toggleList } = useFormVisibility({
@@ -47,10 +48,7 @@ const Shipping = () => {
           isOpen={isListVisible}
           onToggle={toggleList}
         >
-          <div className="p-4 text-center text-muted-foreground">
-            <p>Lista de regras de frete será exibida aqui</p>
-            <p className="text-sm mt-1">Adicione uma nova regra para começar</p>
-          </div>
+          <ShippingRulesTable />
         </CollapsibleCard>
       </div>
     </ConfigurationPageLayout>

--- a/src/services/shipping-rules.ts
+++ b/src/services/shipping-rules.ts
@@ -1,0 +1,31 @@
+import { supabase } from "@/integrations/supabase/client";
+import { BaseService } from "./base";
+import { ShippingRuleType } from "@/types/shipping";
+
+class ShippingRulesService extends BaseService<ShippingRuleType> {
+  constructor() {
+    super("shipping_rules");
+  }
+
+  async getAllWithDetails(): Promise<ShippingRuleType[]> {
+    const { data, error } = await supabase
+      .from("shipping_rules")
+      .select(`
+        *,
+        products:product_id (
+          id,
+          name
+        ),
+        marketplaces:marketplace_id (
+          id,
+          name
+        )
+      `)
+      .order("created_at", { ascending: false });
+
+    if (error) this.handleError(error, "Buscar regras de frete");
+    return data || [];
+  }
+}
+
+export const shippingRulesService = new ShippingRulesService();

--- a/src/types/shipping.ts
+++ b/src/types/shipping.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { shippingRuleSchema } from "@/lib/validations";
+
+export interface ShippingRuleType {
+  id: string;
+  product_id: string | null;
+  marketplace_id: string;
+  shipping_cost: number;
+  free_shipping_threshold: number | null;
+  created_at: string;
+  updated_at: string;
+  products?: {
+    id: string;
+    name: string;
+  } | null;
+  marketplaces?: {
+    id: string;
+    name: string;
+  } | null;
+}
+
+export type ShippingRuleFormData = z.infer<typeof shippingRuleSchema>;


### PR DESCRIPTION
## Summary
- adicionar hook `useShippingRules` para buscar regras no Supabase
- criar `ShippingRulesTable` reutilizando `DataVisualization`
- exibir tabela de regras de frete na página `Shipping`

## Testing
- `pnpm lint` *(falhou: Invalid Tailwind CSS classnames order)*
- `pnpm type-check`
- `pnpm test --run` *(falhou: Test timed out in 5000ms)*
- `npx playwright test tests/a11y.spec.ts` *(falhou: npx playwright install)*
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`


------
https://chatgpt.com/codex/tasks/task_e_6897811a3efc83298cf0659bc6f8fee5