### PR TITLE
chore: reexport button variants

### DIFF
--- a/src/components/ui/button-variants.tsx
+++ b/src/components/ui/button-variants.tsx
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const buttonVariants = cva(
-  "inline-flex h-auto items-center justify-center rounded-md p-0 text-sm font-medium ring-offset-background transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center rounded-md p-0 text-sm font-medium ring-offset-background transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -25,4 +25,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 Button.displayName = "Button"
 
-export { Button }
+export { Button, buttonVariants }


### PR DESCRIPTION
## Summary
- reexport `buttonVariants` alongside `Button`
- refine `buttonVariants` base styles to avoid redundant classes

## Testing
- `npm test tests/components/Button.test.tsx -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689ba067f9e483299bcaf864a5fd77ca