### PR TITLE
docs: adicionar baseline de lint

### DIFF
--- a/docs/lint-baseline.md
+++ b/docs/lint-baseline.md
@@ -1,0 +1,22 @@
+# Baseline de Lint
+
+Resultados de `npm run lint` em 2025-08-09:
+
+- **Erros:** 6827
+- **Avisos:** 923
+
+## Top 10 regras com mais ocorrências
+
+| # | Regra | Ocorrências |
+|---|-------|-------------|
+| 1 | prettier/prettier | 6827 |
+| 2 | tailwindcss/classnames-order | 518 |
+| 3 | tailwindcss/enforces-shorthand | 286 |
+| 4 | import/order | 51 |
+| 5 | no-unused-vars | 40 |
+| 6 | tailwindcss/migration-from-tailwind-2 | 10 |
+| 7 | react-refresh/only-export-components | 10 |
+| 8 | react-hooks/exhaustive-deps | 6 |
+| 9 | (sem regra) | 1 |
+|10 | tailwindcss/no-unnecessary-arbitrary-value | 1 |
+

--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -222,3 +222,20 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Documentar como habilitar Prettier gradualmente para evitar avalanche de erros em bases legadas.
 ---
+---
+Date: 2025-08-09
+TaskRef: "Gerar baseline de lint"
+
+Learnings:
+- `npm run --silent lint -- --format json` gera relatório JSON sem cabeçalho do npm.
+- Script em Node facilitou contar erros e agrupar regras.
+
+Difficulties:
+- Execução inicial do lint registrou cabeçalho do npm, invalidando o JSON.
+
+Successes:
+- Baseline capturado com 6827 erros e 923 avisos.
+
+Improvements_Identified_For_Consolidation:
+- Automatizar processo de geração do baseline para comparações futuras.
+---


### PR DESCRIPTION
## Summary
- adicionar relatório inicial de erros do ESLint
- documentar principais regras problemáticas

## Testing
- `npm run type-check`
- `npm test -- --run` *(fails: Playwright Test did not expect test.describe)*
- `npx playwright test tests/a11y.spec.ts` *(fails: missing browsers, multiple failures)*
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`

------
https://chatgpt.com/codex/tasks/task_e_6897965021d88329bcf09544c034263f