### PR TITLE
feat: add ML auth callback API route

### DIFF
--- a/src/api/ml/callback.ts
+++ b/src/api/ml/callback.ts
@@ -1,0 +1,34 @@
+const getCookieValue = (cookieHeader: string | null, name: string): string | null => {
+  if (!cookieHeader) return null;
+  const match = cookieHeader
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${name}=`));
+  return match ? decodeURIComponent(match.split('=')[1]) : null;
+};
+
+export default async function handler(req: Request): Promise<Response> {
+  const token = getCookieValue(req.headers.get('cookie'), 'sb-access-token');
+
+  if (!token) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const { code, state } = await req.json();
+
+  const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/ml-auth`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ action: 'handle_callback', code, state }),
+  });
+
+  const text = await response.text();
+  return new Response(text, {
+    status: response.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+

--- a/src/hooks/useMLAuth.ts
+++ b/src/hooks/useMLAuth.ts
@@ -68,15 +68,16 @@ export function useMLAuthCallback() {
       const urlParams = new URLSearchParams(window.location.search);
       const state = urlParams.get('state');
 
-      const { error } = await supabase.functions.invoke('ml-auth', {
-        body: { 
-          action: 'handle_callback',
-          code,
-          state
-        }
+      const response = await fetch('/api/ml/callback', {
+        method: 'POST',
+        body: JSON.stringify({ code, state }),
+        headers: { 'Content-Type': 'application/json' }
       });
 
-      if (error) throw error;
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || 'Failed to handle callback');
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [ML_AUTH_QUERY_KEY] });


### PR DESCRIPTION
## 🎯 Descrição
- adiciona rota `/api/ml/callback` para repassar code/state à edge function `ml-auth`
- atualiza `useMLAuthCallback` para usar a nova rota

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [ ] Testes adicionados/atualizados
- [x] Documentação atualizada (não necessário)
- [x] Edge Function pronta para uso
- [ ] Logs de debug implementados

## 🧪 Testes
- `CI=1 npm test`
- `npm run lint`
- `npm run type-check`

## 📋 Próximos Passos
- adicionar testes específicos para fluxo de callback


------
https://chatgpt.com/codex/tasks/task_e_68b2068c7e1483298beb80f4952412b9