### PR TITLE
fix: reduce retries on ML auth status

### DIFF
--- a/src/hooks/useMLAuth.ts
+++ b/src/hooks/useMLAuth.ts
@@ -24,6 +24,14 @@ export function useMLAuth() {
       return data;
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
+    retry: 0,
+    onError: (error: Error) => {
+      toast({
+        title: "Erro na verificação",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
   });
 }
 


### PR DESCRIPTION
## 🎯 Descrição
- add retry and error toast to Mercado Livre auth status query

## 🧪 Testes
- `npm test` *(fails: see log)*
- `npm run lint` *(fails: 2 errors, 10 warnings)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b1e2ed147c832986b1ec6752e1a995