### PR TITLE
docs: documenta script de type-check e links de referência

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Catalog Maker Hub é uma plataforma SaaS para gestão de marketplaces e definiç
 - `pnpm build:dev` – gera o build em modo de desenvolvimento
 - `pnpm lint` – executa o ESLint nos arquivos `ts/tsx` de `src`, `app`, `components` e `pages`
 - `pnpm lint:fix` – corrige automaticamente os problemas reportados pelo ESLint
+- `pnpm type-check` – verifica os tipos TypeScript
 - `pnpm format` – formata o código com Prettier
 - `pnpm test` – executa a suite de testes
 - `pnpm test:coverage` – executa os testes com relatório de cobertura
@@ -32,6 +33,11 @@ Catalog Maker Hub é uma plataforma SaaS para gestão de marketplaces e definiç
 - Estilos devem ser escritos exclusivamente com **Tailwind CSS**.
 - Componentes base devem seguir o catálogo **shadcn/ui**.
 - Cores e tipografia usam apenas tokens `brand-*`; CSS legado ou bibliotecas de estilo extras não são permitidos.
+
+## Documentação
+- [Base de conhecimento](docs/CUSTOM_KNOWLEDGE.md)
+- [Design System](docs/DESIGN_SYSTEM.md)
+- [Melhoria contínua](docs/continuous-improvement.md)
 
 ## Diretrizes de Contribuição
 1. Faça um fork do repositório e crie um branch para a sua feature ou correção.

--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -453,3 +453,20 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Considerar integração do logger das edge functions com sistema principal para unificação de formatos.
 ---
+Date: 2025-08-11
+TaskRef: "Adicionar script type-check e links de docs ao README"
+
+Learnings:
+- README exige seção dedicada para documentações chave.
+- Script `pnpm type-check` já existia no `package.json`, bastando documentá-lo.
+
+Difficulties:
+- `pnpm lint` falha com milhares de erros herdados, impedindo verificação limpa.
+
+Successes:
+- README agora lista `pnpm type-check` e links para `CUSTOM_KNOWLEDGE`, `DESIGN_SYSTEM` e `continuous-improvement`.
+- `pnpm type-check` e `pnpm test --run` executaram sem falhas.
+
+Improvements_Identified_For_Consolidation:
+- Priorizar correção do backlog de lint para possibilitar validação completa no CI.
+---


### PR DESCRIPTION
## Summary
- adiciona `pnpm type-check` à lista de scripts disponíveis
- inclui seção de documentação com links para conhecimento base, design system e melhoria contínua
- registra aprendizado no `raw_reflection_log`

## Testing
- `pnpm lint` *(falhou: 6952 problems)*
- `pnpm type-check`
- `pnpm test --run`
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`


------
https://chatgpt.com/codex/tasks/task_e_689a80d6d4008329838718925353003c