### PR TITLE
fix: surface ML function error details

### DIFF
--- a/src/utils/ml/ml-api.ts
+++ b/src/utils/ml/ml-api.ts
@@ -98,7 +98,18 @@ export async function callMLFunction(
     
     if (error) {
       console.error(`[ML API] Error in ${action}:`, error);
-      throw new Error(error.message || `Erro na operação ${action}`);
+
+      interface InvokeError {
+        message?: string;
+        details?: { message?: string };
+        error?: { message?: string };
+      }
+
+      const invokeError = error as InvokeError;
+      const details = invokeError.details || invokeError.error;
+      const message = details?.message || invokeError.message || `Erro na operação ${action}`;
+
+      throw new Error(message);
     }
     
     // Registrar a chamada como sucesso


### PR DESCRIPTION
## Summary
- improve callMLFunction to surface edge-function error details
- test MLService error propagation when details are returned

## Testing
- `npm test -- --run`
- `npx eslint src/utils/ml/ml-api.ts tests/services/ml-service.test.ts`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b466b4d0a8832984473a658ba5c4c1