### PR TITLE
fix: handle partial ML batch sync

### DIFF
--- a/src/hooks/useMLIntegration.ts
+++ b/src/hooks/useMLIntegration.ts
@@ -1,7 +1,7 @@
 // Hook centralizado para integração ML - implementa princípios SOLID e DRY
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@/hooks/use-toast';
-import { MLService, MLAuthStatus, MLSyncStatus, MLSyncProduct, MLPerformanceMetrics, MLAdvancedSettings } from '@/services/ml-service';
+import { MLService, MLAuthStatus, MLSyncStatus, MLSyncProduct, MLPerformanceMetrics, MLAdvancedSettings, MLBatchSyncResult } from '@/services/ml-service';
 
 // Chaves de query centralizadas
 export const ML_QUERY_KEYS = {
@@ -198,18 +198,18 @@ export function useMLSync() {
     },
   });
 
-  const syncBatch = useMutation({
+  const syncBatch = useMutation<MLBatchSyncResult, Error, string[]>({
     mutationFn: MLService.syncBatch,
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ML_QUERY_KEYS.syncStatus });
-      
+
       if (data?.successful && data.successful > 0) {
         toast({
           title: "Sincronização em Lote",
           description: `${data.successful} produtos sincronizados com sucesso.`,
         });
       }
-      
+
       if (data?.failed && data.failed > 0) {
         toast({
           title: "Alguns Erros na Sincronização",

--- a/src/services/ml-service.ts
+++ b/src/services/ml-service.ts
@@ -29,6 +29,11 @@ export interface MLSyncProduct {
   error_message?: string | null;
 }
 
+export interface MLBatchSyncResult {
+  successful: number;
+  failed: number;
+}
+
 export interface MLAuthStatus {
   isConnected: boolean;
   user_id_ml?: number;
@@ -181,7 +186,7 @@ export class MLService {
     }
   }
 
-  static async syncBatch(productIds: string[]): Promise<{ successful: number; failed: number; }> {
+  static async syncBatch(productIds: string[]): Promise<MLBatchSyncResult> {
     const { data, error } = await supabase.functions.invoke('ml-sync-v2', {
       body: { action: 'sync_batch', product_ids: productIds }
     });
@@ -190,7 +195,10 @@ export class MLService {
       throw new Error(error.message || 'Failed to sync products in batch');
     }
 
-    return { successful: productIds.length, failed: 0 };
+    return {
+      successful: data?.successful ?? 0,
+      failed: data?.failed ?? 0
+    };
   }
 
   static async importFromML(): Promise<{ imported: number; items: any[] }> {


### PR DESCRIPTION
## Summary
- track ML batch sync results with successful and failed counts
- use typed batch sync results in ML integration hook

## Testing
- `npm test -- --run` *(fails: 2 failed, 15 passed)*
- `npm run lint` *(fails: 83 errors, 130 warnings)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68b36219b9c88329b57f8aac54d59bed