### PR TITLE
feat: validate ML product fields before syncing

### DIFF
--- a/src/components/ml/MLProductList.tsx
+++ b/src/components/ml/MLProductList.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Package, ExternalLink, RefreshCw, Play, Loader2 } from "@/components/ui/icons";
 import { useMLSync } from "@/hooks/useMLIntegration";
 import { useMLProducts } from "@/hooks/useMLProducts";
+import { toast } from "@/hooks/use-toast";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { formatDistanceToNow } from "date-fns";
 import { ptBR } from "date-fns/locale";
@@ -34,6 +35,27 @@ export function MLProductList() {
   };
 
   const handleSyncProduct = (productId: string) => {
+    const product = (products || []).find(p => p.id === productId);
+    if (!product) return;
+
+    const missingFields: string[] = [];
+    if (!product.name) missingFields.push('nome');
+    if (!product.sku) missingFields.push('SKU');
+    if (!product.description) missingFields.push('descrição');
+    if (product.cost_unit == null || product.cost_unit <= 0) {
+      missingFields.push('custo unitário');
+    }
+    if (!product.image_url) missingFields.push('imagem');
+
+    if (missingFields.length > 0) {
+      toast({
+        title: 'Campos obrigatórios ausentes',
+        description: `Preencha: ${missingFields.join(', ')}`,
+        variant: 'destructive',
+      });
+      return;
+    }
+
     syncProduct.mutate(productId);
   };
 

--- a/src/services/ml-service.ts
+++ b/src/services/ml-service.ts
@@ -27,6 +27,9 @@ export interface MLSyncProduct {
   id: string;
   name: string;
   sku?: string;
+  description?: string;
+  cost_unit?: number;
+  image_url?: string;
   ml_item_id?: string | null;
   ml_permalink?: string | null;
   sync_status: 'pending' | 'syncing' | 'synced' | 'error' | 'not_synced';

--- a/tests/components/MLProductList.test.tsx
+++ b/tests/components/MLProductList.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MLProductList } from '@/components/ml/MLProductList';
+import { toast } from '@/hooks/use-toast';
+
+vi.mock('@/hooks/useMLProducts', () => ({
+  useMLProducts: vi.fn(),
+}));
+
+vi.mock('@/hooks/useMLIntegration', () => ({
+  useMLSync: vi.fn(),
+}));
+
+import { useMLProducts } from '@/hooks/useMLProducts';
+import { useMLSync } from '@/hooks/useMLIntegration';
+
+describe('MLProductList', () => {
+  it('should not call sync when required fields are missing', () => {
+    const mutate = vi.fn();
+    (useMLProducts as vi.Mock).mockReturnValue({
+      data: [
+        {
+          id: '1',
+          name: 'Produto Teste',
+          sync_status: 'not_synced',
+        },
+      ],
+      isLoading: false,
+    });
+    (useMLSync as vi.Mock).mockReturnValue({
+      syncProduct: { mutate, isPending: false },
+      syncBatch: { mutate: vi.fn(), isPending: false },
+    });
+
+    render(<MLProductList />);
+
+    const row = screen.getByText('Produto Teste').closest('tr')!;
+    const button = within(row).getByRole('button');
+    fireEvent.click(button);
+
+    expect(mutate).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: expect.stringContaining('SKU'),
+      })
+    );
+  });
+
+  it('should call sync when all required fields are present', () => {
+    const mutate = vi.fn();
+    (useMLProducts as vi.Mock).mockReturnValue({
+      data: [
+        {
+          id: '1',
+          name: 'Produto Completo',
+          sku: 'SKU-1',
+          description: 'desc',
+          cost_unit: 100,
+          image_url: 'http://example.com/img.jpg',
+          sync_status: 'not_synced',
+        },
+      ],
+      isLoading: false,
+    });
+    (useMLSync as vi.Mock).mockReturnValue({
+      syncProduct: { mutate, isPending: false },
+      syncBatch: { mutate: vi.fn(), isPending: false },
+    });
+
+    render(<MLProductList />);
+
+    const row = screen.getByText('Produto Completo').closest('tr')!;
+    const button = within(row).getByRole('button');
+    fireEvent.click(button);
+
+    expect(mutate).toHaveBeenCalledWith('1');
+  });
+});
+


### PR DESCRIPTION
## Summary
- prevent ML sync when product lacks required data
- add tests for sync field validation

## Testing
- `npx vitest run tests/components/MLProductList.test.tsx`
- `npx vitest run`
- `npm run lint` *(fails: Unexpected any, unused vars)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b468f2985883299f9f17f102fb831a