### PR TITLE
test: replace index selectors with accessible queries

### DIFF
--- a/src/components/marketplace/MarketplaceHierarchyCard.tsx
+++ b/src/components/marketplace/MarketplaceHierarchyCard.tsx
@@ -52,6 +52,7 @@ export const MarketplaceHierarchyCard = ({
               variant="outline"
               size="sm"
               onClick={() => onEditPlatform(platform)}
+              aria-label="Editar plataforma"
             >
               <Settings className="size-4" />
             </Button>
@@ -59,6 +60,7 @@ export const MarketplaceHierarchyCard = ({
               variant="destructive"
               size="sm"
               onClick={() => onDeletePlatform(platform.id)}
+              aria-label="Excluir plataforma"
             >
               <Trash2 className="size-4" />
             </Button>
@@ -121,6 +123,7 @@ export const MarketplaceHierarchyCard = ({
                         size="sm"
                         onClick={() => onEditModality(modality)}
                         className="size-8 p-0"
+                        aria-label={`Editar ${modality.name}`}
                       >
                         <Settings className="size-3" />
                       </Button>
@@ -129,6 +132,7 @@ export const MarketplaceHierarchyCard = ({
                         size="sm"
                         onClick={() => onDeleteModality(modality.id)}
                         className="size-8 p-0 text-destructive hover:text-destructive"
+                        aria-label={`Excluir ${modality.name}`}
                       >
                         <Trash2 className="size-3" />
                       </Button>

--- a/src/components/ui/data-visualization.tsx
+++ b/src/components/ui/data-visualization.tsx
@@ -147,6 +147,7 @@ export function DataVisualization<T extends { id: string }>({
                       variant={action.variant || "outline"}
                       onClick={() => action.onClick(item)}
                       disabled={action.disabled?.(item)}
+                      aria-label={action.label}
                     >
                       {action.icon}
                     </Button>
@@ -154,7 +155,7 @@ export function DataVisualization<T extends { id: string }>({
                   {actions.length > 2 && (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button size="sm" variant="ghost">
+                        <Button size="sm" variant="ghost" aria-label="Mais ações">
                           <MoreHorizontal className="size-4" />
                         </Button>
                       </DropdownMenuTrigger>
@@ -228,6 +229,7 @@ export function DataVisualization<T extends { id: string }>({
                   variant={viewMode === "table" ? "default" : "ghost"}
                   onClick={() => onViewModeChange("table")}
                   className="rounded-r-none"
+                  aria-label="Modo tabela"
                 >
                   <List className="size-4" />
                 </Button>
@@ -236,6 +238,7 @@ export function DataVisualization<T extends { id: string }>({
                   variant={viewMode === "grid" ? "default" : "ghost"}
                   onClick={() => onViewModeChange("grid")}
                   className="rounded-l-none border-l"
+                  aria-label="Modo grade"
                 >
                   <Grid className="size-4" />
                 </Button>

--- a/tests/components/DataVisualization.test.tsx
+++ b/tests/components/DataVisualization.test.tsx
@@ -95,7 +95,8 @@ describe('Componente DataVisualization', () => {
       />, { wrapper: createWrapper() }
     );
 
-    const button = screen.getAllByRole('button')[0];
+    const row = screen.getByRole('row', { name: /Item 1/i });
+    const button = within(row).getByRole('button', { name: /Editar/i });
     await user.click(button);
     expect(mockAction).toHaveBeenCalledWith(mockData[0]);
   });
@@ -163,12 +164,18 @@ describe('Componente DataVisualization', () => {
     const header = screen.getByText('Nome');
     await user.click(header);
 
-    let rows = screen.getAllByRole('row');
-    expect(within(rows[1]).getByText('Alpha')).toBeInTheDocument();
+    let alphaRow = screen.getByRole('row', { name: /Alpha/i });
+    let betaRow = screen.getByRole('row', { name: /Beta/i });
+    expect(
+      alphaRow.compareDocumentPosition(betaRow) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
 
     await user.click(header);
-    rows = screen.getAllByRole('row');
-    expect(within(rows[1]).getByText('Beta')).toBeInTheDocument();
+    betaRow = screen.getByRole('row', { name: /Beta/i });
+    alphaRow = screen.getByRole('row', { name: /Alpha/i });
+    expect(
+      betaRow.compareDocumentPosition(alphaRow) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
   });
 
   it('deve paginar os resultados', async () => {
@@ -218,11 +225,12 @@ describe('Componente DataVisualization', () => {
       />, { wrapper: createWrapper() }
     );
 
-    const buttons = screen.getAllByRole('button');
-    await user.click(buttons[1]);
+    const gridButton = screen.getByRole('button', { name: /modo grade/i });
+    await user.click(gridButton);
     expect(mockChange).toHaveBeenCalledWith('grid');
 
-    await user.click(buttons[0]);
+    const tableButton = screen.getByRole('button', { name: /modo tabela/i });
+    await user.click(tableButton);
     expect(mockChange).toHaveBeenCalledWith('table');
   });
 
@@ -243,12 +251,11 @@ describe('Componente DataVisualization', () => {
       />, { wrapper: createWrapper() }
     );
 
-    const row = screen.getAllByRole('row')[1];
-    const actionButtons = within(row).getAllByRole('button');
-    const menuButton = actionButtons[2];
+    const row = screen.getByRole('row', { name: /Item 1/i });
+    const menuButton = within(row).getByRole('button', { name: /mais ações/i });
     await user.click(menuButton);
 
-    const menuItem = await screen.findByText('Ver');
+    const menuItem = await screen.findByRole('menuitem', { name: /Ver/i });
     await user.click(menuItem);
 
     expect(extraAction).toHaveBeenCalledWith(mockData[0]);

--- a/tests/components/MarketplaceHierarchyCard.test.tsx
+++ b/tests/components/MarketplaceHierarchyCard.test.tsx
@@ -75,21 +75,27 @@ describe('MarketplaceHierarchyCard', () => {
       />
     );
 
-    const buttons = screen.getAllByRole('button');
-
-    await user.click(buttons[0]);
+    await user.click(
+      screen.getByRole('button', { name: /Editar plataforma/i })
+    );
     expect(onEditPlatform).toHaveBeenCalledWith(hierarchy.parent);
 
-    await user.click(buttons[1]);
+    await user.click(
+      screen.getByRole('button', { name: /Excluir plataforma/i })
+    );
     expect(onDeletePlatform).toHaveBeenCalledWith('platform-1');
 
     await user.click(screen.getByRole('button', { name: /Nova Modalidade/i }));
     expect(onAddModality).toHaveBeenCalledWith('platform-1');
 
-    await user.click(buttons[3]);
+    await user.click(
+      screen.getByRole('button', { name: /Editar Modalidade A/i })
+    );
     expect(onEditModality).toHaveBeenCalledWith(hierarchy.children[0]);
 
-    await user.click(buttons[4]);
+    await user.click(
+      screen.getByRole('button', { name: /Excluir Modalidade A/i })
+    );
     expect(onDeleteModality).toHaveBeenCalledWith('mod-1');
   });
 

--- a/tests/components/Sidebar.test.tsx
+++ b/tests/components/Sidebar.test.tsx
@@ -80,8 +80,9 @@ describe('AppSidebar accessibility', () => {
       </MemoryRouter>
     );
 
-    const [configButton] = screen.getAllByRole('button', { name: /configurações/i });
-    expect(configButton).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: /configurações/i })
+    ).not.toHaveLength(0);
   });
 
   it('allows keyboard navigation through items', async () => {
@@ -95,15 +96,19 @@ describe('AppSidebar accessibility', () => {
     );
 
     await user.tab();
-    const [dashboardLink] = screen.getAllByRole('link', { name: /dashboard/i });
-    expect(dashboardLink).toHaveFocus();
+    const dashboardLinks = screen.getAllByRole('link', { name: /dashboard/i });
+    expect(
+      dashboardLinks.some(link => link === document.activeElement)
+    ).toBe(true);
 
     await user.tab();
     expect(screen.getByRole('link', { name: /estratégia/i })).toHaveFocus();
 
     await user.tab();
-    const [configButton] = screen.getAllByRole('button', { name: /configurações/i });
-    expect(configButton).toHaveFocus();
+    const configButtons = screen.getAllByRole('button', { name: /configurações/i });
+    expect(
+      configButtons.some(btn => btn === document.activeElement)
+    ).toBe(true);
 
     await user.tab();
     expect(screen.getByRole('link', { name: /marketplaces/i })).toHaveFocus();


### PR DESCRIPTION
## Summary
- add accessible `aria-label`s to icon-only buttons
- refactor tests to query elements by role/text instead of index
- ensure sort assertions don't rely on row order indices

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Direct imports from "lucide-react" are only allowed within src/components/ui, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b3a164656c8329b6fd81e45a78e4b3