### PR TITLE
feat: add ML product resync methods and hook

### DIFF
--- a/README-ML-INTEGRATION.md
+++ b/README-ML-INTEGRATION.md
@@ -28,7 +28,7 @@ src/
 │   ├── useMLIntegration.ts             # Hook principal
 │   ├── useMLAuth.ts                    # Autenticação
 │   ├── useMLSync.ts                    # Sincronização
-│   └── useMLResync.ts                  # Re-sincronização
+│   └── useMLProductResync.ts           # Re-sincronização
 ├── services/ml-service.ts              # Serviço principal
 ├── utils/ml/ml-api.ts                  # Rate limiting e utilitários
 └── types/                              # Tipos TypeScript

--- a/src/hooks/useMLProductResync.ts
+++ b/src/hooks/useMLProductResync.ts
@@ -11,14 +11,14 @@ interface ResyncBatchParams {
   productIds: string[];
 }
 
-export function useMLResync() {
+export function useMLProductResync() {
   const queryClient = useQueryClient();
 
   const resyncProduct = useMutation({
     mutationFn: async (params: ResyncProductParams) => {
       console.log('Re-syncing product:', params.productId);
       
-      return await MLService.syncProduct(params.productId);
+      return await MLService.resyncProduct(params.productId);
     },
     onSuccess: (data, variables) => {
       // Invalidar caches relevantes
@@ -46,7 +46,7 @@ export function useMLResync() {
     mutationFn: async (params: ResyncBatchParams) => {
       console.log('Re-syncing batch:', params.productIds.length, 'products');
       
-      return await MLService.syncBatch(params.productIds);
+      return await MLService.resyncBatch(params.productIds);
     },
     onSuccess: (data) => {
       // Invalidar caches relevantes

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -9,7 +9,7 @@ import { formatarMoeda } from "@/utils/pricing";
 import { useProduct } from "@/hooks/useProducts";
 import type { ProductWithCategory } from "@/types/products";
 import { useMLProducts } from "@/hooks/useMLProducts";
-import { useMLResync } from "@/hooks/useMLResync";
+import { useMLProductResync } from "@/hooks/useMLProductResync";
 import { useProductImages } from "@/hooks/useProductImages";
 import { ProductSourceBadge } from "@/components/common/ProductSourceBadge";
 import { useGlobalModal } from "@/hooks/useGlobalModal";
@@ -26,7 +26,7 @@ export default function ProductDetail() {
   const product = productData as ProductWithCategory;
   const { data: mlProducts = [] } = useMLProducts();
   const { data: productImages = [] } = useProductImages(id!);
-  const { resyncProduct } = useMLResync();
+  const { resyncProduct } = useMLProductResync();
 
   if (productLoading) {
     return (

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -12,7 +12,7 @@ import { ProductModalForm } from "@/components/forms/ProductModalForm";
 import { ProductSourceBadge } from "@/components/common/ProductSourceBadge";
 import { useMLIntegration, useMLSync } from "@/hooks/useMLIntegration";
 import { useMLProducts } from "@/hooks/useMLProducts";
-import { useMLResync } from "@/hooks/useMLResync";
+import { useMLProductResync } from "@/hooks/useMLProductResync";
 import { MLAdvertiseModal } from "@/components/forms/MLAdvertiseModal";
 import { MLConflictModal } from "@/components/forms/MLConflictModal";
 import type { MLSyncProduct } from "@/services/ml-service";
@@ -22,7 +22,7 @@ export default function Products() {
   const { data: products = [], isLoading } = useProductsWithCategories();
   const { data: mlProducts = [] } = useMLProducts();
   const { importFromML } = useMLSync();
-  const { resyncProduct } = useMLResync();
+  const { resyncProduct } = useMLProductResync();
   const deleteMutation = useDeleteProduct();
   const { showFormModal, showConfirmModal } = useGlobalModal();
 

--- a/src/services/ml-service.ts
+++ b/src/services/ml-service.ts
@@ -214,6 +214,33 @@ export class MLService {
     };
   }
 
+  static async resyncProduct(productId: string): Promise<void> {
+    const { error } = await supabase.functions.invoke('ml-sync-v2', {
+      body: { action: 'resync_product', product_id: productId }
+    });
+
+    if (error) {
+      throw new Error(error.message || 'Failed to re-sync product');
+    }
+  }
+
+  static async resyncBatch(productIds: string[]): Promise<MLBatchSyncResult> {
+    let successful = 0;
+    let failed = 0;
+
+    for (const id of productIds) {
+      try {
+        await MLService.resyncProduct(id);
+        successful++;
+      } catch (err) {
+        console.error('Failed to re-sync product:', id, err);
+        failed++;
+      }
+    }
+
+    return { successful, failed };
+  }
+
   static async importFromML(): Promise<{ imported: number; items: any[] }> {
     const { data, error } = await supabase.functions.invoke('ml-sync-v2', {
       body: { action: 'import_from_ml' }


### PR DESCRIPTION
## Summary
- add MLService.resyncProduct/resyncBatch to call ml-sync-v2 resync edge function
- replace useMLResync with useMLProductResync hook using new service methods
- update product pages and docs to use renamed resync hook

## Testing
- `npm test` *(fails: Tests failed)*
- `npm run lint` *(fails: 97 errors, 4 warnings)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b447a2839c832981990076cfc303a3