### PR TITLE
docs: update ML callback URL

### DIFF
--- a/docs/integration/overview.md
+++ b/docs/integration/overview.md
@@ -13,7 +13,7 @@ A integração do Catalog Maker Hub com o Mercado Livre centraliza o gerenciamen
 
 1. Possuir contas no Catalog Maker Hub e no Mercado Livre.
 2. Criar a aplicação no [DevCenter](https://developers.mercadolivre.com.br/).
-3. Definir a URL de redirecionamento: `https://peepers-hub.lovable.app/integrations/mercadolivre/callback`.
+3. Definir a URL de redirecionamento: `https://peepers-hub.lovable.app/api/ml/callback`.
 4. Selecionar os escopos `read`, `write` e `offline_access`.
 5. Registrar a URL de webhooks: `https://peepers-hub.lovable.app/api/webhooks/mercadolivre` com tópicos `items`, `orders_v2`, `payments` e `questions`.
 


### PR DESCRIPTION
## Summary
- use updated ML callback URL in integration overview

## Testing
- `npm test` *(fails: no tests executed; watch mode prompts)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ac65fb683c83299be1021642e4642f