### PR TITLE
fix: parse ML error context

### DIFF
--- a/tests/utils/ml-api.test.ts
+++ b/tests/utils/ml-api.test.ts
@@ -108,6 +108,22 @@ describe('ML API Utils', () => {
 
       await expect(callMLFunction('ml-sync-v2', 'sync_product', { productId: '123' })).rejects.toThrow('Token do Mercado Livre expirado ou inválido');
     });
+
+    it('deve extrair erro do contexto quando FunctionsHttpError é retornado', async () => {
+      const context = {
+        text: vi.fn().mockResolvedValue(JSON.stringify({ error: 'Missing required fields' }))
+      };
+
+      testUtils.mockSupabaseClient.functions.invoke.mockResolvedValue({
+        data: null,
+        error: { name: 'FunctionsHttpError', context }
+      });
+
+      await expect(
+        callMLFunction('ml-sync-v2', 'sync_product', { productId: '123' })
+      ).rejects.toThrow('Missing required fields');
+      expect(context.text).toHaveBeenCalled();
+    });
   });
 
   describe('processInBatches', () => {


### PR DESCRIPTION
## 🎯 Descrição
- parse FunctionsHttpError context to surface ML API payload errors
- add test for missing-field error extraction

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [x] Testes adicionados/atualizados
- [ ] Documentação atualizada
- [ ] Edge Function deployável
- [x] Logs de debug implementados

## 🧪 Testes
- `npm run lint`
- `npm run type-check`
- `npm test` (pass)
- `npm test -- --run` (fails: Sidebar.test.tsx timeout)

## 📋 Próximos Passos
- investigar falha em `Sidebar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b5de10bf548329b6f34c96b17373ef