### PR TITLE
feat: add product_images bucket and owner policies

### DIFF
--- a/src/hooks/useProductImages.ts
+++ b/src/hooks/useProductImages.ts
@@ -16,7 +16,7 @@ export function useProductImages(productId: string) {
   const { profile } = useAuth();
   const tenantId = profile?.tenant_id;
   return useQuery<ProductImage[]>({
-    queryKey: ['product-images', tenantId, productId],
+    queryKey: ['product_images', tenantId, productId],
     queryFn: async () => {
       if (!productId) return [];
       

--- a/src/services/ads.ts
+++ b/src/services/ads.ts
@@ -49,7 +49,7 @@ export class AdsService extends BaseService<ProductImage> {
 
       // Upload do arquivo para o Storage
       const { error: uploadError } = await supabase.storage
-        .from('product-images')
+        .from('product_images')
         .upload(filePath, file);
 
       if (uploadError) {
@@ -57,9 +57,15 @@ export class AdsService extends BaseService<ProductImage> {
         throw new Error(`Erro no upload: ${uploadError.message}`);
       }
 
+      await supabase
+        .from('storage.objects')
+        .update({ owner: tenantId })
+        .eq('bucket_id', 'product_images')
+        .eq('name', filePath);
+
       // Obter URL pública da imagem
       const { data: { publicUrl } } = supabase.storage
-        .from('product-images')
+        .from('product_images')
         .getPublicUrl(filePath);
 
       // Salvar referência no banco (tenant_id será adicionado automaticamente pelo BaseService)
@@ -90,11 +96,11 @@ export class AdsService extends BaseService<ProductImage> {
 
       // Extrair caminho do arquivo da URL (agora no formato tenant_id/product_id/arquivo)
       const url = new URL(image.image_url);
-      const filePath = url.pathname.split('/product-images/')[1];
+      const filePath = url.pathname.split('/product_images/')[1];
 
       // Deletar arquivo do Storage
       const { error: storageError } = await supabase.storage
-        .from('product-images')
+        .from('product_images')
         .remove([filePath]);
 
       if (storageError) {

--- a/supabase/migrations/20250902114727_92c04277-09e1-4402-ba08-b43556397138.sql
+++ b/supabase/migrations/20250902114727_92c04277-09e1-4402-ba08-b43556397138.sql
@@ -1,0 +1,29 @@
+-- Create product_images bucket if not exists
+INSERT INTO storage.buckets (id, name, public)
+SELECT 'product_images', 'product_images', true
+WHERE NOT EXISTS (
+  SELECT 1 FROM storage.buckets WHERE id = 'product_images'
+);
+
+-- Policies for product_images bucket
+DROP POLICY IF EXISTS "Public access to product images" ON storage.objects;
+DROP POLICY IF EXISTS "Users can manage own product images" ON storage.objects;
+
+CREATE POLICY "Public access to product images"
+ON storage.objects
+FOR SELECT
+USING (
+  bucket_id = 'product_images'
+);
+
+CREATE POLICY "Users can manage own product images"
+ON storage.objects
+FOR INSERT, UPDATE, DELETE
+USING (
+  bucket_id = 'product_images'
+  AND owner = (auth.jwt()->>'tenant_id')::uuid
+)
+WITH CHECK (
+  bucket_id = 'product_images'
+  AND owner = (auth.jwt()->>'tenant_id')::uuid
+);


### PR DESCRIPTION
## Summary
- add migration creating `product_images` bucket and owner-based policies
- use `product_images` bucket in client uploads and record owner
- update hooks and services to reference new bucket

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any and unused vars in test files)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b6d87e57dc8329aba28b6b9f79883b