### PR TITLE
fix: log results after ml sync

### DIFF
--- a/supabase/functions/ml-sync-v2/actions/syncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/syncProduct.ts
@@ -18,19 +18,44 @@ export async function syncProduct(
     return errorResponse('Product not found', 404);
   }
 
-  await supabase
-    .from('ml_sync_log')
-    .insert({
+  const startTime = Date.now();
+  try {
+    const { data: syncData, error: syncError } = await supabase.functions.invoke('ml-sync', {
+      body: { action: 'sync_product', product_id: req.product_id }
+    });
+
+    const status = syncError || !syncData?.success ? 'error' : 'success';
+
+    await supabase.from('ml_sync_log').insert({
       tenant_id: tenantId,
       operation_type: 'sync_product',
       entity_type: 'product',
       entity_id: req.product_id,
-      status: 'success',
+      status,
       request_data: { product_name: product.name },
+      response_data: syncData,
+      error_details: syncError ? { message: syncError.message } : undefined,
+      execution_time_ms: Date.now() - startTime
     });
 
-  return new Response(
-    JSON.stringify({ success: true, message: 'Product sync initiated' }),
-    { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-  );
+    if (status === 'error') {
+      return errorResponse(syncError?.message || syncData?.error || 'ML sync failed', 500);
+    }
+
+    return new Response(JSON.stringify(syncData), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    await supabase.from('ml_sync_log').insert({
+      tenant_id: tenantId,
+      operation_type: 'sync_product',
+      entity_type: 'product',
+      entity_id: req.product_id,
+      status: 'error',
+      error_details: { message: (error as Error).message },
+      execution_time_ms: Date.now() - startTime
+    });
+
+    return errorResponse('Internal error: ' + (error as Error).message, 500);
+  }
 }


### PR DESCRIPTION
## Summary
- move ml sync logging after actual synchronization
- store sync status and error details based on Mercado Livre response

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b36b6fb5648329a80c985798761c8a