### PR TITLE
docs: replace pnpm usage with npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Siga estas instruções para obter uma cópia do projeto e executá-lo em sua m�
 ### Pré-requisitos
 
 *   Node.js (versão 18 ou superior)
-*   npm, pnpm ou yarn
+*   npm
 *   Uma conta no [Supabase](https://supabase.com/) para o backend.
 *   Uma conta de desenvolvedor no [Mercado Livre](https://developers.mercadolivre.com.br/) para criar sua aplicação de integração.
 
@@ -46,7 +46,7 @@ Siga estas instruções para obter uma cópia do projeto e executá-lo em sua m�
 
 2.  **Instale as dependências:**
     ```bash
-    pnpm install
+    npm install
     ```
 
 3.  **Configure as Variáveis de Ambiente:**
@@ -58,7 +58,7 @@ Siga estas instruções para obter uma cópia do projeto e executá-lo em sua m�
 
 4.  **Execute a aplicação:**
     ```bash
-    pnpm dev
+    npm run dev
     ```
     A aplicação estará disponível em `http://localhost:5173`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,9 @@ Documentação completa para integração entre **Catalog Maker Hub** e **API Me
 
 ### 1. Pré-requisitos
 ```bash
+# Instalar dependências
+npm install
+
 # Verificar se o projeto está funcionando
 npm run dev
 


### PR DESCRIPTION
## Summary
- replace pnpm commands with npm in README and docs
- clarify Quick Start instructions to use npm install and npm run dev

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a9dc614e748329b298390c66ed89dc