### PR TITLE
fix: encrypt legacy ML tokens and drop hardcoded service key

### DIFF
--- a/supabase/migrations/20250902130612_b7d9e2e9-1fcb-4e2a-b792-8fb06a0bfed2.sql
+++ b/supabase/migrations/20250902130612_b7d9e2e9-1fcb-4e2a-b792-8fb06a0bfed2.sql
@@ -27,23 +27,6 @@ CREATE TRIGGER encrypt_ml_tokens_trigger
 BEFORE INSERT OR UPDATE ON public.ml_auth_tokens
 FOR EACH ROW EXECUTE FUNCTION public.encrypt_ml_tokens();
 
--- Backfill existing tokens so the decrypting view won't fail
-DO $$
-DECLARE
-  secret_key text := current_setting('app.ml_encryption_key', true);
-BEGIN
-  IF secret_key IS NULL THEN
-    secret_key := 'changeme';
-  END IF;
-
-  UPDATE public.ml_auth_tokens
-  SET
-    access_token = encode(pgp_sym_encrypt(access_token, secret_key), 'base64'),
-    refresh_token = encode(pgp_sym_encrypt(refresh_token, secret_key), 'base64')
-  WHERE access_token IS NOT NULL OR refresh_token IS NOT NULL;
-END;
-$$;
-
 -- View with decrypted tokens
 CREATE OR REPLACE VIEW public.ml_auth_tokens_decrypted AS
 SELECT
@@ -67,10 +50,7 @@ SELECT cron.schedule(
   $$
   SELECT net.http_post(
     url:='https://ngkhzbzynkhgezkqykeb.supabase.co/functions/v1/ml-token-renewal',
-    headers:=jsonb_build_object(
-      'Content-Type','application/json',
-      'Authorization', 'Bearer ' || coalesce(current_setting('app.ml_service_role_key', true), '')
-    ),
+    headers:='{"Content-Type": "application/json", "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5na2h6Ynp5bmtoZ2V6a3F5a2ViIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwMDM3ODgsImV4cCI6MjA2OTU3OTc4OH0.EMk6edTPpwvcy_6VVDxARgoRsJrY9EiijbfR4dFDQAQ"}'::jsonb,
     body:=jsonb_build_object('triggered_at', now())
   );
   $$

--- a/supabase/migrations/20250902140000_d7a78905-b7c7-4b9e-8b5c-5427c8c70aa6.sql
+++ b/supabase/migrations/20250902140000_d7a78905-b7c7-4b9e-8b5c-5427c8c70aa6.sql
@@ -1,0 +1,35 @@
+-- Backfill encrypted tokens and update cron job auth header
+
+-- Backfill existing tokens so the decrypting view won't fail
+DO $$
+DECLARE
+  secret_key text := current_setting('app.ml_encryption_key', true);
+BEGIN
+  IF secret_key IS NULL THEN
+    secret_key := 'changeme';
+  END IF;
+
+  UPDATE public.ml_auth_tokens
+  SET
+    access_token = encode(pgp_sym_encrypt(access_token, secret_key), 'base64'),
+    refresh_token = encode(pgp_sym_encrypt(refresh_token, secret_key), 'base64')
+  WHERE access_token IS NOT NULL OR refresh_token IS NOT NULL;
+END;
+$$;
+
+-- Update cron job to use dynamic service role key
+SELECT cron.unschedule('ml-token-renewal-hourly');
+SELECT cron.schedule(
+  'ml-token-renewal-hourly',
+  '0 * * * *',
+  $$
+  SELECT net.http_post(
+    url:='https://ngkhzbzynkhgezkqykeb.supabase.co/functions/v1/ml-token-renewal',
+    headers:=jsonb_build_object(
+      'Content-Type','application/json',
+      'Authorization', 'Bearer ' || coalesce(current_setting('app.ml_service_role_key', true), '')
+    ),
+    body:=jsonb_build_object('triggered_at', now())
+  );
+  $$
+);


### PR DESCRIPTION
## Summary
- move token backfill and cron update to a new migration

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b6f6be44e88329ae0e789bdd28af11