### PR TITLE
fix: preserve sync data structure

### DIFF
--- a/src/hooks/useMLIntegration.ts
+++ b/src/hooks/useMLIntegration.ts
@@ -82,7 +82,7 @@ export function useMLIntegration() {
     // Dados
     auth: authData,
     sync: {
-      status: syncData,
+      ...(syncData ?? {}),
       ...syncActions,
     },
     performance: performanceData,


### PR DESCRIPTION
## Summary
- keep sync status fields at top level while still exposing mutation handlers

## Testing
- `npm test` *(passes: 10 passed, 20 skipped)*
- `npm run lint` *(fails: 48 errors, 4 warnings)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b6ca752c9c832994e61812d954323d