### PR TITLE
fix: send camelCase productId for resync

### DIFF
--- a/src/services/ml-service.ts
+++ b/src/services/ml-service.ts
@@ -216,7 +216,7 @@ export class MLService {
 
   static async resyncProduct(productId: string): Promise<void> {
     const { error } = await supabase.functions.invoke('ml-sync-v2', {
-      body: { action: 'resync_product', product_id: productId }
+      body: { action: 'resync_product', productId }
     });
 
     if (error) {

--- a/tests/services/ml-service.test.ts
+++ b/tests/services/ml-service.test.ts
@@ -67,9 +67,9 @@ describe('MLService', () => {
     });
 
     it('deve sincronizar em lote', async () => {
-      testUtils.mockSupabaseClient.functions.invoke.mockResolvedValue({ 
-        data: { successful: 3, failed: 1 }, 
-        error: null 
+      testUtils.mockSupabaseClient.functions.invoke.mockResolvedValue({
+        data: { successful: 3, failed: 1 },
+        error: null
       });
 
       const result = await MLService.syncBatch(['p1', 'p2', 'p3', 'p4']);
@@ -81,10 +81,23 @@ describe('MLService', () => {
       });
     });
 
+    it('deve re-sincronizar produto', async () => {
+      testUtils.mockSupabaseClient.functions.invoke.mockResolvedValue({
+        data: null,
+        error: null
+      });
+
+      await MLService.resyncProduct('product-123');
+
+      expect(testUtils.mockSupabaseClient.functions.invoke).toHaveBeenCalledWith('ml-sync-v2', {
+        body: { action: 'resync_product', productId: 'product-123' }
+      });
+    });
+
     it('deve importar do ML', async () => {
-      testUtils.mockSupabaseClient.functions.invoke.mockResolvedValue({ 
-        data: { imported: 5, items: [] }, 
-        error: null 
+      testUtils.mockSupabaseClient.functions.invoke.mockResolvedValue({
+        data: { imported: 5, items: [] },
+        error: null
       });
 
       const result = await MLService.importFromML();


### PR DESCRIPTION
## Summary
- send `productId` in MLService.resyncProduct to match edge handler
- cover resyncProduct request shape with unit test

## Testing
- `npm test` *(fails: Test timed out, other failures)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b44a0dcc148329bd44033b06874abe