### PR TITLE
test: add ML auth and webhook function tests

### DIFF
--- a/tests/functions/ml-auth.test.ts
+++ b/tests/functions/ml-auth.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MLService } from '@/services/ml-service';
+import { testUtils } from '../setup';
+
+const { mockSupabaseClient } = testUtils;
+
+describe('ml-auth service', () => {
+  beforeEach(() => {
+    testUtils.resetAllMocks();
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: { access_token: 'token' } },
+      error: null,
+    });
+  });
+
+  it('starts auth flow and returns url', async () => {
+    mockSupabaseClient.functions.invoke.mockResolvedValue({
+      data: { auth_url: 'https://auth.url', state: 'state123' },
+      error: null,
+    });
+
+    const result = await MLService.startAuth();
+
+    expect(result).toEqual({ auth_url: 'https://auth.url', state: 'state123' });
+    expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledWith('ml-auth', {
+      body: { action: 'start_auth' },
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+
+  it('handles callback with provided code and state', async () => {
+    mockSupabaseClient.functions.invoke.mockResolvedValue({ data: null, error: null });
+
+    await MLService.handleCallback('code123', 'state456');
+
+    expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledWith('ml-auth', {
+      body: { action: 'handle_callback', code: 'code123', state: 'state456' },
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+
+  it('refreshes token successfully', async () => {
+    mockSupabaseClient.functions.invoke.mockResolvedValue({ data: { success: true }, error: null });
+
+    await MLService.refreshToken();
+
+    expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledWith('ml-auth', {
+      body: { action: 'refresh_token' },
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
+});

--- a/tests/functions/ml-webhook.test.ts
+++ b/tests/functions/ml-webhook.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { callMLFunction } from '@/utils/ml/ml-api';
+import { testUtils } from '../setup';
+
+const { mockSupabaseClient } = testUtils;
+
+describe('ml-webhook function', () => {
+  beforeEach(() => {
+    testUtils.resetAllMocks();
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: { access_token: 'token' } },
+      error: null,
+    });
+  });
+
+  it('throws error when signature is invalid', async () => {
+    mockSupabaseClient.functions.invoke.mockResolvedValue({
+      data: null,
+      error: { message: 'Invalid webhook signature' },
+    });
+
+    await expect(
+      callMLFunction('ml-webhook', 'process', {}, { headers: { 'X-Webhook-Signature': 'bad' } })
+    ).rejects.toThrow('Invalid webhook signature');
+
+    expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledWith('ml-webhook', {
+      body: { action: 'process' },
+      headers: { Authorization: 'Bearer token', 'X-Webhook-Signature': 'bad' },
+    });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,6 +3,14 @@ import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
 import * as toastMock from './mocks/toast';
 
+// Inject environment variables for tests
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+process.env.ML_CLIENT_ID = 'test-client-id';
+process.env.ML_CLIENT_SECRET = 'test-client-secret';
+process.env.ML_REDIRECT_URL = 'https://example.com/callback';
+process.env.ML_WEBHOOK_SECRET = 'test-webhook-secret';
+
 // Limpa e reseta mocks após cada teste
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Summary
- inject required environment variables in test setup
- add ML auth tests for start, callback, and refresh flows
- cover invalid signature handling in ML webhook

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b70ac2ccac8329b98984adfb5519ed