### PR TITLE
fix: avoid description wipe on ML API failure

### DIFF
--- a/supabase/functions/ml-webhook/updateProductFromItem.test.ts
+++ b/supabase/functions/ml-webhook/updateProductFromItem.test.ts
@@ -65,6 +65,25 @@ describe('updateProductFromItem', () => {
     expect(productsQuery.update).toHaveBeenCalled();
     expect(productsQuery.eq).toHaveBeenCalledWith('id', 'prod-1');
     expect(productsQuery.eq).toHaveBeenCalledWith('tenant_id', 'tenant1');
-    expect(fields).toEqual(['sku', 'description', 'attributes', 'pictures', 'stock']);
+    expect(fields).toEqual(['sku', 'attributes', 'pictures', 'stock', 'description']);
+  });
+
+  it('skips description update when fetch fails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = vi.fn().mockResolvedValue({ ok: false });
+
+    const itemData = {
+      id: 'ML2',
+      seller_sku: 'SKU2',
+      attributes: [],
+      pictures: [{ url: 'pic2' }],
+      available_quantity: 5,
+    };
+
+    const fields = await updateProductFromItem(supabase, 'tenant1', itemData, 'token');
+
+    const updateArg = productsQuery.update.mock.calls[0][0];
+    expect(updateArg).not.toHaveProperty('description');
+    expect(fields).toEqual(['sku', 'attributes', 'pictures', 'stock']);
   });
 });


### PR DESCRIPTION
## Summary
- avoid clearing product description if MercadoLibre description fetch fails
- add tests for skipping description update when fetch fails

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any etc. in unrelated files)*
- `npx eslint supabase/functions/ml-webhook/index.ts supabase/functions/ml-webhook/updateProductFromItem.ts supabase/functions/ml-webhook/updateProductFromItem.test.ts`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b5b33c6c708329a7ef456548cd94b4