### PR TITLE
test: reset nested mocks in setup

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -136,12 +136,12 @@ export const testUtils = {
 
   // Reseta todos os mocks
   resetAllMocks: () => {
-    vi.resetAllMocks();
-    mockSupabaseClient.from.mockReset();
-    mockSupabaseClient.rpc.mockReset();
-    Object.values(mockSupabaseClient.auth).forEach(fn => fn.mockReset());
-    Object.values(mockSupabaseClient.storage).forEach(fn => fn.mockReset());
-    mockToast.mockReset();
-    Object.values(mockQueryClient).forEach(fn => fn.mockReset());
+    vi.clearAllMocks();
+    mockSupabaseClient.from.mockClear();
+    mockSupabaseClient.rpc.mockClear();
+    Object.values(mockSupabaseClient.auth).forEach(fn => fn.mockClear());
+    Object.values(mockSupabaseClient.storage).forEach(fn => fn.mockClear());
+    mockToast.mockClear();
+    Object.values(mockQueryClient).forEach(fn => fn.mockClear());
   },
 };


### PR DESCRIPTION
## Summary
- ensure test utilities reset nested auth and storage mocks with `mockClear`
- preserve default Supabase stub while clearing call counts

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run lint` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run type-check` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b38d0b87ac8329947388a47e119dbf