### PR TITLE
refactor: migrate ml auth to api routes

### DIFF
--- a/src/components/ml/MLConnectionCard.tsx
+++ b/src/components/ml/MLConnectionCard.tsx
@@ -102,9 +102,11 @@ export function MLConnectionCard() {
               Conecte sua conta do Mercado Livre para sincronizar produtos e gerenciar vendas automaticamente.
             </p>
             
-            {authStatus?.error && (
+            {(authStatus?.error || startAuthMutation.error) && (
               <div className="rounded-md bg-destructive/10 p-3">
-                <p className="text-sm text-destructive">{authStatus.error}</p>
+                <p className="text-sm text-destructive">
+                  {authStatus?.error || (startAuthMutation.error as Error).message}
+                </p>
               </div>
             )}
             

--- a/src/hooks/useMLAuth.ts
+++ b/src/hooks/useMLAuth.ts
@@ -39,11 +39,13 @@ export function useMLAuthStart() {
   return useMutation({
     mutationFn: async (): Promise<{ auth_url: string; state: string }> => {
       const response = await fetch("/api/ml/start", { method: "POST" });
+      const data = await response.json().catch(() => null);
+
       if (!response.ok) {
-        const text = await response.text();
-        throw new Error(text || "Failed to start auth");
+        throw new Error(data?.error || data?.message || "Failed to start auth");
       }
-      return response.json();
+
+      return data;
     },
     onSuccess: (data) => {
       // Redirect to ML OAuth
@@ -74,11 +76,12 @@ export function useMLAuthCallback() {
         headers: { 'Content-Type': 'application/json' }
       });
 
+      const data = await response.json().catch(() => null);
       if (!response.ok) {
-        const text = await response.text();
-        throw new Error(text || 'Failed to handle callback');
+        throw new Error(data?.error || data?.message || 'Failed to handle callback');
       }
     },
+    retry: 0,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [ML_AUTH_QUERY_KEY] });
       toast({

--- a/src/pages/MLCallback.tsx
+++ b/src/pages/MLCallback.tsx
@@ -19,7 +19,7 @@ export default function MLCallback() {
   useEffect(() => {
     if (error) {
       console.error('OAuth Error:', error);
-      navigate('/integrations/mercado-livre?error=oauth_failed');
+      navigate(`/integrations/mercado-livre?error=${encodeURIComponent(error)}`);
       return;
     }
 
@@ -30,8 +30,8 @@ export default function MLCallback() {
           onSuccess: () => {
             navigate('/integrations/mercado-livre?success=connected');
           },
-          onError: () => {
-            navigate('/integrations/mercado-livre?error=connection_failed');
+          onError: (err: Error) => {
+            navigate(`/integrations/mercado-livre?error=${encodeURIComponent(err.message)}`);
           }
         });
       }
@@ -42,12 +42,12 @@ export default function MLCallback() {
 
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="flex min-h-screen items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardContent className="flex flex-col items-center space-y-4 p-6">
             <AlertCircle className="size-12 text-destructive" />
             <div className="text-center">
-              <h2 className="text-lg font-semibold text-foreground mb-2">
+              <h2 className="mb-2 text-lg font-semibold text-foreground">
                 Erro na Conexão
               </h2>
               <p className="text-sm text-muted-foreground">
@@ -62,12 +62,12 @@ export default function MLCallback() {
 
   if (callbackMutation.isSuccess) {
     return (
-      <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="flex min-h-screen items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardContent className="flex flex-col items-center space-y-4 p-6">
             <CheckCircle2 className="size-12 text-success" />
             <div className="text-center">
-              <h2 className="text-lg font-semibold text-foreground mb-2">
+              <h2 className="mb-2 text-lg font-semibold text-foreground">
                 Conexão Realizada!
               </h2>
               <p className="text-sm text-muted-foreground">
@@ -81,12 +81,12 @@ export default function MLCallback() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4">
+    <div className="flex min-h-screen items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardContent className="flex flex-col items-center space-y-4 p-6">
           <LoadingSpinner size="lg" />
           <div className="text-center">
-            <h2 className="text-lg font-semibold text-foreground mb-2">
+            <h2 className="mb-2 text-lg font-semibold text-foreground">
               Conectando...
             </h2>
             <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## 🎯 Descrição
- Usa rotas `/api/ml/start` e `/api/ml/callback` nos hooks de autenticação
- Exibe erros da API na carta de conexão
- Redireciona callback com mensagens de erro sem retries automáticos

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [x] Testes passando
- [x] Lint sem erros
- [x] Type-check sem erros

## 🧪 Testes
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b2ed2aa81883298952e00c73a0520f