### PR TITLE
feat: store ML variations during import

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -825,6 +825,7 @@ export type Database = {
           ml_sold_quantity: number | null
           ml_stock_quantity: number | null
           ml_variation_id: string | null
+          ml_variations: Json | null
           model: string | null
           name: string
           packaging_cost: number | null
@@ -851,6 +852,7 @@ export type Database = {
           ml_sold_quantity?: number | null
           ml_stock_quantity?: number | null
           ml_variation_id?: string | null
+          ml_variations?: Json | null
           model?: string | null
           name: string
           packaging_cost?: number | null
@@ -877,6 +879,7 @@ export type Database = {
           ml_sold_quantity?: number | null
           ml_stock_quantity?: number | null
           ml_variation_id?: string | null
+          ml_variations?: Json | null
           model?: string | null
           name?: string
           packaging_cost?: number | null

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -111,11 +111,8 @@ export default function ProductDetail() {
     ? (product.ml_attributes as MLAttribute[])
     : [];
 
-  const variations: MLVariation[] = Array.isArray(
-    (product.ml_attributes as { variations?: MLVariation[] })?.variations
-  )
-    ? ((product.ml_attributes as { variations?: MLVariation[] })
-        .variations as MLVariation[])
+  const variations: MLVariation[] = Array.isArray(product.ml_variations)
+    ? (product.ml_variations as MLVariation[])
     : [];
 
   const mlProduct = mlProducts.find(ml => ml.id === product.id);

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -14,8 +14,8 @@ export interface ProductType {
   updated_at: string;
   // Novos campos ML
   ml_stock_quantity?: number;
-  ml_attributes?: any;
-  dimensions?: any;
+  ml_attributes?: unknown;
+  dimensions?: unknown;
   weight?: number;
   warranty?: string;
   brand?: string;
@@ -24,7 +24,8 @@ export interface ProductType {
   ml_available_quantity?: number;
   ml_sold_quantity?: number;
   ml_variation_id?: string;
-  ml_pictures?: any[];
+  ml_variations?: unknown[];
+  ml_pictures?: unknown[];
 }
 
 export interface ProductWithCategory extends ProductType {

--- a/supabase/functions/ml-sync-v2/actions/importFromML.ts
+++ b/supabase/functions/ml-sync-v2/actions/importFromML.ts
@@ -228,6 +228,7 @@ export async function importFromML(
           ml_available_quantity: itemDetail.available_quantity || 0,
           ml_sold_quantity: itemDetail.sold_quantity || 0,
           ml_variation_id: itemDetail.variation_id || null,
+          ml_variations: itemDetail.variations || [],
           ml_pictures: itemDetail.pictures || [],
         })
         .select()

--- a/tests/actions/importFromML.test.ts
+++ b/tests/actions/importFromML.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { importFromML } from '../../supabase/functions/ml-sync-v2/actions/importFromML.ts';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe('importFromML action', () => {
+  it('should save variations in product record', async () => {
+    const itemData = {
+      id: 'MLA1',
+      title: 'Test Item',
+      attributes: [],
+      price: 100,
+      available_quantity: 10,
+      sold_quantity: 0,
+      seller_sku: 'SELLER',
+      variations: [{ id: 'VAR1', attribute_combinations: [] }],
+      pictures: [],
+    } as any;
+
+    global.fetch = vi.fn((url: RequestInfo) => {
+      const urlStr = url.toString();
+      if (urlStr.includes('/items/search')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            results: ['MLA1'],
+            paging: { total: 1, offset: 0, limit: 50 },
+          }),
+        } as any);
+      }
+      if (urlStr.includes('/items/MLA1/description')) {
+        return Promise.resolve({ ok: true, json: async () => ({ plain_text: '' }) } as any);
+      }
+      if (urlStr.includes('/items/MLA1')) {
+        return Promise.resolve({ ok: true, json: async () => itemData } as any);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as any);
+    });
+
+    const productsTable = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 'prod1' }, error: null }),
+    };
+    const mappingTable = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    };
+    const mlSyncLogTable = { insert: vi.fn().mockResolvedValue({}) };
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'products') return productsTable;
+        if (table === 'ml_product_mapping') return mappingTable;
+        if (table === 'ml_sync_log') return mlSyncLogTable;
+        return {
+          upsert: vi.fn().mockReturnThis(),
+          select: vi.fn().mockReturnThis(),
+          single: vi.fn().mockReturnThis(),
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          insert: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockReturnThis(),
+          ilike: vi.fn().mockReturnThis(),
+        };
+      }),
+    } as any;
+
+    await importFromML({ action: 'import_from_ml' } as any, {
+      supabase,
+      tenantId: 'tenant1',
+      authToken: { user_id_ml: 'user1', access_token: 'token' } as any,
+    });
+
+    expect(productsTable.insert).toHaveBeenCalled();
+    const inserted = productsTable.insert.mock.calls[0][0];
+    expect(inserted.ml_variations).toEqual(itemData.variations);
+  });
+});


### PR DESCRIPTION
## Summary
- capture Mercado Livre variations when importing products
- expose new `ml_variations` field across types and UI
- test import flow to ensure variations are persisted

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: 54 errors, 4 warnings)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b644bff4108329852d349c098ad4c8