### PR TITLE
refactor: tipar cliente Supabase e remover any

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -417,3 +417,22 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Avaliar criação de util genérico para invocar edge functions com métodos variados.
 ---
+---
+Date: 2025-08-12
+TaskRef: "Tipar Supabase com generics e remover any em serviços"
+
+Learnings:
+- `PostgrestResponse<T>` permite tipar respostas evitando casts para `any`.
+- `supabase.functions.invoke` aceita generics para o retorno, removendo necessidade de `as` duplo.
+- Parâmetros de marketplace podem reutilizar `Assistant['marketplace']` para união forte.
+
+Difficulties:
+- Tipar `.insert` exigiu cast para `T` devido aos campos opcionais.
+
+Successes:
+- Serviços `base` e `assistants` agora usam generics e removem `eslint-disable`.
+- `pnpm type-check` e testes passaram após ajustes.
+
+Improvements_Identified_For_Consolidation:
+- Criar util genérico para supabase CRUD evitando repetição de tipos.
+---

--- a/src/services/assistants.ts
+++ b/src/services/assistants.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { supabase } from "@/integrations/supabase/client";
 import { BaseService } from "./base";
 import type { Assistant, AssistantFormData } from "@/types/assistants";
@@ -24,19 +23,22 @@ export class AssistantsService extends BaseService<Assistant> {
       }
 
       // Chamar edge function para criar assistente
-      const { data: result, error } = await supabase.functions.invoke('assistants', {
-        body: {
-          ...data,
-          tenant_id: tenantId,
+      const { data: result, error } = await supabase.functions.invoke<Assistant>(
+        "assistants",
+        {
+          body: {
+            ...data,
+            tenant_id: tenantId,
+          },
         },
-      });
+      );
 
       if (error) {
-        this.logger.error('Erro ao criar assistente', error);
+        this.logger.error("Erro ao criar assistente", error);
         throw new Error(`Falha ao criar assistente: ${error.message}`);
       }
 
-      this.logger.info('Assistente criado com sucesso', result);
+      this.logger.info("Assistente criado com sucesso", result);
       return result as Assistant;
     } catch (error) {
       this.logger.error('Erro na criação do assistente', error);
@@ -48,17 +50,20 @@ export class AssistantsService extends BaseService<Assistant> {
     try {
       this.logger.debug('Atualizando assistente', { id, data });
 
-      const { data: result, error } = await supabase.functions.invoke(`assistants/${id}`, {
-        method: 'PUT',
-        body: data,
-      });
+      const { data: result, error } = await supabase.functions.invoke<Assistant>(
+        `assistants/${id}`,
+        {
+          method: "PUT",
+          body: data,
+        },
+      );
 
       if (error) {
-        this.logger.error('Erro ao atualizar assistente', error);
+        this.logger.error("Erro ao atualizar assistente", error);
         throw new Error(`Falha ao atualizar assistente: ${error.message}`);
       }
 
-      this.logger.info('Assistente atualizado com sucesso', result);
+      this.logger.info("Assistente atualizado com sucesso", result);
       return result as Assistant;
     } catch (error) {
       this.logger.error('Erro na atualização do assistente', error);
@@ -70,8 +75,8 @@ export class AssistantsService extends BaseService<Assistant> {
     try {
       this.logger.debug('Deletando assistente', { id });
 
-      const { error } = await supabase.functions.invoke(`assistants/${id}`, {
-        method: 'DELETE',
+      const { error } = await supabase.functions.invoke<null>(`assistants/${id}`, {
+        method: "DELETE",
       });
 
       if (error) {
@@ -86,14 +91,16 @@ export class AssistantsService extends BaseService<Assistant> {
     }
   }
 
-  async getAssistantByMarketplace(marketplace: string): Promise<Assistant | null> {
+  async getAssistantByMarketplace(
+    marketplace: Assistant["marketplace"],
+  ): Promise<Assistant | null> {
     try {
       this.logger.debug('Buscando assistente por marketplace', { marketplace });
 
       const { data, error } = await supabase
-        .from('assistants' as any)
-        .select('*')
-        .eq('marketplace', marketplace)
+        .from<Assistant>("assistants")
+        .select("*")
+        .eq("marketplace", marketplace)
         .maybeSingle();
 
       if (error) {
@@ -101,12 +108,12 @@ export class AssistantsService extends BaseService<Assistant> {
       }
 
       if (!data) {
-        this.logger.debug('Nenhum assistente encontrado para o marketplace', { marketplace });
+        this.logger.debug("Nenhum assistente encontrado para o marketplace", { marketplace });
         return null;
       }
 
-      this.logger.debug('Assistente encontrado', data);
-      return data as unknown as Assistant;
+      this.logger.debug("Assistente encontrado", data);
+      return data;
     } catch (error) {
       this.logger.error('Erro ao buscar assistente por marketplace', error);
       if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- tipar BaseService usando PostgrestResponse e PostgrestSingleResponse
- tipar AssistantsService com generics e marketplace forte
- registrar aprendizados sobre Supabase generics

## Testing
- `pnpm lint src/services/base.ts src/services/assistants.ts` (falhou: 6952 problemas de lint existentes)
- `pnpm type-check`
- `pnpm test --run`
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_689a6252e22c83298a270b0cd6051e99