### PR TITLE
feat: add product_images bucket and owner policies

### DIFF
--- a/supabase/migrations/20250902114727_92c04277-09e1-4402-ba08-b43556397138.sql
+++ b/supabase/migrations/20250902114727_92c04277-09e1-4402-ba08-b43556397138.sql
@@ -21,9 +21,15 @@ ON storage.objects
 FOR INSERT, UPDATE, DELETE
 USING (
   bucket_id = 'product_images'
-  AND owner = auth.uid()
+  AND (
+    owner = auth.uid()
+    OR owner = auth.jwt()->>'tenant_id'
+  )
 )
 WITH CHECK (
   bucket_id = 'product_images'
-  AND owner = auth.uid()
+  AND (
+    owner = auth.uid()
+    OR owner = auth.jwt()->>'tenant_id'
+  )
 );


### PR DESCRIPTION
## Summary
- relax storage policy to authenticate using auth.uid()
- support legacy product image paths when deleting
- allow policy to authorize by tenant or user IDs so legacy images remain manageable

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any and unused vars in test files)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b6e1133fd4832983dbec339b134ffd