### PR TITLE
feat: add modal form for shipping rules

### DIFF
--- a/src/components/forms/ShippingRuleForm.tsx
+++ b/src/components/forms/ShippingRuleForm.tsx
@@ -1,15 +1,13 @@
-import { useState, useEffect } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
-import { Trash2, Edit } from '@/components/ui/icons';
+import { Edit, Trash2 } from "@/components/ui/icons";
 import { handleSupabaseError } from "@/utils/errors";
+import { useGlobalModal } from "@/hooks/useGlobalModal";
+import { ShippingRuleModalForm } from "./ShippingRuleModalForm";
 
 interface ShippingRule {
   id: string;
@@ -17,132 +15,28 @@ interface ShippingRule {
   marketplace_id: string;
   shipping_cost: number;
   free_shipping_threshold: number;
-  created_at: string;
-  updated_at: string;
-  products?: {
-    name: string;
-  };
-  marketplaces?: {
-    name: string;
-  };
+  products?: { name: string };
+  marketplaces?: { name: string };
 }
 
-interface Product {
-  id: string;
-  name: string;
-}
-
-interface Marketplace {
-  id: string;
-  name: string;
-}
-
-interface ShippingRuleFormProps {
-  onCancel?: () => void;
-}
-
-export const ShippingRuleForm = ({ onCancel }: ShippingRuleFormProps) => {
-  interface ShippingRuleFormData {
-    product_id: string;
-    marketplace_id: string;
-    shipping_cost: string;
-    free_shipping_threshold: string;
-  }
-
-  const [formData, setFormData] = useState<ShippingRuleFormData>({
-    product_id: "",
-    marketplace_id: "",
-    shipping_cost: "",
-    free_shipping_threshold: ""
-  });
-  const [editingId, setEditingId] = useState<string | null>(null);
+export const ShippingRuleForm = () => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
-
-  const { data: products = [] } = useQuery({
-    queryKey: ["products"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("products")
-        .select("id, name")
-        .order("name");
-      
-      if (error) throw error;
-      return data as Product[];
-    }
-  });
-
-  const { data: marketplaces = [] } = useQuery({
-    queryKey: ["marketplaces"],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("marketplaces")
-        .select("id, name")
-        .order("name");
-      
-      if (error) throw error;
-      return data as Marketplace[];
-    }
-  });
+  const { showFormModal, showConfirmModal } = useGlobalModal();
 
   const { data: shippingRules = [], isLoading } = useQuery({
     queryKey: ["shipping_rules"],
     queryFn: async () => {
       const { data, error } = await supabase
         .from("shipping_rules")
-        .select(`
-          *,
-          products (name),
-          marketplaces (name)
-        `)
+        .select(
+          `*, products(name), marketplaces(name)`
+        )
         .order("created_at", { ascending: false });
-      
       if (error) throw error;
       return data as ShippingRule[];
-    }
-  });
-
-  const upsertMutation = useMutation({
-    mutationFn: async (data: ShippingRuleFormData & { id?: string }) => {
-      const { error } = await supabase
-        .from("shipping_rules")
-        .upsert({
-          ...data,
-          shipping_cost: parseFloat(data.shipping_cost),
-          free_shipping_threshold: parseFloat(data.free_shipping_threshold || "0")
-        }, {
-          onConflict: 'product_id,marketplace_id',
-          ignoreDuplicates: false
-        });
-      
-      if (error) throw error;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["shipping_rules"] });
-      resetForm();
-      toast({ 
-        title: editingId ? "Regra de frete atualizada com sucesso!" : "Regra de frete criada com sucesso!" 
-      });
-    },
-    onError: (error) => {
-      const friendlyMessage = handleSupabaseError(error);
-      toast({ 
-        title: "Erro ao salvar regra de frete", 
-        description: friendlyMessage, 
-        variant: "destructive" 
-      });
-    }
   });
-
-  const resetForm = () => {
-    setFormData({
-      product_id: "",
-      marketplace_id: "",
-      shipping_cost: "",
-      free_shipping_threshold: ""
-    });
-    setEditingId(null);
-  };
 
   const deleteMutation = useMutation({
     mutationFn: async (id: string) => {
@@ -150,7 +44,6 @@ export const ShippingRuleForm = ({ onCancel }: ShippingRuleFormProps) => {
         .from("shipping_rules")
         .delete()
         .eq("id", id);
-      
       if (error) throw error;
     },
     onSuccess: () => {
@@ -159,213 +52,108 @@ export const ShippingRuleForm = ({ onCancel }: ShippingRuleFormProps) => {
     },
     onError: (error) => {
       const friendlyMessage = handleSupabaseError(error);
-      toast({ 
-        title: "Erro ao excluir regra de frete", 
-        description: friendlyMessage, 
-        variant: "destructive" 
+      toast({
+        title: "Erro ao excluir regra de frete",
+        description: friendlyMessage,
+        variant: "destructive",
       });
-    }
+    },
   });
 
-  // Detectar automaticamente se uma regra já existe para produto + marketplace
-  useEffect(() => {
-    if (formData.product_id && formData.marketplace_id) {
-      const existingRule = shippingRules.find(rule => 
-        rule.product_id === formData.product_id && 
-        rule.marketplace_id === formData.marketplace_id
-      );
-      
-      if (existingRule && !editingId) {
-        // Regra existe e não estamos em modo de edição - mudar para edição
-        setFormData({
-          product_id: existingRule.product_id,
-          marketplace_id: existingRule.marketplace_id,
-          shipping_cost: existingRule.shipping_cost.toString(),
-          free_shipping_threshold: existingRule.free_shipping_threshold.toString()
-        });
-        setEditingId(existingRule.id);
-        toast({ 
-          title: "Regra encontrada", 
-          description: "Esta combinação já existe. Modo de edição ativado.",
-          variant: "default"
-        });
-      } else if (!existingRule && editingId) {
-        // Não existe regra e estamos em modo de edição - voltar para criação
-        setEditingId(null);
-        setFormData({
-          product_id: formData.product_id,
-          marketplace_id: formData.marketplace_id,
-          shipping_cost: "",
-          free_shipping_threshold: ""
-        });
-        toast({ 
-          title: "Nova combinação", 
-          description: "Modo de criação ativado para esta nova combinação.",
-          variant: "default"
-        });
-      }
-    } else if (editingId && (!formData.product_id || !formData.marketplace_id)) {
-      // Se está em modo de edição mas não tem produto ou marketplace selecionado, resetar
-      setEditingId(null);
-    }
-  }, [formData.product_id, formData.marketplace_id, shippingRules, editingId, toast]);
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    const dataToSave = editingId ? { id: editingId, ...formData } : formData;
-    upsertMutation.mutate(dataToSave);
-  };
-
   const handleEdit = (rule: ShippingRule) => {
-    setFormData({
-      product_id: rule.product_id,
-      marketplace_id: rule.marketplace_id,
-      shipping_cost: rule.shipping_cost.toString(),
-      free_shipping_threshold: rule.free_shipping_threshold.toString()
+    let submitForm: (() => Promise<void>) | null = null;
+
+    showFormModal({
+      title: "Editar Regra de Frete",
+      content: (
+        <ShippingRuleModalForm
+          rule={rule}
+          onSuccess={() => {}}
+          onSubmitForm={(fn) => {
+            submitForm = fn;
+          }}
+        />
+      ),
+      onSave: async () => {
+        if (submitForm) await submitForm();
+      },
+      size: "md",
     });
-    setEditingId(rule.id);
   };
 
-  const handleCancelEdit = () => {
-    resetForm();
+  const handleDelete = (rule: ShippingRule) => {
+    showConfirmModal({
+      title: "Excluir Regra de Frete",
+      description:
+        "Tem certeza que deseja excluir esta regra de frete? Esta ação não pode ser desfeita.",
+      onConfirm: async () => {
+        await deleteMutation.mutateAsync(rule.id);
+      },
+      confirmText: "Excluir",
+      variant: "destructive",
+    });
   };
 
   return (
-    <div className="space-y-lg">
-      <Card>
-        <CardHeader>
-          <CardTitle>{editingId ? "Editar Regra de Frete" : "Nova Regra de Frete"}</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-md">
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <div>
-                <Label htmlFor="product">Produto *</Label>
-                <Select value={formData.product_id} onValueChange={(value) => setFormData(prev => ({ ...prev, product_id: value }))}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione um produto" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {products.map((product) => (
-                      <SelectItem key={product.id} value={product.id}>
-                        {product.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              
-              <div>
-                <Label htmlFor="marketplace">Marketplace *</Label>
-                <Select value={formData.marketplace_id} onValueChange={(value) => setFormData(prev => ({ ...prev, marketplace_id: value }))}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Selecione um marketplace" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {marketplaces.map((marketplace) => (
-                      <SelectItem key={marketplace.id} value={marketplace.id}>
-                        {marketplace.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <div>
-                <Label htmlFor="shipping_cost">Custo do Frete (R$) *</Label>
-                <Input
-                  id="shipping_cost"
-                  type="number"
-                  step="0.01"
-                  value={formData.shipping_cost}
-                  onChange={(e) => setFormData(prev => ({ ...prev, shipping_cost: e.target.value }))}
-                  required
-                />
-              </div>
-              
-              <div>
-                <Label htmlFor="free_shipping_threshold">Frete Grátis a partir de (R$)</Label>
-                <Input
-                  id="free_shipping_threshold"
-                  type="number"
-                  step="0.01"
-                  value={formData.free_shipping_threshold}
-                  onChange={(e) => setFormData(prev => ({ ...prev, free_shipping_threshold: e.target.value }))}
-                />
-              </div>
-            </div>
-            
-            <div className="flex gap-2">
-              <Button type="submit" disabled={upsertMutation.isPending}>
-                {editingId ? "Atualizar" : "Criar"}
-              </Button>
-              <Button type="button" variant="outline" onClick={onCancel || handleCancelEdit}>
-                Cancelar
-              </Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Regras de Frete Cadastradas</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <p>Carregando...</p>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Produto</TableHead>
-                  <TableHead>Marketplace</TableHead>
-                  <TableHead>Custo Frete</TableHead>
-                  <TableHead>Frete Grátis</TableHead>
-                  <TableHead>Ações</TableHead>
+    <Card>
+      <CardHeader>
+        <CardTitle>Regras de Frete Cadastradas</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <p>Carregando...</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Produto</TableHead>
+                <TableHead>Marketplace</TableHead>
+                <TableHead>Custo Frete</TableHead>
+                <TableHead>Frete Grátis</TableHead>
+                <TableHead>Ações</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {shippingRules.map((rule) => (
+                <TableRow key={rule.id}>
+                  <TableCell className="font-medium">
+                    {rule.products?.name}
+                  </TableCell>
+                  <TableCell>{rule.marketplaces?.name}</TableCell>
+                  <TableCell>R$ {rule.shipping_cost.toFixed(2)}</TableCell>
+                  <TableCell>
+                    {rule.free_shipping_threshold > 0
+                      ? `A partir de R$ ${rule.free_shipping_threshold.toFixed(2)}`
+                      : "Não disponível"}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleEdit(rule)}
+                      >
+                        <Edit className="size-4" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => handleDelete(rule)}
+                        disabled={deleteMutation.isPending}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
                 </TableRow>
-              </TableHeader>
-              <TableBody>
-                {shippingRules.map((rule) => (
-                  <TableRow key={rule.id}>
-                    <TableCell className="font-medium">{rule.products?.name}</TableCell>
-                    <TableCell>{rule.marketplaces?.name}</TableCell>
-                    <TableCell>R$ {rule.shipping_cost.toFixed(2)}</TableCell>
-                    <TableCell>
-                      {rule.free_shipping_threshold > 0 
-                        ? `A partir de R$ ${rule.free_shipping_threshold.toFixed(2)}`
-                        : "Não disponível"
-                      }
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex gap-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleEdit(rule)}
-                        >
-                          <Edit className="size-4" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="destructive"
-                          onClick={() => deleteMutation.mutate(rule.id)}
-                          disabled={deleteMutation.isPending}
-                        >
-                          <Trash2 className="size-4" />
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </CardContent>
-      </Card>
-    </div>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
   );
 };
+
+export default ShippingRuleForm;
+

--- a/src/components/forms/ShippingRuleModalForm.tsx
+++ b/src/components/forms/ShippingRuleModalForm.tsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { handleSupabaseError } from "@/utils/errors";
+
+interface ShippingRule {
+  id: string;
+  product_id: string;
+  marketplace_id: string;
+  shipping_cost: number;
+  free_shipping_threshold: number;
+}
+
+interface Product {
+  id: string;
+  name: string;
+}
+
+interface Marketplace {
+  id: string;
+  name: string;
+}
+
+interface ShippingRuleModalFormProps {
+  rule?: ShippingRule;
+  onSuccess: () => void;
+  onSubmitForm: (submitFn: () => Promise<void>) => void;
+}
+
+interface ShippingRuleFormData {
+  product_id: string;
+  marketplace_id: string;
+  shipping_cost: string;
+  free_shipping_threshold: string;
+}
+
+export function ShippingRuleModalForm({ rule, onSuccess, onSubmitForm }: ShippingRuleModalFormProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const isEdit = !!rule;
+
+  const [formData, setFormData] = useState<ShippingRuleFormData>({
+    product_id: rule?.product_id || "",
+    marketplace_id: rule?.marketplace_id || "",
+    shipping_cost: rule ? rule.shipping_cost.toString() : "",
+    free_shipping_threshold: rule ? rule.free_shipping_threshold.toString() : "",
+  });
+
+  const { data: products = [] } = useQuery({
+    queryKey: ["products"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("products")
+        .select("id, name")
+        .order("name");
+      if (error) throw error;
+      return data as Product[];
+    },
+  });
+
+  const { data: marketplaces = [] } = useQuery({
+    queryKey: ["marketplaces"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("marketplaces")
+        .select("id, name")
+        .order("name");
+      if (error) throw error;
+      return data as Marketplace[];
+    },
+  });
+
+  const upsertMutation = useMutation({
+    mutationFn: async (data: ShippingRuleFormData & { id?: string }) => {
+      const { error } = await supabase
+        .from("shipping_rules")
+        .upsert(
+          {
+            ...data,
+            shipping_cost: parseFloat(data.shipping_cost),
+            free_shipping_threshold: parseFloat(data.free_shipping_threshold || "0"),
+          },
+          {
+            onConflict: "product_id,marketplace_id",
+            ignoreDuplicates: false,
+          }
+        );
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["shipping_rules"] });
+      toast({
+        title: isEdit
+          ? "Regra de frete atualizada com sucesso!"
+          : "Regra de frete criada com sucesso!",
+      });
+      onSuccess();
+    },
+    onError: (error) => {
+      const friendlyMessage = handleSupabaseError(error);
+      toast({
+        title: "Erro ao salvar regra de frete",
+        description: friendlyMessage,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = useCallback(async () => {
+    const dataToSave = rule ? { id: rule.id, ...formData } : formData;
+    await upsertMutation.mutateAsync(dataToSave);
+  }, [formData, rule, upsertMutation]);
+
+  const handleSubmit = useCallback(async () => {
+    await onSubmit();
+  }, [onSubmit]);
+
+  useEffect(() => {
+    onSubmitForm(handleSubmit);
+  }, [onSubmitForm, handleSubmit]);
+
+  const isLoading = upsertMutation.isPending;
+
+  return (
+    <div className="space-y-md">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <Label htmlFor="product">Produto *</Label>
+          <Select
+            value={formData.product_id}
+            onValueChange={(value) =>
+              setFormData((prev) => ({ ...prev, product_id: value }))
+            }
+            disabled={isLoading}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Selecione um produto" />
+            </SelectTrigger>
+            <SelectContent>
+              {products.map((product) => (
+                <SelectItem key={product.id} value={product.id}>
+                  {product.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div>
+          <Label htmlFor="marketplace">Marketplace *</Label>
+          <Select
+            value={formData.marketplace_id}
+            onValueChange={(value) =>
+              setFormData((prev) => ({ ...prev, marketplace_id: value }))
+            }
+            disabled={isLoading}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Selecione um marketplace" />
+            </SelectTrigger>
+            <SelectContent>
+              {marketplaces.map((marketplace) => (
+                <SelectItem key={marketplace.id} value={marketplace.id}>
+                  {marketplace.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <Label htmlFor="shipping_cost">Custo do Frete (R$) *</Label>
+          <Input
+            id="shipping_cost"
+            type="number"
+            step="0.01"
+            value={formData.shipping_cost}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, shipping_cost: e.target.value }))
+            }
+            required
+            disabled={isLoading}
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="free_shipping_threshold">
+            Frete Grátis a partir de (R$)
+          </Label>
+          <Input
+            id="free_shipping_threshold"
+            type="number"
+            step="0.01"
+            value={formData.free_shipping_threshold}
+            onChange={(e) =>
+              setFormData((prev) => ({
+                ...prev,
+                free_shipping_threshold: e.target.value,
+              }))
+            }
+            disabled={isLoading}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ShippingRuleModalForm;
+

--- a/src/pages/Shipping.tsx
+++ b/src/pages/Shipping.tsx
@@ -1,24 +1,42 @@
 import { ShippingRuleForm } from "@/components/forms/ShippingRuleForm";
+import { ShippingRuleModalForm } from "@/components/forms/ShippingRuleModalForm";
 import { ConfigurationPageLayout } from "@/components/layout/ConfigurationPageLayout";
 import { Truck, Plus } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
-import { useFormVisibility } from "@/hooks/useFormVisibility";
-import { CollapsibleCard } from "@/components/ui/collapsible-card";
+import { useGlobalModal } from "@/hooks/useGlobalModal";
 
 const Shipping = () => {
-  const { isFormVisible, isListVisible, showForm, hideForm, toggleList } = useFormVisibility({
-    formStorageKey: 'shipping-form-visible',
-    listStorageKey: 'shipping-list-visible'
-  });
+  const { showFormModal } = useGlobalModal();
+
+  const handleCreateNew = () => {
+    let submitForm: (() => Promise<void>) | null = null;
+
+    showFormModal({
+      title: "Nova Regra de Frete",
+      description: "Crie uma nova regra de frete por produto e marketplace",
+      content: (
+        <ShippingRuleModalForm
+          onSuccess={() => {}}
+          onSubmitForm={(fn) => {
+            submitForm = fn;
+          }}
+        />
+      ),
+      onSave: async () => {
+        if (submitForm) await submitForm();
+      },
+      size: "md",
+    });
+  };
 
   const breadcrumbs = [
     { label: "Configurações", href: "/dashboard" },
-    { label: "Regras de Frete" }
+    { label: "Regras de Frete" },
   ];
 
   const headerActions = (
     <div className="flex items-center gap-2">
-      <Button size="sm" onClick={showForm}>
+      <Button size="sm" onClick={handleCreateNew}>
         <Plus className="mr-2 size-4" />
         Nova Regra
       </Button>
@@ -33,28 +51,12 @@ const Shipping = () => {
       breadcrumbs={breadcrumbs}
       actions={headerActions}
     >
-      {isFormVisible && (
-        <div className="xl:col-span-6">
-          <ShippingRuleForm onCancel={hideForm} />
-        </div>
-      )}
-
-      {/* Lista externa colapsável */}
-      <div className={isFormVisible ? "xl:col-span-6" : "xl:col-span-12"}>
-        <CollapsibleCard
-          title="Regras de Frete Configuradas"
-          icon={<Truck className="size-4" />}
-          isOpen={isListVisible}
-          onToggle={toggleList}
-        >
-          <div className="p-4 text-center text-muted-foreground">
-            <p>Lista de regras de frete será exibida aqui</p>
-            <p className="mt-1 text-sm">Adicione uma nova regra para começar</p>
-          </div>
-        </CollapsibleCard>
+      <div className="xl:col-span-12">
+        <ShippingRuleForm />
       </div>
     </ConfigurationPageLayout>
   );
 };
 
 export default Shipping;
+


### PR DESCRIPTION
## Summary
- add ShippingRuleModalForm with onSubmit callback
- use modals for creating/editing shipping rules
- confirm before deleting shipping rules

## Testing
- `npm run lint`
- `npm test` *(fails: hook tests expect toast calls)*

------
https://chatgpt.com/codex/tasks/task_e_68a36e33025483298df087b43f4abded