### PR TITLE
docs: clarify npm workflow and tests

### DIFF
--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -1,4 +1,36 @@
 # Configuração do Ambiente
 
-Instruções iniciais para preparar o ambiente de desenvolvimento do Catalog Maker Hub.
+## Instalação
+
+1. Certifique-se de ter o Node.js 18 ou superior instalado.
+2. Instale as dependências com npm:
+
+```bash
+npm install
+```
+
+## Execução
+
+Inicie o servidor de desenvolvimento com:
+
+```bash
+npm run dev
+```
+
+## Verificações de Qualidade
+
+Execute todas as verificações antes de abrir um pull request:
+
+```bash
+npm run lint
+npm run type-check
+npm test
+npm run test:coverage
+```
+
+## Referências de Documentação
+
+- Escreva a documentação em português.
+- Utilize o estilo descrito em [docs/README.md](../README.md).
+- Prefira links relativos e use `https://peepers-hub.lovable.app` para URLs de produção.
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,4 +1,26 @@
 # Estratégia de Testes
 
-Diretrizes para criação e execução de testes automatizados no Catalog Maker Hub.
+## Lint
+
+```bash
+npm run lint
+```
+
+## Type Check
+
+```bash
+npm run type-check
+```
+
+## Testes Unitários
+
+```bash
+npm test
+```
+
+## Cobertura de Testes
+
+```bash
+npm run test:coverage
+```
 


### PR DESCRIPTION
## Summary
- document npm as default for setup and development
- add lint, type-check, and coverage instructions
- guide documentation references and link style

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a9de38de04832992e316f7b62aef22