### PR TITLE
feat: capture Mercado Livre SKU and category path

### DIFF
--- a/tests/actions/importFromML.test.ts
+++ b/tests/actions/importFromML.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   importFromML,
@@ -13,7 +13,7 @@ afterEach(() => {
 });
 
 describe('importFromML action', () => {
-  it('should save variations in product record', async () => {
+  it('uses seller_custom_field as sku and saves category path', async () => {
     const itemData = {
       id: 'MLA1',
       title: 'Test Item',
@@ -21,8 +21,9 @@ describe('importFromML action', () => {
       price: 100,
       available_quantity: 10,
       sold_quantity: 0,
-      seller_sku: 'SELLER',
-      variations: [{ id: 'VAR1', attribute_combinations: [] }],
+      seller_custom_field: 'SCF123',
+      category_id: 'CAT1',
+      variations: [],
       pictures: [],
     } as any;
 
@@ -43,35 +44,57 @@ describe('importFromML action', () => {
       if (urlStr.includes('/items/MLA1')) {
         return Promise.resolve({ ok: true, json: async () => itemData } as any);
       }
+      if (urlStr.includes('/categories/CAT1')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ name: 'Root', path_from_root: [{ id: 'CAT1', name: 'Root' }] }),
+        } as any);
+      }
       return Promise.resolve({ ok: true, json: async () => ({}) } as any);
     });
 
     const productsTable = {
-      insert: vi.fn().mockReturnThis(),
+      upsert: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue({ data: { id: 'prod1' }, error: null }),
     };
     const mappingTable = {
-      select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      maybeSingle: vi.fn().mockResolvedValue({ data: null }),
-      insert: vi.fn().mockResolvedValue({ error: null }),
+      upsert: vi.fn().mockResolvedValue({ error: null }),
     };
     const mlSyncLogTable = { insert: vi.fn().mockResolvedValue({}) };
+    const productImagesTable = { insert: vi.fn().mockResolvedValue({ error: null }) };
+    const mlCategoriesTable = {
+      upsert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 'mlcat' }, error: null }),
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({}),
+    };
+    const categoriesTable = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      ilike: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'catLocal' } }),
+      insert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+    };
 
     const supabase = {
       from: vi.fn((table: string) => {
         if (table === 'products') return productsTable;
         if (table === 'ml_product_mapping') return mappingTable;
         if (table === 'ml_sync_log') return mlSyncLogTable;
+        if (table === 'product_images') return productImagesTable;
+        if (table === 'ml_categories') return mlCategoriesTable;
+        if (table === 'categories') return categoriesTable;
         return {
           upsert: vi.fn().mockReturnThis(),
           select: vi.fn().mockReturnThis(),
-          single: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: null, error: null }),
           update: vi.fn().mockReturnThis(),
           eq: vi.fn().mockReturnThis(),
-          insert: vi.fn().mockReturnThis(),
-          maybeSingle: vi.fn().mockReturnThis(),
+          insert: vi.fn().mockResolvedValue({ error: null }),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null }),
           ilike: vi.fn().mockReturnThis(),
         };
       }),
@@ -83,9 +106,86 @@ describe('importFromML action', () => {
       authToken: { user_id_ml: 'user1', access_token: 'token' } as any,
     });
 
-    expect(productsTable.insert).toHaveBeenCalled();
-    const inserted = productsTable.insert.mock.calls[0][0];
-    expect(inserted.ml_variations).toEqual(itemData.variations);
+    expect(productsTable.upsert).toHaveBeenCalled();
+    const inserted = productsTable.upsert.mock.calls[0][0];
+    expect(inserted.sku).toBe('SCF123');
+    expect(inserted.sku_source).toBe('mercado_livre');
+    expect(inserted.category_ml_path).toEqual([{ id: 'CAT1', name: 'Root' }]);
+  });
+
+  it('falls back to null sku when not provided', async () => {
+    const itemData = {
+      id: 'MLA2',
+      title: 'No SKU Item',
+      attributes: [],
+      price: 50,
+      available_quantity: 5,
+      sold_quantity: 0,
+      category_id: null,
+      variations: [],
+      pictures: [],
+    } as any;
+
+    global.fetch = vi.fn((url: RequestInfo) => {
+      const urlStr = url.toString();
+      if (urlStr.includes('/items/search')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            results: ['MLA2'],
+            paging: { total: 1, offset: 0, limit: 50 },
+          }),
+        } as any);
+      }
+      if (urlStr.includes('/items/MLA2/description')) {
+        return Promise.resolve({ ok: true, json: async () => ({ plain_text: '' }) } as any);
+      }
+      if (urlStr.includes('/items/MLA2')) {
+        return Promise.resolve({ ok: true, json: async () => itemData } as any);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as any);
+    });
+
+    const productsTable = {
+      upsert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: 'prod2' }, error: null }),
+    };
+    const mappingTable = {
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    };
+    const mlSyncLogTable = { insert: vi.fn().mockResolvedValue({}) };
+    const productImagesTable = { insert: vi.fn().mockResolvedValue({ error: null }) };
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'products') return productsTable;
+        if (table === 'ml_product_mapping') return mappingTable;
+        if (table === 'ml_sync_log') return mlSyncLogTable;
+        if (table === 'product_images') return productImagesTable;
+        return {
+          upsert: vi.fn().mockReturnThis(),
+          select: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: null, error: null }),
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          insert: vi.fn().mockResolvedValue({ error: null }),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+          ilike: vi.fn().mockReturnThis(),
+        };
+      }),
+    } as any;
+
+    await importFromML({ action: 'import_from_ml' } as any, {
+      supabase,
+      tenantId: 'tenant1',
+      authToken: { user_id_ml: 'user1', access_token: 'token' } as any,
+    });
+
+    expect(productsTable.upsert).toHaveBeenCalled();
+    const inserted = productsTable.upsert.mock.calls[0][0];
+    expect(inserted.sku).toBeNull();
+    expect(inserted.sku_source).toBe('none');
   });
 });
 


### PR DESCRIPTION
## Summary
- use Mercado Livre provided SKU or attribute instead of generating one
- upsert products and mappings with ML identifiers and category path
- cover seller_custom_field/null SKU scenarios in tests

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b7142865048329a528150c3a444041