### PR TITLE
refactor: centralizar importação de ícones

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -150,3 +150,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Definir estratégia para execução isolada de testes de unidade e Playwright.
 ---
+Date: 2025-08-09
+TaskRef: "Use shared icon exports in DataVisualization"
+
+Learnings:
+- Importar ícones via '@/components/ui/icons' evita uso direto de lucide-react e centraliza updates.
+- Busca com `rg` facilita garantir ausência de importações diretas em componentes compartilhados.
+
+Difficulties:
+- Lint e testes apresentaram erros preexistentes, dificultando validação completa.
+- Playwright falhou por configuração e dependências ausentes.
+
+Successes:
+- Linha de importação atualizada para usar ícones compartilhados.
+- Confirmei que nenhum componente fora de 'ui' importa lucide-react diretamente.
+
+Improvements_Identified_For_Consolidation:
+- Documentar abordagem para lidar com erros de lint e Playwright em ambiente legado.
+---

--- a/src/components/ui/data-visualization.tsx
+++ b/src/components/ui/data-visualization.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Search, SortAsc, SortDesc, Grid, List, MoreHorizontal } from "lucide-react";
+import { Search, SortAsc, SortDesc, Grid, List, MoreHorizontal } from "@/components/ui/icons";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 
 export interface DataColumn<T> {


### PR DESCRIPTION
## Summary
- usar ícones reexportados em DataVisualization para evitar `lucide-react`
- registrar aprendizados sobre uso de ícones compartilhados

## Testing
- `pnpm lint` *(falhou: 96 errors, 832 warnings)*
- `pnpm type-check`
- `pnpm test --run` *(falhou: 3 failed, 17 passed)*
- `npx playwright test tests/a11y.spec.ts` *(falhou: 13 failed)*
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68978310ef088329924a9c82dc406d49