### PR TITLE
fix: derive ML webhook payload type from schema

### DIFF
--- a/supabase/functions/ml-webhook/index.ts
+++ b/supabase/functions/ml-webhook/index.ts
@@ -2,6 +2,9 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { updateProductFromItem } from './updateProductFromItem.ts';
 import { mlWebhookSchema } from '../shared/schemas.ts';
+import type { z } from 'zod';
+
+type MLWebhookPayload = z.infer<typeof mlWebhookSchema>;
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
## Summary
- derive ML webhook payload type from schema

## Testing
- `npm run lint` (fails: Unexpected any in tests)
- `npm run type-check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b6e9eb1800832992a7938e65632a4c