### PR TITLE
test: centralize toast mock

### DIFF
--- a/tests/hooks/useProducts.test.tsx
+++ b/tests/hooks/useProducts.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { testUtils } from '../setup';
+import { toast } from '../mocks/toast';
 import { useProducts, useCreateProduct, useUpdateProduct, useDeleteProduct } from '@/hooks/useProducts';
 import { productsService } from '@/services/products';
 
@@ -87,7 +88,7 @@ describe('useProducts hooks', () => {
 
       await result.current.mutateAsync(productData);
       expect(productsService.create).toHaveBeenCalledWith(productData);
-      expect(testUtils.mockToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
           title: 'Sucesso',
           description: 'Produto criado com sucesso!',
@@ -111,7 +112,7 @@ describe('useProducts hooks', () => {
       });
 
       await expect(result.current.mutateAsync(productData)).rejects.toThrow(mockError);
-      expect(testUtils.mockToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
           title: 'Erro',
           description: mockError.message,
@@ -147,7 +148,7 @@ describe('useProducts hooks', () => {
 
       await result.current.mutateAsync('test-id');
       expect(productsService.delete).toHaveBeenCalledWith('test-id');
-      expect(testUtils.mockToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
           title: 'Sucesso',
           description: 'Produto deletado com sucesso!',

--- a/tests/mocks/toast.ts
+++ b/tests/mocks/toast.ts
@@ -1,0 +1,4 @@
+import { vi } from 'vitest'
+
+export const toast = vi.fn()
+export const useToast = () => ({ toast })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
+import * as toastMock from './mocks/toast';
 
 // Limpa e reseta mocks após cada teste
 afterEach(() => {
@@ -33,7 +34,7 @@ const mockSupabaseClient = {
 };
 
 // Mock das funções de toast
-const mockToast = vi.fn();
+const { toast: mockToast } = toastMock;
 
 // Mock do React Query
 const mockQueryClient = {
@@ -48,14 +49,7 @@ vi.mock('@/integrations/supabase/client', () => ({
 }));
 
 // Mock do toast
-vi.mock('@/components/ui/use-toast', () => ({
-  toast: mockToast,
-  useToast: () => ({ toast: mockToast }),
-}));
-vi.mock('@/hooks/use-toast', () => ({
-  toast: mockToast,
-  useToast: () => ({ toast: mockToast }),
-}));
+vi.mock('@/hooks/use-toast', () => toastMock);
 
 // Mock do React Router
 vi.mock('react-router-dom', async () => {


### PR DESCRIPTION
## Summary
- centralize toast mock in tests
- update setup to mock new toast module
- adjust useProducts tests to use unified toast mock

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in supabase functions)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b38e1ca928832984fccd5a9026907b