### PR TITLE
fix: limita largura do layout de configuração

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -168,3 +168,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Documentar abordagem para lidar com erros de lint e Playwright em ambiente legado.
 ---
+---
+Date: 2025-08-09
+TaskRef: "Ajustar largura do container em ConfigurationPageLayout"
+
+Learnings:
+- Adicionar `max-w-7xl` padroniza a largura dos layouts de configuração com `SharedLayout`.
+- Playwright depende de navegadores e bibliotecas de sistema instaladas para rodar testes.
+
+Difficulties:
+- `pnpm lint` falhou devido a erros pré-existentes em arquivos não relacionados.
+- `npx playwright test` não executou por falta de dependências do sistema mesmo após tentativa de instalação.
+
+Successes:
+- `ConfigurationPageLayout` agora usa `container max-w-7xl`, alinhando largura com o restante da aplicação.
+
+Improvements_Identified_For_Consolidation:
+- Documentar configuração mínima para rodar Playwright em ambientes limpos.
+---

--- a/src/components/layout/ConfigurationPageLayout.tsx
+++ b/src/components/layout/ConfigurationPageLayout.tsx
@@ -29,7 +29,7 @@ export function ConfigurationPageLayout({
         breadcrumbs={breadcrumbs}
       />
       
-      <main className="container mx-auto px-4 sm:px-6 py-6">
+      <main className="container max-w-7xl mx-auto px-4 sm:px-6 py-6">
         <PageTransition>
           <div className="grid grid-cols-1 xl:grid-cols-12 gap-6">
             {children}


### PR DESCRIPTION
## Summary
- adiciona `max-w-7xl` ao `ConfigurationPageLayout` para padronizar largura

## Testing
- `pnpm lint` *(falhou: erros Tailwind preexistentes)*
- `pnpm type-check`
- `pnpm test --run` *(falhou: testes Playwright executados pelo Vitest)*
- `npx playwright test tests/a11y.spec.ts` *(falhou: dependências de sistema ausentes)*
- `npx playwright test tests/responsiveness.spec.ts` *(falhou: dependências de sistema ausentes)*
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_6897869215b88329bdfc1aa9ea00eb12