### PR TITLE
fix: avoid re-encrypting ml tokens

### DIFF
--- a/supabase/migrations/20250902130612_b7d9e2e9-1fcb-4e2a-b792-8fb06a0bfed2.sql
+++ b/supabase/migrations/20250902130612_b7d9e2e9-1fcb-4e2a-b792-8fb06a0bfed2.sql
@@ -50,7 +50,10 @@ SELECT cron.schedule(
   $$
   SELECT net.http_post(
     url:='https://ngkhzbzynkhgezkqykeb.supabase.co/functions/v1/ml-token-renewal',
-    headers:='{"Content-Type": "application/json", "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5na2h6Ynp5bmtoZ2V6a3F5a2ViIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwMDM3ODgsImV4cCI6MjA2OTU3OTc4OH0.EMk6edTPpwvcy_6VVDxARgoRsJrY9EiijbfR4dFDQAQ"}'::jsonb,
+    headers:=jsonb_build_object(
+      'Content-Type','application/json',
+      'Authorization', 'Bearer ' || coalesce(current_setting('app.ml_service_role_key', true), '')
+    ),
     body:=jsonb_build_object('triggered_at', now())
   );
   $$

--- a/supabase/migrations/20250902140000_d7a78905-b7c7-4b9e-8b5c-5427c8c70aa6.sql
+++ b/supabase/migrations/20250902140000_d7a78905-b7c7-4b9e-8b5c-5427c8c70aa6.sql
@@ -11,8 +11,14 @@ BEGIN
 
   UPDATE public.ml_auth_tokens
   SET
-    access_token = encode(pgp_sym_encrypt(access_token, secret_key), 'base64'),
-    refresh_token = encode(pgp_sym_encrypt(refresh_token, secret_key), 'base64')
+    access_token = CASE
+      WHEN access_token LIKE '%.%.%' THEN encode(pgp_sym_encrypt(access_token, secret_key), 'base64')
+      ELSE access_token
+    END,
+    refresh_token = CASE
+      WHEN refresh_token LIKE '%.%.%' THEN encode(pgp_sym_encrypt(refresh_token, secret_key), 'base64')
+      ELSE refresh_token
+    END
   WHERE access_token IS NOT NULL OR refresh_token IS NOT NULL;
 END;
 $$;


### PR DESCRIPTION
## Summary
- prevent double encryption during ML token backfill
- stop embedding service key in ml token renewal cron

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b6fb09aa448329b297d6cd1e2a8d04