### PR TITLE
chore: add coverage verification and pre-commit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
       run: npm run test:coverage
 
     - name: Check coverage threshold
-      run: |
-        node -e "const fs=require('fs');const pct=JSON.parse(fs.readFileSync('coverage/coverage-summary.json')).total.lines.pct; if(pct < 80){console.error(`Coverage ${pct}% is below 80%`); process.exit(1);}" 
+      run: node scripts/verifyCoverage.mjs
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
 npx lint-staged
+npm test -- --run --passWithNoTests

--- a/scripts/verifyCoverage.mjs
+++ b/scripts/verifyCoverage.mjs
@@ -1,0 +1,22 @@
+import { readFile } from 'node:fs/promises';
+
+async function verifyCoverage() {
+  try {
+    const data = await readFile('coverage/coverage-summary.json', 'utf8');
+    const summary = JSON.parse(data);
+    const pct = summary.total.lines.pct;
+    const threshold = 80;
+
+    if (pct < threshold) {
+      console.error(`Coverage ${pct}% is below ${threshold}%`);
+      process.exit(1);
+    }
+
+    console.log(`Coverage ${pct}% meets threshold ${threshold}%`);
+  } catch (error) {
+    console.error('Failed to verify coverage:', error);
+    process.exit(1);
+  }
+}
+
+verifyCoverage();


### PR DESCRIPTION
## 🎯 Descrição
- add `scripts/verifyCoverage.mjs` and use it in CI
- run `lint-staged` and tests on pre-commit

## ✅ Checklist
- [x] coverage verification script
- [x] CI updated
- [x] pre-commit runs lint and tests

## 🧪 Testes
- `npm run lint`
- `npm run type-check`
- `npm test -- --run --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b7061ab5bc83298daba4da32714b4a