### PR TITLE
fix: split RLS policies by action

### DIFF
--- a/supabase/migrations/20250902003000_1dc3f100-6ee8-4c99-a8dd-b964de195a8f.sql
+++ b/supabase/migrations/20250902003000_1dc3f100-6ee8-4c99-a8dd-b964de195a8f.sql
@@ -23,27 +23,6 @@ WITH CHECK (
   OR get_current_user_role() = 'super_admin'::user_role
 );
 
--- ml_integration_status
-DROP POLICY IF EXISTS "Users can view own tenant ML integration status" ON public.ml_integration_status;
-DROP POLICY IF EXISTS "Users can manage own tenant ML integration status" ON public.ml_integration_status;
-
-CREATE POLICY "Users can view own tenant ML integration status"
-ON public.ml_integration_status
-FOR SELECT
-USING (
-  tenant_id = (auth.jwt()->>'tenant_id')::uuid
-);
-
-CREATE POLICY "Users can manage own tenant ML integration status"
-ON public.ml_integration_status
-FOR INSERT, UPDATE, DELETE
-USING (
-  tenant_id = (auth.jwt()->>'tenant_id')::uuid
-)
-WITH CHECK (
-  tenant_id = (auth.jwt()->>'tenant_id')::uuid
-);
-
 -- product_images
 DROP POLICY IF EXISTS "Users can access own tenant product images" ON public.product_images;
 


### PR DESCRIPTION
## Summary
- remove RLS policies for `ml_integration_status` view

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in test files)*
- `npm run type-check`
- `npx supabase db lint policies` *(fails: invalid keys in config)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d93ddb788329bc48d5a956dcb0cd