### PR TITLE
fix: tratar limites numericos como strings na StrategyForm

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -556,3 +556,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Avaliar adoção de script de lint segmentado por arquivo para evitar ruído até que backlog seja resolvido.
 ---
+
+---
+Date: 2025-08-12
+TaskRef: "Tratar limites numéricos como strings na StrategyForm"
+
+Learnings:
+- Manter valores do formulário como string simplifica validação e evita tipos `number | string`.
+- Aplicar `Number.isNaN` após `parseFloat` garante fallback seguro para operações aritméticas.
+
+Difficulties:
+- `pnpm lint` continua falhando com milhares de erros herdados, dificultando verificação completa.
+
+Successes:
+- Estado e parsing ajustados conforme requisito e testes unitários passaram.
+
+Improvements_Identified_For_Consolidation:
+- Criar helper reutilizável para parsing seguro de campos numéricos.
+---


### PR DESCRIPTION
## Resumo
- manter limites de margem e giro como strings
- aplicar parse seguro com `Number.isNaN` antes de operações numéricas
- controlar inputs de margem e giro com strings
- atualizar registro de reflexões

## Testes
- `pnpm lint` *(falhou: prettier/prettier)*
- `pnpm type-check`
- `pnpm test --run`
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`


------
https://chatgpt.com/codex/tasks/task_e_689b688c6174832996a756ee65a18c33