### PR TITLE
fix: remove items from ML import result

### DIFF
--- a/src/services/ml-service.ts
+++ b/src/services/ml-service.ts
@@ -214,12 +214,11 @@ export class MLService {
     return { successful, failed };
   }
 
-  static async importFromML(): Promise<{ imported: number; items: unknown[] }> {
-    const data = await callMLFunction('ml-sync-v2', 'import_from_ml', {}, {}) as { imported?: number; items?: unknown[] };
+  static async importFromML(): Promise<{ imported: number }> {
+    const data = await callMLFunction('ml-sync-v2', 'import_from_ml', {}, {}) as { imported?: number };
 
     return {
-      imported: data?.imported || 0,
-      items: data?.items || []
+      imported: data?.imported || 0
     };
   }
 

--- a/tests/services/ml-service.test.ts
+++ b/tests/services/ml-service.test.ts
@@ -84,7 +84,7 @@ describe('MLService', () => {
     });
 
     it('deve importar do ML', async () => {
-      vi.mocked(callMLFunction).mockResolvedValue({ imported: 5, items: [] });
+      vi.mocked(callMLFunction).mockResolvedValue({ imported: 5 });
 
       const result = await MLService.importFromML();
 


### PR DESCRIPTION
## Summary
- remove unused items array from ML import service return
- update ML service tests for new importFromML contract

## Testing
- `npm run lint` *(fails: Unexpected any in tests)*
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63d608f78832989f63c2a6a2206d7