### PR TITLE
refactor: move admin tab queries to lazy-loaded components

### DIFF
--- a/src/pages/admin/tabs/SubscriptionsTab.tsx
+++ b/src/pages/admin/tabs/SubscriptionsTab.tsx
@@ -1,0 +1,121 @@
+import { memo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { DataVisualization } from "@/components/ui/data-visualization";
+import { Badge } from "@/components/ui/badge";
+
+interface SubscriptionTableRow {
+  id: string;
+  user?: {
+    full_name: string | null;
+    email: string | null;
+  } | null;
+  plan?: {
+    display_name?: string;
+    price_monthly?: number;
+  } | null;
+  status: string;
+  current_period_end?: string | null;
+}
+
+function SubscriptionsTabComponent() {
+  const { data: allSubscriptions = [], isLoading } = useQuery({
+    queryKey: ["admin-subscriptions"],
+    staleTime: 5 * 60 * 1000,
+    queryFn: async (): Promise<SubscriptionTableRow[]> => {
+      try {
+        const { data: subscriptions, error: subError } = await supabase
+          .from("subscriptions")
+          .select("id, user_id, plan_id, status, current_period_end")
+          .order("created_at", { ascending: false });
+
+        if (subError) {
+          console.error("Subscriptions basic query error:", subError);
+          throw new Error(`Erro ao buscar assinaturas: ${subError.message}`);
+        }
+
+        if (!subscriptions || subscriptions.length === 0) {
+          return [];
+        }
+
+        const userIds = [...new Set(subscriptions.map(sub => sub.user_id))];
+        const planIds = [...new Set(subscriptions.map(sub => sub.plan_id))];
+
+        const [{ data: users }, { data: plans }] = await Promise.all([
+          supabase.from("profiles").select("id, full_name, email").in("id", userIds),
+          supabase.from("subscription_plans").select("id, display_name, price_monthly").in("id", planIds)
+        ]);
+
+        const transformedData = subscriptions.map(sub => ({
+          id: sub.id,
+          status: sub.status,
+          current_period_end: sub.current_period_end,
+          user: users?.find(u => u.id === sub.user_id) || null,
+          plan: plans?.find(p => p.id === sub.plan_id) || null
+        }));
+
+        return transformedData as SubscriptionTableRow[];
+      } catch (error) {
+        console.error("Subscriptions fetch error:", error);
+        throw error;
+      }
+    }
+  });
+
+  const subscriptionColumns = [
+    {
+      key: "user.full_name",
+      header: "Usuário",
+      render: (item: SubscriptionTableRow) => (
+        <div>
+          <div className="font-medium">{item.user?.full_name || "N/A"}</div>
+          <div className="text-sm text-muted-foreground">{item.user?.email}</div>
+        </div>
+      )
+    },
+    {
+      key: "plan.display_name",
+      header: "Plano",
+      render: (item: SubscriptionTableRow) => (
+        <Badge variant="outline">
+          {item.plan?.display_name}
+        </Badge>
+      )
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (item: SubscriptionTableRow) => (
+        <Badge variant={item.status === "active" ? "default" : "secondary"}>
+          {item.status}
+        </Badge>
+      )
+    },
+    {
+      key: "plan.price_monthly",
+      header: "Valor Mensal",
+      render: (item: SubscriptionTableRow) => `R$ ${(item.plan?.price_monthly || 0).toFixed(2)}`
+    },
+    {
+      key: "current_period_end",
+      header: "Período",
+      render: (item: SubscriptionTableRow) => {
+        if (!item.current_period_end) return "N/A";
+        return new Date(item.current_period_end).toLocaleDateString("pt-BR");
+      }
+    }
+  ];
+
+  return (
+    <DataVisualization
+      title="Gestão de Assinaturas"
+      description="Monitore todas as assinaturas ativas na plataforma"
+      data={allSubscriptions}
+      columns={subscriptionColumns}
+      isLoading={isLoading}
+    />
+  );
+}
+
+export default memo(SubscriptionsTabComponent);
+

--- a/src/pages/admin/tabs/UsersTab.tsx
+++ b/src/pages/admin/tabs/UsersTab.tsx
@@ -1,0 +1,92 @@
+import { memo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { DataVisualization } from "@/components/ui/data-visualization";
+import { Badge } from "@/components/ui/badge";
+
+interface UserTableRow {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+  role: string;
+  company_name: string | null;
+  created_at: string;
+  is_active: boolean;
+}
+
+function UsersTabComponent() {
+  const { data: allUsers = [], isLoading } = useQuery({
+    queryKey: ["admin-users"],
+    staleTime: 5 * 60 * 1000,
+    queryFn: async (): Promise<UserTableRow[]> => {
+      try {
+        const { data, error } = await supabase
+          .from("profiles")
+          .select("id, full_name, email, role, company_name, created_at, is_active")
+          .order("created_at", { ascending: false });
+
+        if (error) {
+          console.error("Users query error:", error);
+          throw new Error(`Erro ao buscar usuários: ${error.message}`);
+        }
+        return (data || []) as UserTableRow[];
+      } catch (error) {
+        console.error("Users fetch error:", error);
+        throw error;
+      }
+    }
+  });
+
+  const userColumns = [
+    {
+      key: "full_name",
+      header: "Nome",
+      render: (item: UserTableRow) => (
+        <div>
+          <div className="font-medium">{item.full_name || "N/A"}</div>
+          <div className="text-sm text-muted-foreground">{item.email}</div>
+        </div>
+      )
+    },
+    {
+      key: "role",
+      header: "Role",
+      render: (item: UserTableRow) => (
+        <Badge variant={item.role === "super_admin" ? "destructive" : "secondary"}>
+          {item.role}
+        </Badge>
+      )
+    },
+    {
+      key: "company_name",
+      header: "Empresa"
+    },
+    {
+      key: "created_at",
+      header: "Criado em",
+      render: (item: UserTableRow) => new Date(String(item.created_at)).toLocaleDateString("pt-BR")
+    },
+    {
+      key: "is_active",
+      header: "Status",
+      render: (item: UserTableRow) => (
+        <Badge variant={item.is_active ? "default" : "secondary"}>
+          {item.is_active ? "Ativo" : "Inativo"}
+        </Badge>
+      )
+    }
+  ];
+
+  return (
+    <DataVisualization
+      title="Gestão de Usuários"
+      description="Gerencie todos os usuários da plataforma"
+      data={allUsers}
+      columns={userColumns}
+      isLoading={isLoading}
+    />
+  );
+}
+
+export default memo(UsersTabComponent);
+


### PR DESCRIPTION
## Summary
- factor out admin user and subscription data fetching into dedicated tab components
- lazily load admin dashboard tabs and add accessibility attributes

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and @typescript-eslint/no-unused-vars)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b65e4198f88329831ba686f1d3771f