### PR TITLE
refactor: centralizar aliases do Supabase

### DIFF
--- a/memory-bank/raw_reflection_log.md
+++ b/memory-bank/raw_reflection_log.md
@@ -592,3 +592,21 @@ Successes:
 Improvements_Identified_For_Consolidation:
 - Priorizar limpeza do backlog de lint para agilizar validações futuras.
 ---
+
+---
+Date: 2025-08-12
+TaskRef: "Map Supabase aliases for saved pricing"
+
+Learnings:
+- Exportar aliases de linhas do Supabase evita divergência entre interfaces e esquema.
+- Usar `Pick` sobre tipos gerados permite consultas seletivas sem redefinir campos.
+
+Difficulties:
+- `pnpm lint` continua falhando com milhares de erros de formatação existentes.
+
+Successes:
+- `pnpm type-check` e `pnpm test --run` passaram após refatoração de tipos.
+
+Improvements_Identified_For_Consolidation:
+- Propagar gradualmente o uso de aliases do Supabase em outros módulos para eliminar interfaces manuais.
+---

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -838,7 +838,13 @@ export type CompositeTypes<
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
 
-export type SavedPricingRow = Tables<"saved_pricing">;
+// Aliases de conveniência para evitar interfaces manuais
+export type SavedPricingRow = Database['public']['Tables']['saved_pricing']['Row'];
+export type SavedPricingInsert = Database['public']['Tables']['saved_pricing']['Insert'];
+export type SavedPricingUpdate = Database['public']['Tables']['saved_pricing']['Update'];
+
+export type ProductRow = Database['public']['Tables']['products']['Row'];
+export type MarketplaceRow = Database['public']['Tables']['marketplaces']['Row'];
 
 export const Constants = {
   public: {

--- a/src/services/pricing.ts
+++ b/src/services/pricing.ts
@@ -1,17 +1,20 @@
 import { supabase } from "@/integrations/supabase/client";
 import { BaseService } from "./base";
-import { SavedPricingType } from "@/types/pricing";
 import { logger } from "@/utils/logger";
+import type { SavedPricingRow } from "@/types/pricing";
+import type { ProductRow, MarketplaceRow } from "@/integrations/supabase/types";
 
-export class PricingService extends BaseService<SavedPricingType> {
+export class PricingService extends BaseService<SavedPricingRow> {
   constructor() {
     super('saved_pricing');
   }
 
-  async getAllWithDetails(): Promise<(SavedPricingType & { 
-    products: { id: string; name: string; sku: string };
-    marketplaces: { id: string; name: string };
-  })[]> {
+  async getAllWithDetails(): Promise<
+    (SavedPricingRow & {
+      products: Pick<ProductRow, "id" | "name" | "sku">;
+      marketplaces: Pick<MarketplaceRow, "id" | "name">;
+    })[]
+  > {
     const { data, error } = await supabase
       .from('saved_pricing')
       .select(`
@@ -32,7 +35,10 @@ export class PricingService extends BaseService<SavedPricingType> {
     return data || [];
   }
 
-  async getByProductAndMarketplace(productId: string, marketplaceId: string): Promise<SavedPricingType[]> {
+  async getByProductAndMarketplace(
+    productId: string,
+    marketplaceId: string,
+  ): Promise<SavedPricingRow[]> {
     const { data, error } = await supabase
       .from('saved_pricing')
       .select('*')
@@ -90,7 +96,9 @@ export class PricingService extends BaseService<SavedPricingType> {
       return (data as Record<string, unknown>) || {};
     }
 
-  async upsert(data: Omit<SavedPricingType, 'id' | 'created_at' | 'updated_at'>): Promise<SavedPricingType> {
+  async upsert(
+    data: Omit<SavedPricingRow, 'id' | 'created_at' | 'updated_at'>,
+  ): Promise<SavedPricingRow> {
     const { data: result, error } = await supabase
       .from('saved_pricing')
       .upsert(data, {

--- a/src/types/pricing.ts
+++ b/src/types/pricing.ts
@@ -1,40 +1,18 @@
 import { z } from "zod";
+import type {
+  SavedPricingRow as SupabaseSavedPricingRow,
+} from "@/integrations/supabase/types";
 
-export interface SavedPricingRow {
-  product_id: string;
-  marketplace_id: string;
-  custo_total: number;
-  valor_fixo: number;
-  frete: number;
-  comissao: number;
-  preco_sugerido: number;
-  margem_unitaria: number;
-  margem_percentual: number;
-  preco_praticado: number | null;
-  taxa_cartao: number;
-  provisao_desconto: number;
-  margem_desejada: number;
+/**
+ * Alias para a linha de `saved_pricing` gerada pelo Supabase.
+ * Centralizar este tipo evita divergências com o schema do banco.
+ */
+export type SavedPricingRow = SupabaseSavedPricingRow;
+
+/** Linha de precificação acompanhada do nome do marketplace (join). */
+export type SavedPricingWithMarketplace = SavedPricingRow & {
   marketplace_name: string;
-}
-
-export interface SavedPricingType {
-  id: string;
-  product_id: string;
-  marketplace_id: string;
-  custo_total: number;
-  valor_fixo: number;
-  frete: number;
-  comissao: number;
-  taxa_cartao: number;
-  provisao_desconto: number;
-  margem_desejada: number;
-  preco_sugerido: number;
-  preco_praticado: number | null;
-  margem_unitaria: number;
-  margem_percentual: number;
-  created_at: string;
-  updated_at: string;
-}
+};
 
 export interface PricingCalculationParams {
   productId: string;


### PR DESCRIPTION
## Summary
- centralizar tipos `saved_pricing`, `products` e `marketplaces` via aliases do Supabase
- substituir interfaces manuais em serviços e DashboardForm
- documentar e reexportar `SavedPricingRow` em `src/types/pricing.ts`

## Testing
- `pnpm lint` *(fails: 6965 problems)*
- `pnpm type-check`
- `pnpm test --run`
- `rg '#[0-9a-fA-F]{3,6}' -g '!node_modules'`


------
https://chatgpt.com/codex/tasks/task_e_689b6ceea52883299acf6da9e36f0dd3