### PR TITLE
refactor: centralize edge function schemas with zod

### DIFF
--- a/supabase/functions/assistants/index.ts
+++ b/supabase/functions/assistants/index.ts
@@ -1,6 +1,7 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { assistantCreateSchema, assistantUpdateSchema } from '../shared/schemas.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -103,7 +104,8 @@ serve(async (req) => {
 async function handleCreateAssistant(req: Request) {
   try {
     console.log('=== INICIANDO CRIAÇÃO ===');
-    const { name, marketplace, model, instructions, tenant_id } = await req.json();
+    const { name, marketplace, model, instructions, tenant_id } =
+      assistantCreateSchema.parse(await req.json());
     console.log('Dados recebidos:', { name, marketplace, model, tenant_id });
 
     // Criar assistente na OpenAI
@@ -181,9 +183,9 @@ async function handleUpdateAssistant(req: Request, assistantDbId: string) {
     console.log('=== INICIANDO ATUALIZAÇÃO ===');
     console.log('Assistant DB ID:', assistantDbId);
     
-    const requestBody = await req.json();
+    const requestBody = assistantUpdateSchema.parse(await req.json());
     console.log('Dados recebidos:', requestBody);
-    
+
     const { name, model, instructions } = requestBody;
 
     // Buscar assistente no banco

--- a/supabase/functions/generate-ad-chat/index.ts
+++ b/supabase/functions/generate-ad-chat/index.ts
@@ -1,6 +1,7 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
+import { generateAdChatSchema } from '../shared/schemas.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -13,13 +14,13 @@ serve(async (req) => {
   }
 
   try {
-    const { 
-      thread_id, 
-      message, 
-      product_info, 
+    const {
+      thread_id,
+      message,
+      product_info,
       marketplace,
-      is_initial_message = false 
-    } = await req.json();
+      is_initial_message = false,
+    } = generateAdChatSchema.parse(await req.json());
 
     const openaiApiKey = Deno.env.get('OPENAI_API_KEY');
     if (!openaiApiKey) {

--- a/supabase/functions/generate-ad/index.ts
+++ b/supabase/functions/generate-ad/index.ts
@@ -1,19 +1,11 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { generateAdSchema } from '../shared/schemas.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
-
-interface GenerateAdRequest {
-  assistant_id: string;
-  product_info: string;
-  marketplace: string;
-  image_urls: string[];
-  custom_prompt?: string;
-  description_only?: boolean;
-}
 
 serve(async (req) => {
   // Handle CORS preflight requests
@@ -28,7 +20,14 @@ serve(async (req) => {
       throw new Error('OpenAI API key not configured');
     }
 
-    const { assistant_id, product_info, marketplace, image_urls, custom_prompt, description_only }: GenerateAdRequest = await req.json();
+    const {
+      assistant_id,
+      product_info,
+      marketplace,
+      image_urls,
+      custom_prompt,
+      description_only,
+    } = generateAdSchema.parse(await req.json());
 
     console.log('Iniciando geração de anúncio', { assistant_id, marketplace, description_only });
 

--- a/supabase/functions/ml-webhook/index.ts
+++ b/supabase/functions/ml-webhook/index.ts
@@ -1,21 +1,12 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { updateProductFromItem } from './updateProductFromItem.ts';
+import { mlWebhookSchema } from '../shared/schemas.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
-
-interface MLWebhookPayload {
-  topic: string;
-  resource: string;
-  user_id: number;
-  application_id: number;
-  attempts: number;
-  sent: string;
-  received: string;
-}
 
 serve(async (req) => {
   // Handle CORS preflight requests
@@ -29,7 +20,7 @@ serve(async (req) => {
 
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
-    const payload: MLWebhookPayload = await req.json();
+    const payload = mlWebhookSchema.parse(await req.json());
     console.log('Received ML webhook:', payload);
 
     // Find tenant by ML user ID

--- a/supabase/functions/shared/schemas.ts
+++ b/supabase/functions/shared/schemas.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+export const generateAdSchema = z.object({
+  assistant_id: z.string(),
+  product_info: z.string(),
+  marketplace: z.string(),
+  image_urls: z.array(z.string()),
+  custom_prompt: z.string().optional(),
+  description_only: z.boolean().optional(),
+});
+
+export const generateAdChatSchema = z.object({
+  thread_id: z.string().optional(),
+  message: z.string(),
+  product_info: z.record(z.unknown()).optional(),
+  marketplace: z.string(),
+  is_initial_message: z.boolean().optional(),
+});
+
+export const assistantCreateSchema = z.object({
+  name: z.string(),
+  marketplace: z.string(),
+  model: z.string(),
+  instructions: z.string(),
+  tenant_id: z.string(),
+});
+
+export const assistantUpdateSchema = z.object({
+  name: z.string().optional(),
+  model: z.string().optional(),
+  instructions: z.string().optional(),
+});
+
+export const mlAuthSchema = z.object({
+  action: z
+    .enum(['start_auth', 'handle_callback', 'refresh_token', 'get_status'])
+    .default('get_status'),
+  code: z.string().optional(),
+  state: z.string().optional(),
+  tenant_id: z.string().optional(),
+});
+
+export const mlSyncRequestSchema = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('get_status') }),
+  z.object({
+    action: z.literal('sync_product'),
+    product_id: z.string(),
+    force_update: z.boolean().optional(),
+  }),
+  z.object({
+    action: z.literal('sync_batch'),
+    product_ids: z.array(z.string()),
+    force_update: z.boolean().optional(),
+  }),
+  z.object({ action: z.literal('import_from_ml') }),
+  z.object({
+    action: z.literal('link_product'),
+    product_id: z.string(),
+    ml_item_id: z.string(),
+  }),
+  z.object({ action: z.literal('get_products') }),
+  z.object({
+    action: z.literal('create_ad'),
+    ad_data: z.record(z.unknown()),
+  }),
+  z.object({
+    action: z.literal('resync_product'),
+    productId: z.string(),
+  }),
+]);
+
+export const mlWebhookSchema = z.object({
+  topic: z.string(),
+  resource: z.string(),
+  user_id: z.number(),
+  application_id: z.number(),
+  attempts: z.number(),
+  sent: z.string(),
+  received: z.string(),
+});

--- a/tests/functions/schemas.test.ts
+++ b/tests/functions/schemas.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateAdSchema,
+  generateAdChatSchema,
+  assistantCreateSchema,
+  assistantUpdateSchema,
+  mlAuthSchema,
+  mlSyncRequestSchema,
+  mlWebhookSchema,
+} from '../../supabase/functions/shared/schemas';
+
+describe('supabase function schemas', () => {
+  it('validates generate-ad request', () => {
+    const payload = {
+      assistant_id: 'a',
+      product_info: 'info',
+      marketplace: 'MLB',
+      image_urls: ['url'],
+      custom_prompt: 'prompt',
+      description_only: true,
+    };
+    expect(generateAdSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('validates generate-ad-chat request', () => {
+    const payload = {
+      message: 'hello',
+      marketplace: 'MLB',
+    };
+    expect(generateAdChatSchema.parse(payload)).toMatchObject(payload);
+  });
+
+  it('validates assistants create request', () => {
+    const payload = {
+      name: 'assistant',
+      marketplace: 'MLB',
+      model: 'gpt',
+      instructions: 'do things',
+      tenant_id: 'tenant',
+    };
+    expect(assistantCreateSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('validates assistants update request', () => {
+    const payload = { name: 'new' };
+    expect(assistantUpdateSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('validates ml-auth request', () => {
+    const payload = { action: 'start_auth' as const };
+    expect(mlAuthSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('validates ml-sync request', () => {
+    const payload = { action: 'sync_product' as const, product_id: '1' };
+    expect(mlSyncRequestSchema.parse(payload)).toEqual(payload);
+  });
+
+  it('validates ml webhook payload', () => {
+    const payload = {
+      topic: 'items',
+      resource: '/items/1',
+      user_id: 1,
+      application_id: 1,
+      attempts: 1,
+      sent: '2020-01-01',
+      received: '2020-01-01',
+    };
+    expect(mlWebhookSchema.parse(payload)).toEqual(payload);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared Zod schemas for edge functions
- replace manual request parsing with `schema.parse`
- add contract tests for schema validation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b6e60f4c408329a4b25238b897d1bd