### PR TITLE
fix: permitir preco praticado nulo

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -504,3 +504,20 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Considerar modelo único para documentar erros e retries em futuros serviços.
 ---
+---
+Date: 2025-08-12
+TaskRef: "Allow null preco_praticado and adjust DashboardForm"
+
+Learnings:
+- Alias para linhas do Supabase facilita reaproveitar tipagens.
+- Campos numéricos opcionais exigem uso de fallback `??` e condicionais para RPCs.
+
+Difficulties:
+- `pnpm lint` ainda retorna milhares de erros herdados, dificultando validação limpa.
+
+Successes:
+- Type-check, testes e servidor de desenvolvimento executaram sem problemas.
+
+Improvements_Identified_For_Consolidation:
+- Agendar mutirão para resolver backlog de lint e reduzir ruído.
+---

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -838,6 +838,8 @@ export type CompositeTypes<
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
 
+export type SavedPricingRow = Tables<"saved_pricing">;
+
 export const Constants = {
   public: {
     Enums: {

--- a/src/types/pricing.ts
+++ b/src/types/pricing.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+export type { SavedPricingRow } from "@/integrations/supabase/types";
 
 export interface SavedPricingType {
   id: string;
@@ -12,7 +13,7 @@ export interface SavedPricingType {
   provisao_desconto: number;
   margem_desejada: number;
   preco_sugerido: number;
-  preco_praticado: number;
+  preco_praticado: number | null;
   margem_unitaria: number;
   margem_percentual: number;
   created_at: string;
@@ -45,7 +46,11 @@ export const pricingSchema = z.object({
   taxa_cartao: z.number().min(0, "Taxa do cartão deve ser positiva").max(100, "Taxa não pode exceder 100%").default(0),
   provisao_desconto: z.number().min(0, "Provisão de desconto deve ser positiva").max(100, "Provisão não pode exceder 100%").default(0),
   margem_desejada: z.number().min(0, "Margem desejada deve ser positiva").max(100, "Margem não pode exceder 100%").default(0),
-  preco_praticado: z.number().min(0, "Preço praticado deve ser positivo").default(0),
+  preco_praticado: z
+    .number()
+    .min(0, "Preço praticado deve ser positivo")
+    .nullable()
+    .default(null),
 });
 
 export type PricingFormData = z.infer<typeof pricingSchema>;


### PR DESCRIPTION
## Summary
- permitir preco_praticado nulo nos tipos de precificação e schema
- alinhar DashboardForm ao novo tipo com salvamento e ordenação seguros

## Testing
- `pnpm lint` *(falhou: 6948 problemas)*
- `pnpm type-check`
- `pnpm test --run`
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_689b2f4a80188329bd3639f9eaf44015