### PR TITLE
fix: normalize weight on product resync

### DIFF
--- a/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ActionContext, ResyncProductRequest, errorResponse, corsHeaders } from '../types.ts';
+import {
+  ActionContext,
+  ResyncProductRequest,
+  errorResponse,
+  corsHeaders,
+} from '../types.ts';
+import { parseWeight, weightToGrams } from './importFromML.ts';
 
 export async function resyncProduct(
   req: ResyncProductRequest,
@@ -84,9 +90,14 @@ export async function resyncProduct(
         null,
     } as Record<string, any>;
 
-    const weight = parseFloat(
-      itemData.attributes?.find((attr: any) => attr.id === 'WEIGHT')?.value_name || '0'
+    const weightAttr = itemData.attributes?.find(
+      (attr: any) => attr.id === 'WEIGHT'
     );
+    let weight = 0;
+    if (weightAttr?.value_name) {
+      const { value, unit } = parseWeight(weightAttr.value_name);
+      weight = weightToGrams(value, unit);
+    }
 
     let skuToUse = itemData.seller_sku || '';
     if (!skuToUse && itemData.variations?.length > 0) {

--- a/tests/actions/resyncProduct.test.ts
+++ b/tests/actions/resyncProduct.test.ts
@@ -128,4 +128,71 @@ describe('resyncProduct action', () => {
     expect(updateArg.cost_unit).toBeUndefined();
     expect(updateArg.name).toBeUndefined();
   });
+
+  it('should normalize weight units to grams', async () => {
+    const itemData = {
+      id: 'MLA3',
+      title: 'Weighted Item',
+      price: 10,
+      attributes: [
+        {
+          id: 'WEIGHT',
+          value_name: '0.5 kg',
+        },
+      ],
+      available_quantity: 0,
+      sold_quantity: 0,
+      seller_sku: '',
+      variations: [],
+      pictures: [],
+    } as any;
+
+    global.fetch = vi.fn((url: RequestInfo) => {
+      if (url.toString().includes('/description')) {
+        return Promise.resolve({ ok: true, json: async () => ({ plain_text: '' }) } as any);
+      }
+      return Promise.resolve({ ok: true, json: async () => itemData } as any);
+    });
+
+    const productsTable = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      error: null,
+    };
+    const mappingTable = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { ml_item_id: 'MLA3', products: { id: 'prod3', cost_unit: 0 } },
+        error: null,
+      }),
+      update: vi.fn().mockReturnThis(),
+    };
+    const mlSyncLogTable = { insert: vi.fn().mockResolvedValue({}) };
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'ml_product_mapping') return mappingTable;
+        if (table === 'products') return productsTable;
+        if (table === 'ml_sync_log') return mlSyncLogTable;
+        return {
+          upsert: vi.fn().mockResolvedValue({}),
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+        };
+      }),
+    } as any;
+
+    await resyncProduct({ action: 'resync_product', productId: 'prod3' }, {
+      supabase,
+      tenantId: 'tenant1',
+      mlToken: 'token',
+      authToken: {},
+      mlClientId: 'test',
+      jwt: 'test'
+    });
+
+    const updateArg = productsTable.update.mock.calls[0][0];
+    expect(updateArg.weight).toBeCloseTo(500);
+  });
 });


### PR DESCRIPTION
## Summary
- normalize Mercado Livre weight units to grams when resyncing products
- add unit test covering weight normalization on resync

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / unused vars in existing test files)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b648971d288329b58ca09fa5a22f1d