### PR TITLE
feat: add ML import button in product list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ O desenvolvimento desta integração foi acelerado utilizando uma metodologia de
 *   **Sincronização Automática de Estoque**: Mantenha o estoque consistente entre o Catalog Maker Hub e o Mercado Livre para evitar overselling.
 *   **Dashboard de Integração**: Monitore o status da sua conexão, logs de sincronização e muito mais.
 
+### Fluxos de Sincronização
+
+*   **Enviar ao Mercado Livre**: envie produtos cadastrados no Catalog Maker Hub para criar ou atualizar anúncios no ML. Disponível individualmente pelo botão "Enviar ao Mercado Livre" ou em lote selecionando vários produtos.
+*   **Importar do ML**: traga dados de anúncios existentes no Mercado Livre para o Catalog Maker Hub quando um produto ainda não possui `ml_item_id`.
+
 ---
 
 ## 🚀 Começando

--- a/src/components/ml/MLProductList.tsx
+++ b/src/components/ml/MLProductList.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Package, ExternalLink, RefreshCw, Play, Loader2 } from "@/components/ui/icons";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useMLSync } from "@/hooks/useMLIntegration";
 import { useMLProducts } from "@/hooks/useMLProducts";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
@@ -13,7 +14,7 @@ import { useState } from "react";
 
 export function MLProductList() {
   const { data: products = [], isLoading } = useMLProducts();
-  const { syncProduct, syncBatch } = useMLSync();
+  const { syncProduct, syncBatch, importFromML } = useMLSync();
   
   const [selectedProducts, setSelectedProducts] = useState<string[]>([]);
 
@@ -178,18 +179,44 @@ export function MLProductList() {
                         const isProcessing = syncProduct.isPending;
                         const isLoading = syncProduct.isPending && syncProduct.variables === product.id;
                         return (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleSyncProduct(product.id)}
-                            disabled={isProcessing}
-                          >
-                            {isLoading ? (
-                              <Loader2 className="size-4 animate-spin" />
-                            ) : (
-                              <RefreshCw className="size-4" />
+                          <div className="flex gap-2">
+                            {!product.ml_item_id && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => importFromML.mutate()}
+                                disabled={importFromML.isPending}
+                              >
+                                {importFromML.isPending && (
+                                  <Loader2 className="mr-2 size-4 animate-spin" />
+                                )}
+                                Importar do ML
+                              </Button>
                             )}
-                          </Button>
+
+                            <TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => handleSyncProduct(product.id)}
+                                    disabled={isProcessing}
+                                    aria-label="Enviar ao Mercado Livre"
+                                  >
+                                    {isLoading ? (
+                                      <Loader2 className="size-4 animate-spin" />
+                                    ) : (
+                                      <RefreshCw className="size-4" />
+                                    )}
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  Enviar ao Mercado Livre
+                                </TooltipContent>
+                              </Tooltip>
+                            </TooltipProvider>
+                          </div>
                         );
                       })()}
                     </TableCell>

--- a/tests/components/MLProductList.test.tsx
+++ b/tests/components/MLProductList.test.tsx
@@ -29,12 +29,13 @@ describe('MLProductList', () => {
     (useMLSync as vi.Mock).mockReturnValue({
       syncProduct: { mutate: syncMutate, isPending: false },
       syncBatch: { mutate: vi.fn(), isPending: false },
+      importFromML: { mutate: vi.fn(), isPending: false },
     });
 
     render(<MLProductList />);
 
     const row = screen.getByText('Produto Teste').closest('tr')!;
-    const button = within(row).getByRole('button');
+    const button = within(row).getByLabelText('Enviar ao Mercado Livre');
     fireEvent.click(button);
 
     expect(syncMutate).toHaveBeenCalledWith('1');
@@ -59,14 +60,42 @@ describe('MLProductList', () => {
     (useMLSync as vi.Mock).mockReturnValue({
       syncProduct: { mutate: syncMutate, isPending: false },
       syncBatch: { mutate: vi.fn(), isPending: false },
+      importFromML: { mutate: vi.fn(), isPending: false },
     });
 
     render(<MLProductList />);
 
     const row = screen.getByText('Produto Completo').closest('tr')!;
-    const button = within(row).getByRole('button');
+    const button = within(row).getByLabelText('Enviar ao Mercado Livre');
     fireEvent.click(button);
 
     expect(syncMutate).toHaveBeenCalledWith('1');
+  });
+
+  it('should call importFromML when clicking Importar do ML', () => {
+    const importMutate = vi.fn();
+    (useMLProducts as vi.Mock).mockReturnValue({
+      data: [
+        {
+          id: '1',
+          name: 'Produto sem ML',
+          sync_status: 'not_synced',
+        },
+      ],
+      isLoading: false,
+    });
+    (useMLSync as vi.Mock).mockReturnValue({
+      syncProduct: { mutate: vi.fn(), isPending: false },
+      syncBatch: { mutate: vi.fn(), isPending: false },
+      importFromML: { mutate: importMutate, isPending: false },
+    });
+
+    render(<MLProductList />);
+
+    const row = screen.getByText('Produto sem ML').closest('tr')!;
+    const button = within(row).getByRole('button', { name: /importar do ml/i });
+    fireEvent.click(button);
+
+    expect(importMutate).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 🎯 Descrição
- adiciona botão "Importar do ML" para produtos sem `ml_item_id`
- renomeia ação de sincronização para "Enviar ao Mercado Livre" com tooltip
- documenta fluxos de envio e importação no README

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [x] Testes adicionados/atualizados
- [x] Documentação atualizada

## 🧪 Testes
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b621e8d788832994e54e674b725613