### PR TITLE
fix: derive SKU solely from ML

### DIFF
--- a/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
@@ -99,14 +99,11 @@ export async function resyncProduct(
       weight = weightToGrams(value, unit);
     }
 
-    let skuToUse = itemData.seller_sku || '';
-    if (!skuToUse && itemData.variations?.length > 0) {
-      skuToUse =
-        itemData.variations[0].seller_sku || itemData.variations[0].id || '';
-    }
-    if (!skuToUse) {
-      skuToUse = itemData.id;
-    }
+    const mlSku =
+      itemData.seller_custom_field ||
+      itemData.attributes?.find((attr) => attr.id === 'SELLER_SKU')?.value_name ||
+      null;
+    const skuSource = mlSku ? 'mercado_livre' : 'none';
 
     const shouldUpdateName = !productMapping.products?.name;
     const localCost = productMapping.products?.cost_unit;
@@ -121,20 +118,22 @@ export async function resyncProduct(
 
     const updateData: Record<string, any> = {
       description: description,
-      sku: skuToUse,
+      sku: mlSku,
+      sku_source: skuSource,
       brand: brand,
       model: model,
       warranty: warranty,
       weight: weight,
       dimensions: dimensions,
       ml_attributes: itemData.attributes || {},
-      ml_seller_sku: itemData.seller_sku,
+      ml_seller_sku: mlSku,
       ml_available_quantity: itemData.available_quantity || 0,
       ml_sold_quantity: itemData.sold_quantity || 0,
       ml_variation_id:
         itemData.variations?.length > 0 ? itemData.variations[0].id : null,
       ml_pictures: itemData.pictures || [],
       updated_at: new Date().toISOString(),
+      updated_from_ml_at: new Date().toISOString(),
     };
 
     if (shouldUpdateName) updateData.name = itemData.title;

--- a/supabase/functions/ml-sync-v2/actions/syncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/syncProduct.ts
@@ -118,12 +118,14 @@ export async function syncSingleProduct(
             }
 
             let sku = product.sku;
+            let skuSource = product.sku_source;
             if (!sku) {
-              sku =
-                itemData.seller_sku ||
-                itemData.variations?.[0]?.seller_sku ||
-                itemData.variations?.[0]?.id ||
-                itemData.id;
+              const mlSku =
+                itemData.seller_custom_field ||
+                itemData.attributes?.find((attr) => attr.id === 'SELLER_SKU')?.value_name ||
+                null;
+              sku = mlSku;
+              skuSource = mlSku ? 'mercado_livre' : 'none';
             }
 
             const costUnit =
@@ -135,7 +137,12 @@ export async function syncSingleProduct(
               updated_at: new Date().toISOString(),
             };
             if (!product.description) updates.description = description;
-            if (!product.sku) updates.sku = sku;
+            if (!product.sku) {
+              updates.sku = sku;
+              updates.sku_source = skuSource;
+              updates.ml_seller_sku = sku;
+              updates.updated_from_ml_at = new Date().toISOString();
+            }
             if (product.cost_unit === null || product.cost_unit === undefined)
               updates.cost_unit = costUnit;
 

--- a/supabase/functions/ml-webhook/updateProductFromItem.test.ts
+++ b/supabase/functions/ml-webhook/updateProductFromItem.test.ts
@@ -53,7 +53,7 @@ describe('updateProductFromItem', () => {
   it('updates product fields from item data', async () => {
     const itemData = {
       id: 'ML1',
-      seller_sku: 'SKU1',
+      seller_custom_field: 'SCF1',
       attributes: [],
       pictures: [{ url: 'pic1' }],
       available_quantity: 3,
@@ -74,7 +74,7 @@ describe('updateProductFromItem', () => {
 
     const itemData = {
       id: 'ML2',
-      seller_sku: 'SKU2',
+      seller_custom_field: 'SCF2',
       attributes: [],
       pictures: [{ url: 'pic2' }],
       available_quantity: 5,
@@ -85,5 +85,21 @@ describe('updateProductFromItem', () => {
     const updateArg = productsQuery.update.mock.calls[0][0];
     expect(updateArg).not.toHaveProperty('description');
     expect(fields).toEqual(['sku', 'attributes', 'pictures', 'stock']);
+  });
+
+  it('sets sku to null when ML does not provide', async () => {
+    const itemData = {
+      id: 'ML3',
+      attributes: [],
+      pictures: [],
+      available_quantity: 1,
+    };
+
+    await updateProductFromItem(supabase, 'tenant1', itemData, 'token');
+
+    const updateArg = productsQuery.update.mock.calls[0][0];
+    expect(updateArg.sku).toBeNull();
+    expect(updateArg.sku_source).toBe('none');
+    expect(updateArg).toHaveProperty('updated_from_ml_at');
   });
 });

--- a/supabase/functions/ml-webhook/updateProductFromItem.ts
+++ b/supabase/functions/ml-webhook/updateProductFromItem.ts
@@ -33,20 +33,21 @@ export async function updateProductFromItem(
     console.warn('Could not fetch description:', e);
   }
 
-  let skuToUse = itemData.seller_sku || '';
-  if (!skuToUse && itemData.variations?.length > 0) {
-    skuToUse = itemData.variations[0].seller_sku || itemData.variations[0].id || '';
-  }
-  if (!skuToUse) {
-    skuToUse = itemData.id;
-  }
+  const mlSku =
+    itemData.seller_custom_field ||
+    itemData.attributes?.find((attr) => attr.id === 'SELLER_SKU')?.value_name ||
+    null;
+  const skuSource = mlSku ? 'mercado_livre' : 'none';
 
   const updateData: Record<string, unknown> = {
-    sku: skuToUse,
+    sku: mlSku,
+    sku_source: skuSource,
     ml_attributes: itemData.attributes || {},
     ml_pictures: itemData.pictures || [],
     ml_available_quantity: itemData.available_quantity || 0,
+    ml_seller_sku: mlSku,
     updated_at: new Date().toISOString(),
+    updated_from_ml_at: new Date().toISOString(),
   };
 
   if (description !== undefined) {

--- a/tests/actions/resyncProduct.test.ts
+++ b/tests/actions/resyncProduct.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { resyncProduct } from '../../supabase/functions/ml-sync-v2/actions/resyncProduct.ts';
 
@@ -127,6 +127,64 @@ describe('resyncProduct action', () => {
     const updateArg = productsTable.update.mock.calls[0][0];
     expect(updateArg.cost_unit).toBeUndefined();
     expect(updateArg.name).toBeUndefined();
+  });
+
+  it('sets sku to null when ML does not provide', async () => {
+    const itemData = {
+      id: 'MLA4',
+      title: 'No SKU Item',
+      price: 10,
+      attributes: [],
+      available_quantity: 0,
+      sold_quantity: 0,
+      pictures: [],
+    } as any;
+
+    global.fetch = vi.fn((url: RequestInfo) => {
+      if (url.toString().includes('/description')) {
+        return Promise.resolve({ ok: true, json: async () => ({ plain_text: '' }) } as any);
+      }
+      return Promise.resolve({ ok: true, json: async () => itemData } as any);
+    });
+
+    const productsTable = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      error: null,
+    };
+    const mappingTable = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { ml_item_id: 'MLA4', products: { id: 'prod4', cost_unit: 0 } },
+        error: null,
+      }),
+      update: vi.fn().mockReturnThis(),
+    };
+    const mlSyncLogTable = { insert: vi.fn().mockResolvedValue({}) };
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'ml_product_mapping') return mappingTable;
+        if (table === 'products') return productsTable;
+        if (table === 'ml_sync_log') return mlSyncLogTable;
+        return { upsert: vi.fn().mockResolvedValue({}), update: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      }),
+    } as any;
+
+    await resyncProduct({ action: 'resync_product', productId: 'prod4' }, {
+      supabase,
+      tenantId: 'tenant1',
+      mlToken: 'token',
+      authToken: {},
+      mlClientId: 'test',
+      jwt: 'test'
+    });
+
+    const updateArg = productsTable.update.mock.calls[0][0];
+    expect(updateArg.sku).toBeNull();
+    expect(updateArg.sku_source).toBe('none');
+    expect(updateArg).toHaveProperty('updated_from_ml_at');
   });
 
   it('should normalize weight units to grams', async () => {


### PR DESCRIPTION
## Summary
- rely on Mercado Livre's `seller_custom_field`/`SELLER_SKU` when syncing products
- store SKU source and `updated_from_ml_at` timestamps
- test missing ML SKU handling

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b7173e48888329b883600270759887