### PR TITLE
feat: store ML variations during import

### DIFF
--- a/supabase/migrations/20250902002000_1cf6f37d-1471-49fc-8f23-ccf4bad9adbf.sql
+++ b/supabase/migrations/20250902002000_1cf6f37d-1471-49fc-8f23-ccf4bad9adbf.sql
@@ -1,0 +1,5 @@
+-- Adiciona coluna ml_variations na tabela products para armazenar dados de variações do Mercado Livre
+ALTER TABLE public.products
+ADD COLUMN IF NOT EXISTS ml_variations jsonb DEFAULT '[]';
+
+COMMENT ON COLUMN public.products.ml_variations IS 'Variações do produto no ML';


### PR DESCRIPTION
## Summary
- capture Mercado Livre variations when importing products
- expose new `ml_variations` field across types and UI
- test import flow to ensure variations are persisted
- add migration for `ml_variations` column

## Testing
- `npm run type-check`
- `npm run lint` *(fails: 54 errors, 4 warnings)*
- `npm test -- --run` *(fails: Sidebar test timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b64781c1f08329b597c954103b5ad3