### PR TITLE
feat: normalizar SavedPricingRow no Dashboard

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -521,3 +521,20 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Agendar mutirão para resolver backlog de lint e reduzir ruído.
 ---
+Date: 2025-08-12
+TaskRef: "Map SavedPricingRow type for DashboardForm"
+
+Learnings:
+- Tipos estreitos evitam `never[]` ao combinar `useQuery` com dados padrão.
+- Mapear joins do Supabase dentro do `queryFn` simplifica o uso no componente.
+
+Difficulties:
+- `pnpm lint` ainda apresenta milhares de erros herdados, impedindo verificação limpa.
+
+Successes:
+- Tipagem `SavedPricingRow` criada e resultados do Supabase normalizados.
+- `pnpm type-check`, testes e servidor `pnpm dev` executados sem falhas.
+
+Improvements_Identified_For_Consolidation:
+- Planejar migração gradual para remover dependência de joins desnecessários no Supabase.
+---

--- a/src/types/pricing.ts
+++ b/src/types/pricing.ts
@@ -1,5 +1,21 @@
 import { z } from "zod";
-export type { SavedPricingRow } from "@/integrations/supabase/types";
+
+export interface SavedPricingRow {
+  product_id: string;
+  marketplace_id: string;
+  custo_total: number;
+  valor_fixo: number;
+  frete: number;
+  comissao: number;
+  preco_sugerido: number;
+  margem_unitaria: number;
+  margem_percentual: number;
+  preco_praticado: number | null;
+  taxa_cartao: number;
+  provisao_desconto: number;
+  margem_desejada: number;
+  marketplace_name: string;
+}
 
 export interface SavedPricingType {
   id: string;


### PR DESCRIPTION
## Summary
- tipa SavedPricingRow com campos usados no Dashboard
- mapeia joins do Supabase no queryFn do DashboardForm
- remove colunas não utilizadas do retorno de precificação

## Testing
- `pnpm lint` *(fails: 6102 errors)*
- `pnpm type-check`
- `pnpm test --run`
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_689b392fd8308329814f474fec89217f