### PR TITLE
docs: add supabase cli setup and ml env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 # Exemplo de variáveis de ambiente para o Catalog Maker Hub
 # URL de redirecionamento utilizada após o cadastro no Supabase Auth (sem barra final)
 VITE_AUTH_REDIRECT_URL=http://localhost:5173
+
+# Configurações do Supabase
+VITE_SUPABASE_URL=http://localhost:54321
+VITE_SUPABASE_ANON_KEY=supabase-anon-key
+
+# Integração Mercado Livre
+VITE_ML_CLIENT_ID=seu-client-id-ml

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -17,6 +17,35 @@ Inicie o servidor de desenvolvimento com:
 npm run dev
 ```
 
+## Supabase CLI
+
+1. Instale a CLI:
+
+   ```bash
+   npm install -g supabase
+   ```
+
+2. Inicie os serviços locais:
+
+   ```bash
+   supabase start
+   ```
+
+3. Aplique as migrações existentes:
+
+   ```bash
+   supabase db reset
+   ```
+
+4. Configure os secrets necessários:
+
+   ```bash
+   cp supabase/.env.example supabase/.env
+   supabase secrets set --env-file supabase/.env
+   ```
+
+5. Valide o schema com o documento [database-schema.md](database-schema.md).
+
 ## Verificações de Qualidade
 
 Execute todas as verificações antes de abrir um pull request:

--- a/docs/integration/overview.md
+++ b/docs/integration/overview.md
@@ -17,3 +17,14 @@ A integração do Catalog Maker Hub com o Mercado Livre centraliza o gerenciamen
 4. Selecionar os escopos `read`, `write` e `offline_access`.
 5. Registrar a URL de webhooks: `https://peepers-hub.lovable.app/api/webhooks/mercadolivre` com tópicos `items`, `orders_v2`, `payments` e `questions`.
 
+## Variáveis de Ambiente
+
+A integração requer as seguintes variáveis:
+
+- `VITE_ML_CLIENT_ID`: ID da aplicação para uso no frontend.
+- `ML_APP_ID` e `ML_CLIENT_SECRET`: credenciais da aplicação utilizadas nas Edge Functions.
+- `ML_REDIRECT_URL`: URL de redirecionamento configurada no DevCenter.
+- `ML_WEBHOOK_SECRET`: segredo utilizado para validar webhooks.
+
+As variáveis `ML_APP_ID`, `ML_CLIENT_SECRET`, `ML_REDIRECT_URL` e `ML_WEBHOOK_SECRET` devem ser definidas em `supabase/.env` e carregadas como secrets com `supabase secrets set --env-file supabase/.env`.
+

--- a/supabase/.env.example
+++ b/supabase/.env.example
@@ -1,0 +1,9 @@
+# Secrets para Edge Functions do Catalog Maker Hub
+
+# Credenciais da aplicação no Mercado Livre
+ML_APP_ID=seu-client-id-ml
+ML_CLIENT_SECRET=seu-client-secret-ml
+
+# URLs utilizadas pela aplicação
+ML_REDIRECT_URL=http://localhost:5173/integrations/mercadolivre/callback
+ML_WEBHOOK_SECRET=defina-um-segredo


### PR DESCRIPTION
## Summary
- document Supabase CLI usage, migrations and secrets
- describe Mercado Livre environment variables
- add example of secrets for Supabase functions

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68ac93a4b17c8329a3e1bd5ad6824ac2