### PR TITLE
fix: add auth header to ml sync actions

### DIFF
--- a/supabase/functions/ml-sync-v2/index.ts
+++ b/supabase/functions/ml-sync-v2/index.ts
@@ -87,6 +87,7 @@ serve(async (req) => {
       authToken,
       mlClientId,
       mlToken: authToken.access_token,
+      jwt,
     };
 
     const handler = actions[body.action];

--- a/supabase/functions/ml-sync-v2/types.ts
+++ b/supabase/functions/ml-sync-v2/types.ts
@@ -35,6 +35,7 @@ export interface ActionContext {
   authToken: any;
   mlClientId: string;
   mlToken: string;
+  jwt: string;
 }
 
 export const corsHeaders = {


### PR DESCRIPTION
## Summary
- pass user JWT when invoking `ml-sync` in product and batch actions
- log batch sync status correctly without assuming `success` flag
- expose JWT in `ActionContext` for downstream calls

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68b36fac62e88329998680f1253cb9e7