### PR TITLE
feat: normalize product weight units

### DIFF
--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -118,6 +118,13 @@ export default function ProductDetail() {
   const mlProduct = mlProducts.find(ml => ml.id === product.id);
   const hasIncompleteData = product.source === 'mercado_livre' && (!product.description || !product.sku || !product.brand);
 
+  const formatWeight = (w: number) => {
+    if (w >= 1000) {
+      return `${(w / 1000).toLocaleString('pt-BR', { maximumFractionDigits: 2 })} kg`;
+    }
+    return `${w.toLocaleString('pt-BR', { maximumFractionDigits: 2 })} g`;
+  };
+
   const handleEdit = () => {
     let submitForm: (() => Promise<void>) | null = null;
 
@@ -306,7 +313,7 @@ export default function ProductDetail() {
                         <Weight className="size-3" />
                         Peso
                       </label>
-                      <p>{product.weight} kg</p>
+                      <p>{formatWeight(product.weight)}</p>
                     </div>
                   )}
                   {product.dimensions?.length && (

--- a/tests/actions/importFromML.test.ts
+++ b/tests/actions/importFromML.test.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { importFromML } from '../../supabase/functions/ml-sync-v2/actions/importFromML.ts';
+import {
+  importFromML,
+  parseWeight,
+  weightToGrams,
+} from '../../supabase/functions/ml-sync-v2/actions/importFromML.ts';
 
 const originalFetch = global.fetch;
 
@@ -82,5 +86,18 @@ describe('importFromML action', () => {
     expect(productsTable.insert).toHaveBeenCalled();
     const inserted = productsTable.insert.mock.calls[0][0];
     expect(inserted.ml_variations).toEqual(itemData.variations);
+  });
+});
+
+describe('weight parsing', () => {
+  it.each([
+    ['500 g', 500],
+    ['0.5 kg', 500],
+    ['2kg', 2000],
+    ['1,2 kg', 1200],
+  ])('converts %s to %d grams', (input, expected) => {
+    const { value, unit } = parseWeight(input);
+    const grams = weightToGrams(value, unit);
+    expect(grams).toBeCloseTo(expected);
   });
 });


### PR DESCRIPTION
## 🎯 Descrição
- parse and normalize product weight from Mercado Livre into grams
- show formatted weight units in product detail page
- cover weight parsing with unit tests

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [x] Testes adicionados/atualizados
- [ ] Documentação atualizada
- [ ] Edge Function deployável
- [ ] Logs de debug implementados

## 🧪 Testes
- `npm test`
- `npm run lint` *(falhou: Unexpected any / unused vars em arquivos de teste existentes)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b64671657c83299124943c543f9d8f