### PR TITLE
refactor: usar supabase.functions.invoke no AssistantsService

### DIFF
--- a/docs/assistants-service.md
+++ b/docs/assistants-service.md
@@ -1,0 +1,21 @@
+# Assistants Service
+
+Camada responsável por integrar a aplicação com a edge function `assistants` no Supabase.
+
+## Operações
+- **Criar**: `supabase.functions.invoke('assistants', { body })`
+- **Atualizar**: `supabase.functions.invoke('assistants/${id}', { method: 'PUT', body })`
+- **Remover**: `supabase.functions.invoke('assistants/${id}', { method: 'DELETE' })`
+
+Todas as operações utilizam o cliente autenticado do Supabase, garantindo que o token do usuário seja enviado automaticamente.
+
+## Hooks
+Os métodos são expostos via React Query para reaproveitar cache e estados:
+
+- `useAssistants` – lista assistentes.
+- `useCreateAssistant` – cria novo assistente.
+- `useUpdateAssistant` – atualiza assistente existente.
+- `useDeleteAssistant` – remove assistente.
+- `useAssistantByMarketplace` – obtém assistente por marketplace.
+
+Esses hooks invalidam a chave `['assistants']` após mutações, mantendo os dados sincronizados.

--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -400,3 +400,20 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Planejar correção incremental do backlog de lint para habilitar validações automáticas.
 ---
+---
+Date: 2025-08-12
+TaskRef: "Substituir makeRequest por supabase.functions.invoke no AssistantsService"
+
+Learnings:
+- supabase.functions.invoke aceita métodos PUT e DELETE quando a URL inclui o id do recurso.
+- Hooks React Query facilitam reaproveitar cache ao invalidar a chave compartilhada após mutações.
+
+Difficulties:
+- Remover o wrapper makeRequest exigiu repetir tratamento de erro nas chamadas diretas.
+
+Successes:
+- Atualização e deleção de assistentes agora utilizam autenticação do Supabase de forma transparente.
+
+Improvements_Identified_For_Consolidation:
+- Avaliar criação de util genérico para invocar edge functions com métodos variados.
+---

--- a/src/services/assistants.ts
+++ b/src/services/assistants.ts
@@ -11,69 +11,6 @@ export class AssistantsService extends BaseService<Assistant> {
     super('assistants');
   }
 
-  // Método para fazer requisições HTTP com retry e timeout
-  private async makeRequest(method: string, endpoint: string, body?: unknown): Promise<unknown> {
-    const maxRetries = 3;
-    const timeout = 30000; // 30 segundos
-    
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        this.logger.debug(`Tentativa ${attempt}/${maxRetries} - ${method} ${endpoint}`);
-        
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), timeout);
-        
-        const { data: { session } } = await supabase.auth.getSession();
-        if (!session) {
-          throw new Error('Usuário não autenticado');
-        }
-
-        const response = await fetch(`https://ngkhzbzynkhgezkqykeb.supabase.co/functions/v1/${endpoint}`, {
-          method,
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${session.access_token}`,
-            'apikey': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5na2h6Ynp5bmtoZ2V6a3F5a2ViIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwMDM3ODgsImV4cCI6MjA2OTU3OTc4OH0.EMk6edTPpwvcy_6VVDxARgoRsJrY9EiijbfR4dFDQAQ',
-          },
-          body: body ? JSON.stringify(body) : undefined,
-          signal: controller.signal,
-        });
-
-        clearTimeout(timeoutId);
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(`HTTP ${response.status}: ${errorText}`);
-        }
-
-        const result = await response.json();
-        this.logger.debug(`Sucesso na tentativa ${attempt}`, result);
-        return result;
-
-      } catch (error: unknown) {
-        this.logger.error(`Erro na tentativa ${attempt}/${maxRetries}`, error);
-        
-        if (attempt === maxRetries) {
-          // Se é a última tentativa, relançar o erro
-            if (error instanceof Error) {
-              if (error.name === 'AbortError') {
-                throw new Error('Timeout na requisição - tente novamente');
-              }
-              if (error.message.includes('SSL') || error.message.includes('handshake')) {
-                throw new Error('Erro de conectividade SSL - tente novamente em alguns minutos');
-              }
-            }
-            throw error;
-        }
-        
-        // Aguardar antes de tentar novamente (backoff exponencial)
-        const delay = Math.pow(2, attempt) * 1000; // 2s, 4s, 8s
-        this.logger.debug(`Aguardando ${delay}ms antes da próxima tentativa`);
-        await new Promise(resolve => setTimeout(resolve, delay));
-      }
-    }
-  }
-
   async createAssistant(data: AssistantFormData): Promise<Assistant> {
     try {
       this.logger.debug('Criando assistente', data);
@@ -111,9 +48,16 @@ export class AssistantsService extends BaseService<Assistant> {
     try {
       this.logger.debug('Atualizando assistente', { id, data });
 
-      // Usar fetch direto para PUT com retry e timeout
-        const result = await this.makeRequest('PUT', `assistants/${id}`, data);
-      
+      const { data: result, error } = await supabase.functions.invoke(`assistants/${id}`, {
+        method: 'PUT',
+        body: data,
+      });
+
+      if (error) {
+        this.logger.error('Erro ao atualizar assistente', error);
+        throw new Error(`Falha ao atualizar assistente: ${error.message}`);
+      }
+
       this.logger.info('Assistente atualizado com sucesso', result);
       return result as Assistant;
     } catch (error) {
@@ -126,9 +70,15 @@ export class AssistantsService extends BaseService<Assistant> {
     try {
       this.logger.debug('Deletando assistente', { id });
 
-      // Usar fetch direto para DELETE com retry e timeout
-      await this.makeRequest('DELETE', `assistants/${id}`);
-      
+      const { error } = await supabase.functions.invoke(`assistants/${id}`, {
+        method: 'DELETE',
+      });
+
+      if (error) {
+        this.logger.error('Erro ao deletar assistente', error);
+        throw new Error(`Falha ao deletar assistente: ${error.message}`);
+      }
+
       this.logger.info('Assistente deletado com sucesso');
     } catch (error) {
       this.logger.error('Erro na deleção do assistente', error);


### PR DESCRIPTION
## Summary
- substituir makeRequest por supabase.functions.invoke para atualizar e deletar assistentes
- documentar uso da edge function e hooks de cache

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test --run`
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`


------
https://chatgpt.com/codex/tasks/task_e_689a6077485c8329ab669838251dbb30