### PR TITLE
refactor: centralize ML function calls

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -25,6 +25,7 @@ const mockSupabaseClient = {
   rpc: vi.fn(),
   auth: {
     getUser: vi.fn(),
+    getSession: vi.fn(),
     signIn: vi.fn(),
     signOut: vi.fn(),
     signInWithPassword: vi.fn(),


### PR DESCRIPTION
## Summary
- route ML service actions through shared callMLFunction helper
- add session-based auth headers and improved timeout handling
- update tests to mock callMLFunction

## Testing
- `npx vitest run`
- `npm run type-check`
- `npm run lint` *(fails: Unexpected any in existing test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b4535abc048329aade69b66c702895