### PR TITLE
test: reset nested mocks in setup

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,9 +2,10 @@ import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
 
-// Limpa após cada teste
+// Limpa e reseta mocks após cada teste
 afterEach(() => {
   cleanup();
+  testUtils.resetAllMocks();
 });
 
 // Mock do Supabase Client
@@ -135,10 +136,12 @@ export const testUtils = {
 
   // Reseta todos os mocks
   resetAllMocks: () => {
-    vi.clearAllMocks();
-    mockSupabaseClient.from.mockClear();
-    mockSupabaseClient.rpc.mockClear();
-    mockToast.mockClear();
-    Object.values(mockQueryClient).forEach(fn => fn.mockClear());
+    vi.resetAllMocks();
+    mockSupabaseClient.from.mockReset();
+    mockSupabaseClient.rpc.mockReset();
+    Object.values(mockSupabaseClient.auth).forEach(fn => fn.mockReset());
+    Object.values(mockSupabaseClient.storage).forEach(fn => fn.mockReset());
+    mockToast.mockReset();
+    Object.values(mockQueryClient).forEach(fn => fn.mockReset());
   },
 };


### PR DESCRIPTION
## Summary
- ensure test utilities reset nested auth and storage mocks with `mockReset`
- clear mocks after each test for clean isolated runs

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b38b5ee5988329b3bb4b433992ddf5