### PR TITLE
fix: scope ML import to global control

### DIFF
--- a/src/components/ml/MLProductList.tsx
+++ b/src/components/ml/MLProductList.tsx
@@ -82,20 +82,33 @@ export function MLProductList() {
             </div>
           </div>
           
-          {selectedProducts.length > 0 && (
+          <div className="flex gap-2">
             <Button
-              onClick={handleSyncBatch}
-              disabled={syncBatch.isPending || syncProduct.isPending}
+              onClick={() => importFromML.mutate()}
+              disabled={importFromML.isPending}
               size="sm"
             >
-              {syncBatch.isPending || syncProduct.isPending ? (
+              {importFromML.isPending && (
                 <Loader2 className="mr-2 size-4 animate-spin" />
-              ) : (
-                <Play className="mr-2 size-4" />
               )}
-              Sincronizar Selecionados ({selectedProducts.length})
+              Importar do ML
             </Button>
-          )}
+
+            {selectedProducts.length > 0 && (
+              <Button
+                onClick={handleSyncBatch}
+                disabled={syncBatch.isPending || syncProduct.isPending}
+                size="sm"
+              >
+                {syncBatch.isPending || syncProduct.isPending ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : (
+                  <Play className="mr-2 size-4" />
+                )}
+                Sincronizar Selecionados ({selectedProducts.length})
+              </Button>
+            )}
+          </div>
         </div>
       </CardHeader>
       
@@ -180,20 +193,6 @@ export function MLProductList() {
                         const isLoading = syncProduct.isPending && syncProduct.variables === product.id;
                         return (
                           <div className="flex gap-2">
-                            {!product.ml_item_id && (
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => importFromML.mutate()}
-                                disabled={importFromML.isPending}
-                              >
-                                {importFromML.isPending && (
-                                  <Loader2 className="mr-2 size-4 animate-spin" />
-                                )}
-                                Importar do ML
-                              </Button>
-                            )}
-
                             <TooltipProvider>
                               <Tooltip>
                                 <TooltipTrigger asChild>

--- a/tests/components/MLProductList.test.tsx
+++ b/tests/components/MLProductList.test.tsx
@@ -92,8 +92,7 @@ describe('MLProductList', () => {
 
     render(<MLProductList />);
 
-    const row = screen.getByText('Produto sem ML').closest('tr')!;
-    const button = within(row).getByRole('button', { name: /importar do ml/i });
+    const button = screen.getByRole('button', { name: /importar do ml/i });
     fireEvent.click(button);
 
     expect(importMutate).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- move "Importar do ML" button to card header so import runs once
- remove per-row ML import button and adjust tests

## Testing
- `npm run lint` *(fails: Unexpected any in tests/services)*
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b624191a148329827703e28b6dbacb