### PR TITLE
fix: remover regra duplicada no-unused-vars

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,7 +65,6 @@ export default tseslint.config(
       "tailwindcss/no-custom-classname": "off",
       "local/no-outside-ui-imports": "error",
       "import/order": "warn",
-      "no-unused-vars": "warn",
       "import/no-unresolved": "off",
       "react/display-name": "off",
       "react/prop-types": "off",

--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -314,3 +314,19 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Definir estratégia incremental de `eslint --fix` por módulos para atingir zero erros/avisos.
 ---
+Date: 2025-08-11
+TaskRef: "Remover regra duplicada no-unused-vars do ESLint"
+
+Learnings:
+- Em projetos TypeScript, preferir `@typescript-eslint/no-unused-vars` evita conflito com a regra base `no-unused-vars`.
+
+Difficulties:
+- `pnpm lint` gera saída volumosa de erros de Prettier; limitar com `head` ocasionou `EPIPE`.
+
+Successes:
+- Configuração do ESLint agora usa apenas `@typescript-eslint/no-unused-vars`.
+- Lint, type-check e testes executados após a alteração (lint ainda reporta pendências herdadas).
+
+Improvements_Identified_For_Consolidation:
+- Registrar estratégia para capturar logs de lint extensos sem interromper a execução.
+---


### PR DESCRIPTION
## Summary
- remover regra `no-unused-vars` e manter apenas `@typescript-eslint/no-unused-vars`
- registrar aprendizado sobre lint no log de reflexão

## Testing
- `pnpm lint` (falhou com erros de formatação existentes)
- `pnpm type-check`
- `pnpm test --run`
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_689a2ec9808883299ba5e9ee655cde88