### PR TITLE
fix: include React component types in onboarding tour

### DIFF
--- a/src/components/onboarding/OnboardingTour.tsx
+++ b/src/components/onboarding/OnboardingTour.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ComponentType, type SVGProps } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -10,7 +10,7 @@ interface OnboardingStep {
   id: string;
   title: string;
   description: string;
-    icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+    icon: ComponentType<SVGProps<SVGSVGElement>>;
   completed: boolean;
   action?: {
     label: string;


### PR DESCRIPTION
## Summary
- include React `ComponentType` and `SVGProps` in onboarding tour import
- use React types without global `React` namespace

## Testing
- `npm run lint` (fails: Unexpected any in tests)
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b627cb86748329a58ad0d3ec1a4d6d