### PR TITLE
feat: add rate-limited ML batch utility

### DIFF
--- a/src/hooks/useMLResync.ts
+++ b/src/hooks/useMLResync.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
 import { ML_QUERY_KEYS } from "./useMLIntegration";
+import { callMLFunction, processInBatches } from "@/utils/ml/ml-api";
 
 interface ResyncProductParams {
   productId: string;
@@ -18,19 +18,7 @@ export function useMLResync() {
     mutationFn: async (params: ResyncProductParams) => {
       console.log('Re-syncing product:', params.productId);
       
-      const { data, error } = await supabase.functions.invoke('ml-sync-v2', {
-        body: { 
-          action: 'resync_product',
-          productId: params.productId
-        }
-      });
-
-      if (error) {
-        console.error('Resync Error:', error);
-        throw new Error(error.message || 'Falha na re-sincronização');
-      }
-
-      return data;
+      return await callMLFunction('resync_product', { productId: params.productId });
     },
     onSuccess: (data, variables) => {
       // Invalidar caches relevantes
@@ -58,28 +46,12 @@ export function useMLResync() {
     mutationFn: async (params: ResyncBatchParams) => {
       console.log('Re-syncing batch:', params.productIds.length, 'products');
       
-      const results = [];
-      
-      // Processar em lotes de 3 para não sobrecarregar a API
-      for (let i = 0; i < params.productIds.length; i += 3) {
-        const batch = params.productIds.slice(i, i + 3);
-        const batchPromises = batch.map(productId => 
-          supabase.functions.invoke('ml-sync-v2', {
-            body: { 
-              action: 'resync_product',
-              productId: productId
-            }
-          })
-        );
-        
-        const batchResults = await Promise.allSettled(batchPromises);
-        results.push(...batchResults);
-        
-        // Aguardar 1 segundo entre lotes para respeitar rate limits
-        if (i + 3 < params.productIds.length) {
-          await new Promise(resolve => setTimeout(resolve, 1000));
-        }
-      }
+      const results = await processInBatches(
+        params.productIds,
+        (productId) => callMLFunction('resync_product', { productId }, { skipRateCheck: true }),
+        'resync_product',
+        3
+      );
 
       const successful = results.filter(result => result.status === 'fulfilled').length;
       const failed = results.filter(result => result.status === 'rejected').length;

--- a/src/utils/ml/ml-api.ts
+++ b/src/utils/ml/ml-api.ts
@@ -1,0 +1,62 @@
+import { supabase } from '@/integrations/supabase/client';
+import { MLService } from '@/services/ml-service';
+
+async function wait(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+interface CallOptions {
+  operationType?: string;
+  skipRateCheck?: boolean;
+}
+
+export async function callMLFunction(
+  action: string,
+  body: Record<string, any>,
+  options: CallOptions = {}
+) {
+  const operationType = options.operationType || action;
+
+  if (!options.skipRateCheck) {
+    while (!(await MLService.checkRateLimit(operationType))) {
+      await wait(1000);
+    }
+  }
+
+  const { data, error } = await supabase.functions.invoke('ml-sync-v2', {
+    body: { action, ...body }
+  });
+
+  if (error) {
+    throw new Error(error.message || 'ML function call failed');
+  }
+
+  if (data?.error) {
+    throw new Error(data.error);
+  }
+
+  return data;
+}
+
+export async function processInBatches<T>(
+  items: T[],
+  handler: (item: T) => Promise<any>,
+  operationType: string,
+  concurrency = 3
+) {
+  const results: PromiseSettledResult<any>[] = [];
+
+  for (let i = 0; i < items.length; i += concurrency) {
+    const batch = items.slice(i, i + concurrency);
+
+    while (!(await MLService.checkRateLimit(operationType))) {
+      await wait(1000);
+    }
+
+    const settled = await Promise.allSettled(batch.map(handler));
+    results.push(...settled);
+  }
+
+  return results;
+}
+


### PR DESCRIPTION
## 🎯 Descrição
- implementa utilitário para centralizar chamadas ML com controle de limite
- adiciona processamento em lotes com espera por rate limit

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [x] Testes passando (`npm test`)
- [x] Lint sem erros (`npm run lint`)
- [x] Type check sem erros (`npm run type-check`)

## 🧪 Testes
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b3723c9a3c8329bd6a4f79ea3822de