### PR TITLE
test: add shared React Query wrapper

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -97,9 +97,12 @@ describe('useProducts', () => {
     // Mock do service
     vi.mocked(productsService.getAll).mockResolvedValue(mockData);
 
+    // Configura wrapper do React Query
+    const { wrapper } = createWrapper();
+
     // Render do hook
     const { result } = renderHook(() => useProducts(), {
-      wrapper: createWrapper(),
+      wrapper,
     });
 
     // Aguardar resultado

--- a/tests/components/DataVisualization.test.tsx
+++ b/tests/components/DataVisualization.test.tsx
@@ -1,22 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { testUtils } from '../setup';
+import { createWrapper } from '../utils/query-wrapper';
 import { DataVisualization } from '@/components/ui/data-visualization';
 
-const createWrapper = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
+const { wrapper, queryClient } = createWrapper();
 
-  return ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
-};
+afterEach(() => {
+  queryClient.clear();
+  queryClient.removeQueries();
+});
 
 describe('Componente DataVisualization', () => {
   beforeEach(() => {
@@ -39,7 +33,7 @@ describe('Componente DataVisualization', () => {
         title="Teste"
         data={mockData}
         columns={mockColumns}
-      />, { wrapper: createWrapper() }
+      />, { wrapper }
     );
 
     expect(screen.getByText('Nome')).toBeInTheDocument();
@@ -57,7 +51,7 @@ describe('Componente DataVisualization', () => {
         data={[]}
         columns={mockColumns}
         isLoading={true}
-      />, { wrapper: createWrapper() }
+      />, { wrapper }
     );
 
     expect(screen.getByText('Carregando...')).toBeInTheDocument();
@@ -75,7 +69,7 @@ describe('Componente DataVisualization', () => {
             <p>Adicione um item para começar</p>
           </div>
         )}
-      />, { wrapper: createWrapper() }
+      />, { wrapper }
     );
 
     expect(screen.getByText('Nenhum item encontrado')).toBeInTheDocument();
@@ -92,7 +86,7 @@ describe('Componente DataVisualization', () => {
         data={mockData}
         columns={mockColumns}
         actions={[{ label: 'Editar', onClick: mockAction }]}
-      />, { wrapper: createWrapper() }
+      />, { wrapper }
     );
 
     const row = screen.getByRole('row', { name: /Item 1/i });
@@ -116,7 +110,7 @@ describe('Componente DataVisualization', () => {
         title="Aninhado"
         data={nestedData}
         columns={nestedColumns}
-      />, { wrapper: createWrapper() }
+      />, { wrapper }
     );
 
     expect(screen.getByText('João')).toBeInTheDocument();
@@ -131,7 +125,7 @@ describe('Componente DataVisualization', () => {
         title="Busca"
         data={mockData}
         columns={mockColumns}
-      />, { wrapper: createWrapper() }
+      />, { wrapper }
     );
 
     const input = screen.getByPlaceholderText('Buscar...');
@@ -158,7 +152,7 @@ describe('Componente DataVisualization', () => {
         title="Ordenação"
         data={data}
         columns={columns}
-      />, { wrapper: createWrapper() }
+      />, { wrapper }
     );
 
     const header = screen.getByText('Nome');
@@ -193,7 +187,7 @@ describe('Componente DataVisualization', () => {
         data={data}
         columns={mockColumns}
         itemsPerPage={1}
-      />, { wrapper: createWrapper() }
+      />, { wrapper }
     );
 
     expect(screen.getByText('Item 1')).toBeInTheDocument();
@@ -222,7 +216,7 @@ describe('Componente DataVisualization', () => {
         columns={mockColumns}
         onViewModeChange={mockChange}
         viewMode="table"
-      />, { wrapper: createWrapper() }
+      />, { wrapper }
     );
 
     const gridButton = screen.getByRole('button', { name: /modo grade/i });
@@ -248,7 +242,7 @@ describe('Componente DataVisualization', () => {
           { label: 'Excluir', onClick: vi.fn() },
           { label: 'Ver', onClick: extraAction }
         ]}
-      />, { wrapper: createWrapper() }
+      />, { wrapper }
     );
 
     const row = screen.getByRole('row', { name: /Item 1/i });

--- a/tests/hooks/useProduct.test.tsx
+++ b/tests/hooks/useProduct.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { testUtils } from '../setup';
+import { createWrapper } from '../utils/query-wrapper';
 import { useProduct } from '@/hooks/useProducts';
 import { supabase } from '@/integrations/supabase/client';
 
@@ -11,18 +11,12 @@ vi.mock('@/integrations/supabase/client', () => ({
   },
 }));
 
-const createWrapper = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
+const { wrapper, queryClient } = createWrapper();
 
-  return ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
-};
+afterEach(() => {
+  queryClient.clear();
+  queryClient.removeQueries();
+});
 
 describe('useProduct', () => {
   beforeEach(() => {
@@ -42,7 +36,7 @@ describe('useProduct', () => {
     });
 
     const { result } = renderHook(() => useProduct('1'), {
-      wrapper: createWrapper(),
+      wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -65,7 +59,7 @@ describe('useProduct', () => {
     });
 
     const { result } = renderHook(() => useProduct('1'), {
-      wrapper: createWrapper(),
+      wrapper,
     });
 
     await waitFor(() => {

--- a/tests/hooks/useProductsWithCategories.test.tsx
+++ b/tests/hooks/useProductsWithCategories.test.tsx
@@ -1,24 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { testUtils } from '../setup';
+import { createWrapper } from '../utils/query-wrapper';
 import { useProductsWithCategories } from '@/hooks/useProducts';
 import { productsService } from '@/services/products';
 
 vi.mock('@/services/products');
 
-const createWrapper = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
+const { wrapper, queryClient } = createWrapper();
 
-  return ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
-};
+afterEach(() => {
+  queryClient.clear();
+  queryClient.removeQueries();
+});
 
 describe('useProductsWithCategories', () => {
   beforeEach(() => {
@@ -41,7 +35,7 @@ describe('useProductsWithCategories', () => {
     vi.mocked(productsService.getAllWithCategories).mockResolvedValue(mockProducts);
 
     const { result } = renderHook(() => useProductsWithCategories(), {
-      wrapper: createWrapper(),
+      wrapper,
     });
 
     expect(result.current.isLoading).toBe(true);
@@ -59,7 +53,7 @@ describe('useProductsWithCategories', () => {
     vi.mocked(productsService.getAllWithCategories).mockRejectedValue(mockError);
 
     const { result } = renderHook(() => useProductsWithCategories(), {
-      wrapper: createWrapper(),
+      wrapper,
     });
 
     await waitFor(() => {

--- a/tests/utils/query-wrapper.tsx
+++ b/tests/utils/query-wrapper.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { wrapper, queryClient };
+};


### PR DESCRIPTION
## Summary
- extract React Query wrapper into reusable test utility
- clear React Query cache after each test
- update tests to use shared wrapper

## Testing
- `npx eslint tests/hooks/useProducts.test.tsx tests/hooks/useProduct.test.tsx tests/hooks/useProductsWithCategories.test.tsx tests/components/DataVisualization.test.tsx tests/utils/query-wrapper.tsx tests/README.md`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3b4fff2608329b64fcdefe72905f5