### PR TITLE
chore: add lint-staged and husky pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+
+if [ -f "$(dirname -- "$0")/_/husky.sh" ]; then
+  . "$(dirname -- "$0")/_/husky.sh"
+fi
 
 npx lint-staged


### PR DESCRIPTION
## Summary
- guard against missing husky shim in pre-commit hook

## Testing
- `npm test` *(pass: waiting for file changes, cancelled)*
- `npm run lint` *(fails: 114 problems)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b3b3c68f348329ae766b147a2695ba