### PR TITLE
test: enforce coverage thresholds and update docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
     - name: Run tests
       run: npm run test:coverage
 
+    - name: Check coverage threshold
+      run: |
+        node -e "const fs=require('fs');const pct=JSON.parse(fs.readFileSync('coverage/coverage-summary.json')).total.lines.pct; if(pct < 80){console.error(`Coverage ${pct}% is below 80%`); process.exit(1);}" 
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,6 +38,8 @@ tests/
 
 ## 🎯 Cobertura de Testes
 
+A meta global de cobertura é **80%** para branches, funções, linhas e statements.
+
 ### Metas de Cobertura
 - **Services**: 90%+ (crítico para confiabilidade)
 - **Utils**: 90%+ (funções puras, fáceis de testar)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     setupFiles: ['./tests/setup.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'json-summary'],
       exclude: [
         'node_modules/',
         'tests/',
@@ -21,11 +21,33 @@ export default defineConfig({
         'src/components/ui/**', // shadcn components
       ],
       thresholds: {
-        global: {
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
+        'src/services/**': {
+          branches: 90,
+          functions: 90,
+          lines: 90,
+          statements: 90,
+        },
+        'src/utils/**': {
+          branches: 90,
+          functions: 90,
+          lines: 90,
+          statements: 90,
+        },
+        'src/hooks/**': {
           branches: 80,
           functions: 80,
           lines: 80,
           statements: 80,
+        },
+        'src/components/**': {
+          branches: 70,
+          functions: 70,
+          lines: 70,
+          statements: 70,
         },
       },
     },


### PR DESCRIPTION
## Summary
- enforce segmented coverage thresholds in Vitest config
- note global 80% coverage target in tests docs
- check coverage threshold in CI

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run type-check`
- `npm run test:coverage` *(fails: coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a3a9d68c8329a1d61b8f04835ee4