### PR TITLE
feat: add pino logger for edge functions

### DIFF
--- a/supabase/functions/assistants/index.ts
+++ b/supabase/functions/assistants/index.ts
@@ -2,6 +2,7 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { assistantCreateSchema, assistantUpdateSchema } from '../shared/schemas.ts';
+import { setupLogger } from '../shared/logger.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -16,6 +17,7 @@ const OPENAI_API_KEY = Deno.env.get('OPENAI_API_KEY');
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
 serve(async (req) => {
+  setupLogger(req.headers);
   console.log(`=== ASSISTANTS ${req.method} REQUEST ===`);
   console.log('URL:', req.url);
   console.log('Headers:', Object.fromEntries(req.headers.entries()));

--- a/supabase/functions/generate-ad-chat/index.ts
+++ b/supabase/functions/generate-ad-chat/index.ts
@@ -2,6 +2,7 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 import { generateAdChatSchema } from '../shared/schemas.ts';
+import { setupLogger } from '../shared/logger.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -13,6 +14,7 @@ serve(async (req) => {
     return new Response(null, { headers: corsHeaders });
   }
 
+  setupLogger(req.headers);
   try {
     const {
       thread_id,

--- a/supabase/functions/generate-ad/index.ts
+++ b/supabase/functions/generate-ad/index.ts
@@ -1,6 +1,7 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { generateAdSchema } from '../shared/schemas.ts';
+import { setupLogger } from '../shared/logger.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -14,6 +15,7 @@ serve(async (req) => {
   }
 
   try {
+    setupLogger(req.headers);
     const openAIApiKey = Deno.env.get('OPENAI_API_KEY');
 
     if (!openAIApiKey) {

--- a/supabase/functions/ml-auth/index.ts
+++ b/supabase/functions/ml-auth/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { mlAuthSchema } from '../shared/schemas.ts';
 import type { z } from 'zod';
+import { setupLogger } from '../shared/logger.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -41,6 +42,7 @@ serve(async (req) => {
   }
 
   try {
+    setupLogger(req.headers);
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
     const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
     const mlClientId = Deno.env.get('ML_CLIENT_ID')!;

--- a/supabase/functions/ml-security-monitor/index.ts
+++ b/supabase/functions/ml-security-monitor/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0'
+import { setupLogger } from '../shared/logger.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -14,6 +15,7 @@ serve(async (req) => {
     return new Response(null, { headers: corsHeaders });
   }
 
+  setupLogger(req.headers);
   const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
   const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 

--- a/supabase/functions/ml-sync-v2/index.ts
+++ b/supabase/functions/ml-sync-v2/index.ts
@@ -15,6 +15,7 @@ import { linkProduct } from './actions/linkProduct.ts';
 import { getProducts } from './actions/getProducts.ts';
 import { createAd } from './actions/createAd.ts';
 import { resyncProduct } from './actions/resyncProduct.ts';
+import { setupLogger } from '../shared/logger.ts';
 
 type Handler = (req: SyncRequest, ctx: ActionContext) => Promise<Response>;
 const actions: Record<SyncRequest['action'], Handler> = {
@@ -34,6 +35,7 @@ serve(async (req) => {
   }
 
   try {
+    setupLogger(req.headers);
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
     const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
     const mlClientId = Deno.env.get('ML_CLIENT_ID')!;

--- a/supabase/functions/ml-token-renewal/index.ts
+++ b/supabase/functions/ml-token-renewal/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0'
+import { setupLogger } from '../shared/logger.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -48,6 +49,7 @@ serve(async (req) => {
     return new Response(null, { headers: corsHeaders });
   }
 
+  setupLogger(req.headers);
   const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
   const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
   const mlClientId = Deno.env.get('ML_CLIENT_ID')!;

--- a/supabase/functions/ml-webhook/index.ts
+++ b/supabase/functions/ml-webhook/index.ts
@@ -3,6 +3,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { updateProductFromItem } from './updateProductFromItem.ts';
 import { mlWebhookSchema } from '../shared/schemas.ts';
 import type { z } from 'zod';
+import { setupLogger } from '../shared/logger.ts';
 
 type MLWebhookPayload = z.infer<typeof mlWebhookSchema>;
 
@@ -17,6 +18,7 @@ serve(async (req) => {
     return new Response(null, { headers: corsHeaders });
   }
 
+  setupLogger(req.headers);
   try {
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
     const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;

--- a/supabase/functions/shared/logger.ts
+++ b/supabase/functions/shared/logger.ts
@@ -1,0 +1,55 @@
+import pino from 'https://esm.sh/pino@8';
+
+const originalConsole = globalThis.console;
+
+const elasticUrl = Deno.env.get('ELASTIC_URL');
+const elasticApiKey = Deno.env.get('ELASTIC_API_KEY');
+
+const stream = elasticUrl
+  ? {
+      write: (msg: string) => {
+        fetch(elasticUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(elasticApiKey ? { Authorization: `ApiKey ${elasticApiKey}` } : {}),
+          },
+          body: msg,
+        }).catch((err) => {
+          originalConsole.error('Elastic export error', err);
+        });
+
+        originalConsole.log(msg);
+      },
+    }
+  : undefined;
+
+const baseLogger = pino(
+  {
+    level: Deno.env.get('LOG_LEVEL') ?? 'info',
+    base: undefined,
+    timestamp: pino.stdTimeFunctions.isoTime,
+  },
+  stream,
+);
+
+function bindLogger(logger: pino.Logger): Console {
+  return {
+    log: logger.info.bind(logger),
+    info: logger.info.bind(logger),
+    error: logger.error.bind(logger),
+    warn: logger.warn.bind(logger),
+    debug: logger.debug.bind(logger),
+  } as Console;
+}
+
+// Default console without correlationId
+globalThis.console = bindLogger(baseLogger);
+
+export function setupLogger(headers: Headers) {
+  const correlationId = headers.get('x-correlation-id') ?? crypto.randomUUID();
+  const logger = baseLogger.child({ correlationId });
+  globalThis.console = bindLogger(logger);
+  return logger;
+}
+


### PR DESCRIPTION
## 🎯 Descrição
- adiciona utilitário `pino` para edge functions com suporte a `correlationId`
- permite exportação opcional de logs para Elastic via `ELASTIC_URL`
- aplica inicialização do logger em todas as edge functions

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [x] Testes e lint executados
- [x] Edge Functions atualizadas

## 🧪 Testes
- `npm test -- --run`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b700fd25d88329a86c312bd4b81cbf