### PR TITLE
fix: derive tenant id before ml query invalidation

### DIFF
--- a/src/hooks/useMLIntegration.ts
+++ b/src/hooks/useMLIntegration.ts
@@ -107,6 +107,8 @@ export function useMLIntegration() {
 // ====== HOOKS ESPECÍFICOS PARA AÇÕES ======
 
 export function useMLAuth() {
+  const { profile } = useAuth();
+  const tenantId = profile?.tenant_id;
   const queryClient = useQueryClient();
 
   const startAuth = useMutation({
@@ -188,6 +190,8 @@ export function useMLAuth() {
 }
 
 function useMLSyncActions() {
+  const { profile } = useAuth();
+  const tenantId = profile?.tenant_id;
   const queryClient = useQueryClient();
 
   const syncProduct = useMutation({
@@ -346,6 +350,8 @@ function useMLSyncActions() {
 }
 
 export function useMLSettings() {
+  const { profile } = useAuth();
+  const tenantId = profile?.tenant_id;
   const queryClient = useQueryClient();
 
   const updateAdvancedSettings = useMutation({


### PR DESCRIPTION
## Summary
- derive tenant id from auth in ML hooks before invalidating queries

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b6d272cf9c83298e165953e46af130