### PR TITLE
fix: normaliza campos opcionais do ProductForm

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -538,3 +538,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Planejar migração gradual para remover dependência de joins desnecessários no Supabase.
 ---
+---
+Date: 2025-08-12
+TaskRef: "Normalizar campos opcionais do ProductForm para undefined"
+
+Learnings:
+- Substituir `null` por `undefined` evita divergência com `ProductFormData` derivado do Zod.
+- Componentes `Select` requerem valor sentinela cuidado; usar string vazia simplifica submissão.
+
+Difficulties:
+- `pnpm lint` retorna milhares de erros preexistentes, inviabilizando verificação limpa do repositório.
+
+Successes:
+- `pnpm type-check` e `pnpm test --run` executados sem falhas.
+- Objetos enviados pelas mutações agora omitem campos não preenchidos.
+
+Improvements_Identified_For_Consolidation:
+- Avaliar adoção de script de lint segmentado por arquivo para evitar ruído até que backlog seja resolvido.
+---

--- a/src/components/forms/ProductForm.tsx
+++ b/src/components/forms/ProductForm.tsx
@@ -110,12 +110,12 @@ export const ProductForm = ({ editingProduct, onCancel }: ProductFormProps = {})
       return;
     }
     
-    // Converter "none" para null antes de enviar
+    // Normaliza campos opcionais para undefined quando não preenchidos
     const dataToSubmit = {
       ...formData,
-      category_id: formData.category_id === "none" || formData.category_id === "" ? null : formData.category_id,
-      sku: formData.sku || null,
-      description: formData.description || null
+      category_id: formData.category_id || undefined,
+      sku: formData.sku || undefined,
+      description: formData.description || undefined,
     };
     
     if (editingId) {
@@ -162,7 +162,7 @@ export const ProductForm = ({ editingProduct, onCancel }: ProductFormProps = {})
         name: editingProduct.name,
         description: editingProduct.description || "",
         sku: editingProduct.sku || "",
-        category_id: editingProduct.category_id || "none",
+        category_id: editingProduct.category_id ?? "",
         cost_unit: editingProduct.cost_unit || 0,
         packaging_cost: editingProduct.packaging_cost || 0,
         tax_rate: editingProduct.tax_rate || 0
@@ -236,7 +236,7 @@ export const ProductForm = ({ editingProduct, onCancel }: ProductFormProps = {})
                       <SelectValue placeholder="Selecione uma categoria" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="none">Nenhuma categoria</SelectItem>
+                      <SelectItem value="">Nenhuma categoria</SelectItem>
                       {categories.map((category) => (
                         <SelectItem key={category.id} value={category.id}>
                           {category.name}


### PR DESCRIPTION
## Summary
- normaliza envio de `category_id`, `sku` e `description` para `undefined`
- remove sentinel `none` da seleção de categorias no formulário de produtos

## Testing
- `pnpm lint` *(fails: numerous pre-existing prettier/tailwind warnings)*
- `pnpm type-check`
- `pnpm test --run`
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`


------
https://chatgpt.com/codex/tasks/task_e_689b64f0e6148329904d5a12dbcec00b