### PR TITLE
fix: completar dependências de hooks

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -257,3 +257,19 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Investigar estratégias para reduzir ruído do ESLint em bases legadas.
 ---
+Date: 2025-08-09
+TaskRef: "Ajustar dependências de hooks"
+
+Learnings:
+- `useCallback` estabiliza funções usadas em `useEffect`, evitando advertências de `exhaustive-deps`.
+- Incluir callbacks e objetos externos nos arrays de dependência previne closures obsoletas.
+
+Difficulties:
+- `pnpm lint` ainda falha devido a milhares de erros de formatação herdados.
+
+Successes:
+- Diversos `useEffect` e `useCallback` foram atualizados com dependências completas em formulários e contextos.
+
+Improvements_Identified_For_Consolidation:
+- Criar plano gradual para resolver erros de lint legados e ativar checagem automática de hooks.
+---

--- a/src/components/forms/AdChatInterface.tsx
+++ b/src/components/forms/AdChatInterface.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent } from '@/components/ui/card';
@@ -21,13 +21,13 @@ export function AdChatInterface({
   const { messages, sendMessage, resetChat, isLoading } = useAdChat();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const scrollToBottom = () => {
+  const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  };
+  }, []);
 
   useEffect(() => {
     scrollToBottom();
-  }, [messages]);
+  }, [messages, scrollToBottom]);
 
   const handleSendMessage = () => {
     if (!message.trim() || isLoading) return;

--- a/src/components/forms/CategoryForm.tsx
+++ b/src/components/forms/CategoryForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -97,12 +97,12 @@ export const CategoryForm = ({ onCancel, editingCategory }: CategoryFormProps = 
     }
   };
 
-  const resetForm = () => {
+  const resetForm = useCallback(() => {
     setFormData({ name: "", description: "" });
     setEditingId(null);
     setErrors({});
     setTouched({});
-  };
+  }, []);
 
   // Efeito para preencher formulário quando editingCategory for passado
   useEffect(() => {
@@ -117,7 +117,7 @@ export const CategoryForm = ({ onCancel, editingCategory }: CategoryFormProps = 
     } else {
       resetForm();
     }
-  }, [editingCategory]);
+  }, [editingCategory, resetForm]);
 
   const optionalFields = useCollapsibleSection({ 
     storageKey: 'categories-optional-fields', 

--- a/src/components/forms/DashboardForm.tsx
+++ b/src/components/forms/DashboardForm.tsx
@@ -349,7 +349,7 @@ export const DashboardForm = () => {
     } finally {
       setIsRecalculating(false);
     }
-  }, [calculatePrice, savePricing, toast]);
+  }, [calculatePrice, savePricing, toast, logger]);
 
   const handleMarketplaceToggle = (marketplaceId: string) => {
     setSelectedMarketplaces(prev => {
@@ -417,7 +417,7 @@ export const DashboardForm = () => {
     };
 
     calculateRealMargins();
-  }, [savedPricings]);
+  }, [savedPricings, logger]);
 
   // Transform and organize saved pricing data for display
   const transformedResults = savedPricings
@@ -458,7 +458,7 @@ export const DashboardForm = () => {
     if (transformedResults.length > 0 && cardOrder.length === 0) {
       setCardOrder(transformedResults.map(r => r.marketplace_id));
     }
-  }, [transformedResults, cardOrder.length]);
+  }, [transformedResults, cardOrder]);
 
   // Drag and drop sensors
   const sensors = useSensors(

--- a/src/components/forms/FixedFeeRuleForm.tsx
+++ b/src/components/forms/FixedFeeRuleForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useCallback, useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
@@ -156,7 +156,7 @@ export const FixedFeeRuleForm = ({ onCancel, editingRule }: FixedFeeRuleFormProp
     }
   };
 
-const handleCancelEdit = () => {
+  const handleCancelEdit = useCallback(() => {
     setFormData({
       marketplace_id: "",
       rule_type: "",
@@ -165,7 +165,7 @@ const handleCancelEdit = () => {
       value: ""
     });
     setEditingId(null);
-};
+  }, []);
 
   useEffect(() => {
     if (editingRule) {
@@ -180,7 +180,7 @@ const handleCancelEdit = () => {
     } else {
       handleCancelEdit();
     }
-  }, [editingRule]);
+  }, [editingRule, handleCancelEdit]);
 
   const showRangeFields = formData.rule_type === "faixa" || formData.rule_type === "percentual";
 

--- a/src/components/forms/ProductForm.tsx
+++ b/src/components/forms/ProductForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -141,7 +141,7 @@ export const ProductForm = ({ editingProduct, onCancel }: ProductFormProps = {})
     }
   };
 
-  const resetForm = () => {
+  const resetForm = useCallback(() => {
     setFormData({
       name: "",
       description: "",
@@ -154,7 +154,7 @@ export const ProductForm = ({ editingProduct, onCancel }: ProductFormProps = {})
     setEditingId(null);
     setErrors({});
     setTouched({});
-  };
+  }, []);
 
   useEffect(() => {
     if (editingProduct) {
@@ -173,8 +173,7 @@ export const ProductForm = ({ editingProduct, onCancel }: ProductFormProps = {})
     } else {
       resetForm();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editingProduct]);
+  }, [editingProduct, resetForm]);
 
   // Calcular custo total para exibição
   const custoTotal = formData.cost_unit + formData.packaging_cost;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -91,7 +91,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isMounted = false;
       subscription.unsubscribe();
     };
-  }, []);
+  }, [logger]);
 
   const signIn = async (email: string, password: string) => {
     try {

--- a/src/hooks/useAutomaticPricingUpdate.ts
+++ b/src/hooks/useAutomaticPricingUpdate.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { pricingService } from "@/services/pricing";
 import { toast } from "@/components/ui/use-toast";
@@ -10,7 +10,7 @@ export function useAutomaticPricingUpdate() {
   const queryClient = useQueryClient();
   const isUpdatingRef = useRef(false);
 
-  const handleRulesUpdate = async (tableName: string, eventType: string) => {
+  const handleRulesUpdate = useCallback(async (tableName: string, eventType: string) => {
     // Evitar múltiplas execuções simultâneas
     if (isUpdatingRef.current) {
       logger.debug('Recálculo já em andamento, ignorando evento...', 'useAutomaticPricingUpdate');
@@ -47,7 +47,7 @@ export function useAutomaticPricingUpdate() {
     } finally {
       isUpdatingRef.current = false;
     }
-  };
+  }, [queryClient]);
 
   useEffect(() => {
     logger.info('Configurando listeners de atualização automática...', 'useAutomaticPricingUpdate');
@@ -110,7 +110,7 @@ export function useAutomaticPricingUpdate() {
       supabase.removeChannel(fixedFeesChannel);
       supabase.removeChannel(shippingChannel);
     };
-  }, []); // Removida a dependência do queryClient para evitar loops
+  }, [handleRulesUpdate]);
 
   return {
     triggerManualUpdate: () => handleRulesUpdate('manual', 'manual_trigger')


### PR DESCRIPTION
## Sumário
- garantir dependências completas em `useEffect` e `useCallback`
- estabilizar callbacks usados por efeitos

## Testes
- `pnpm lint` *(falhou: 6521 problems (5607 errors, 914 warnings))*
- `pnpm type-check`
- `pnpm test --run` *(falhou: 3 failed, 17 passed)*
- `npx playwright test tests/a11y.spec.ts` *(falhou: 13 failed)*
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`


------
https://chatgpt.com/codex/tasks/task_e_68979d61d1b483299e8121aed959a241