### PR TITLE
chore: add lint-staged and husky pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
 npx lint-staged


### PR DESCRIPTION
## Summary
- run husky via prepare script
- lint staged files with eslint
- document pre-commit linting workflow
- ensure husky pre-commit hook runs as executable shell script

## Testing
- `npm test` *(fails: CANCELLED Test run cancelled)*
- `npm run lint` *(fails: 114 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b3b10914c88329936f0e3601e1e59d