### PR TITLE
feat: add ML advanced settings schema

### DIFF
--- a/src/hooks/useMLAdvancedSettings.ts
+++ b/src/hooks/useMLAdvancedSettings.ts
@@ -1,25 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "@/hooks/use-toast";
-
-export interface MLAdvancedSettings {
-  id: string;
-  tenant_id: string;
-  feature_flags: Record<string, any>;
-  rate_limits: {
-    sync_product: number;
-    sync_order: number;
-    token_refresh: number;
-    default: number;
-  };
-  backup_schedule: string;
-  auto_recovery_enabled: boolean;
-  advanced_monitoring: boolean;
-  multi_account_enabled: boolean;
-  security_level: string;
-  created_at: string;
-  updated_at: string;
-}
+import {
+  mlAdvancedSettingsSchema,
+  type MLAdvancedSettings,
+} from "@/types/ml/advanced-settings";
 
 export function useMLAdvancedSettings() {
   return useQuery({
@@ -32,7 +17,7 @@ export function useMLAdvancedSettings() {
         throw new Error(error.message);
       }
 
-      return data;
+      return mlAdvancedSettingsSchema.parse(data);
     },
     staleTime: 5 * 60 * 1000, // 5 minutos
     gcTime: 10 * 60 * 1000, // 10 minutos
@@ -43,7 +28,9 @@ export function useUpdateMLAdvancedSettings() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (settings: Partial<MLAdvancedSettings>): Promise<MLAdvancedSettings> => {
+    mutationFn: async (
+      settings: Partial<MLAdvancedSettings>
+    ): Promise<MLAdvancedSettings> => {
       const { data, error } = await supabase.rpc("update_ml_advanced_settings", {
         p_settings: settings,
       });
@@ -53,7 +40,7 @@ export function useUpdateMLAdvancedSettings() {
         throw new Error(error.message || "Falha ao atualizar configurações");
       }
 
-      return data;
+      return mlAdvancedSettingsSchema.parse(data);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["ml-advanced-settings"] });

--- a/src/services/ml-service.ts
+++ b/src/services/ml-service.ts
@@ -1,5 +1,9 @@
 import { supabase } from '@/integrations/supabase/client';
 import { callMLFunction } from '@/utils/ml/ml-api';
+import {
+  mlAdvancedSettingsSchema,
+  type MLAdvancedSettings,
+} from '@/types/ml/advanced-settings';
 
 // ==================== TIPOS ====================
 
@@ -58,20 +62,6 @@ export interface MLPerformanceMetrics {
   average_response_time: number;
   success_rate: number;
   operations_by_type: Record<string, number>;
-}
-
-export interface MLAdvancedSettings {
-  id: string;
-  tenant_id: string;
-  feature_flags: Record<string, boolean>;
-  rate_limits: Record<string, number>;
-  auto_recovery_enabled: boolean;
-  advanced_monitoring: boolean;
-  multi_account_enabled: boolean;
-  backup_schedule: string;
-  security_level: string;
-  created_at: string;
-  updated_at: string;
 }
 
 // ==================== SERVIÇO PRINCIPAL ====================
@@ -241,7 +231,7 @@ export class MLService {
       throw new Error(error.message || 'Failed to get advanced settings');
     }
 
-    return data;
+    return mlAdvancedSettingsSchema.parse(data);
   }
 
   static async updateAdvancedSettings(settings: Partial<MLAdvancedSettings>): Promise<MLAdvancedSettings> {
@@ -253,7 +243,7 @@ export class MLService {
       throw new Error(error.message || 'Failed to update advanced settings');
     }
 
-    return data;
+    return mlAdvancedSettingsSchema.partial().parse(data);
   }
 
   // ====== MÉTRICAS E PERFORMANCE ======

--- a/src/types/ml/advanced-settings.ts
+++ b/src/types/ml/advanced-settings.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const featureFlagsSchema = z.object({
+  auto_sync: z.boolean().optional(),
+  batch_sync: z.boolean().optional(),
+  webhook_processing: z.boolean().optional(),
+}).catchall(z.boolean());
+
+const rateLimitsSchema = z.object({
+  sync_product: z.number().optional(),
+  sync_order: z.number().optional(),
+  token_refresh: z.number().optional(),
+  default: z.number(),
+});
+
+export const mlAdvancedSettingsSchema = z.object({
+  id: z.string(),
+  tenant_id: z.string(),
+  feature_flags: featureFlagsSchema,
+  rate_limits: rateLimitsSchema,
+  backup_schedule: z.string(),
+  auto_recovery_enabled: z.boolean(),
+  advanced_monitoring: z.boolean(),
+  multi_account_enabled: z.boolean(),
+  security_level: z.string(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export type MLAdvancedSettings = z.infer<typeof mlAdvancedSettingsSchema>;


### PR DESCRIPTION
## Summary
- add Zod schemas for ML advanced settings and feature flags
- infer advanced settings and sync types in hooks
- validate advanced settings in service methods

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b65b18e5588329abcced2e444f354c