### PR TITLE
refactor: use internal icon components

### DIFF
--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle } from '@/components/ui/icons';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 

--- a/src/components/common/ProductSourceBadge.tsx
+++ b/src/components/common/ProductSourceBadge.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Badge } from "@/components/ui/badge";
-import { ShoppingCart, Store, Package, ExternalLink, CheckCircle2, AlertCircle } from "lucide-react";
+import { ShoppingCart, Store, Package, ExternalLink, CheckCircle2, AlertCircle } from "@/components/ui/icons";
 
 interface ProductSourceBadgeProps {
   source: 'manual' | 'mercado_livre' | 'shopee';

--- a/src/components/forms/MLConflictModal.tsx
+++ b/src/components/forms/MLConflictModal.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect } from "react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { ExternalLink, Package, AlertTriangle } from "lucide-react";
+import { ExternalLink, Package, AlertTriangle } from "@/components/ui/icons";
 import type { ProductWithCategory } from "@/types/products";
 import type { MLSyncProduct } from "@/services/ml-service";
 
@@ -84,7 +83,10 @@ export function MLConflictModal({ product, conflicts, onSuccess, onSubmitForm }:
 
       <div className="space-y-4">
         <h4 className="font-medium">Como deseja proceder?</h4>
-        <RadioGroup value={resolution} onValueChange={(value: any) => setResolution(value)}>
+        <RadioGroup
+          value={resolution}
+          onValueChange={(value: 'link' | 'create_new' | 'cancel') => setResolution(value)}
+        >
           <div className="flex items-center space-x-2">
             <RadioGroupItem value="link" id="link" />
             <Label htmlFor="link" className="flex-1">

--- a/src/components/forms/MLSyncSettingsModal.tsx
+++ b/src/components/forms/MLSyncSettingsModal.tsx
@@ -1,13 +1,12 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { Settings, Clock, Shield, Zap } from "lucide-react";
+import { Settings, Clock, Shield } from "@/components/ui/icons";
 import { useEffect } from "react";
 
 const syncSettingsSchema = z.object({


### PR DESCRIPTION
## Summary
- import icons from our `@/components/ui/icons` wrapper
- clean up unused imports and types

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors in existing test files)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b62cdd81288329bd381f6a0c793b39