### PR TITLE
feat: capture Mercado Livre SKU and category path

### DIFF
--- a/docs/development/database-schema.md
+++ b/docs/development/database-schema.md
@@ -56,6 +56,21 @@ CREATE TABLE ml_applications (
 
 ### Sincronização de Produtos
 
+#### Campos adicionais em `products`
+Campos de apoio à importação do Mercado Livre.
+
+```sql
+ALTER TABLE products
+  ADD COLUMN sku_source TEXT DEFAULT 'none',
+  ADD COLUMN ml_item_id TEXT,
+  ADD COLUMN category_ml_id TEXT,
+  ADD COLUMN category_ml_path JSONB DEFAULT '[]',
+  ADD COLUMN updated_from_ml_at TIMESTAMPTZ;
+
+CREATE UNIQUE INDEX idx_products_tenant_ml_item_id
+  ON products(tenant_id, ml_item_id);
+```
+
 #### `ml_product_mapping`
 Mapeia produtos locais para anúncios ML.
 

--- a/supabase/functions/ml-sync-v2/actions/importFromML.ts
+++ b/supabase/functions/ml-sync-v2/actions/importFromML.ts
@@ -218,6 +218,7 @@ export async function importFromML(
 
         // Capturar SKU fornecido pelo ML
         const mlSku =
+          itemDetail.seller_sku ||
           itemDetail.seller_custom_field ||
           attributes.find((attr) => attr.id === 'SELLER_SKU')?.value_name ||
           null;

--- a/supabase/migrations/20250902150000_6b460c0c-7a57-4de3-ae01-4d67d4f8da29.sql
+++ b/supabase/migrations/20250902150000_6b460c0c-7a57-4de3-ae01-4d67d4f8da29.sql
@@ -1,0 +1,10 @@
+-- Add ML integration columns to products
+ALTER TABLE public.products
+  ADD COLUMN sku_source TEXT DEFAULT 'none',
+  ADD COLUMN ml_item_id TEXT,
+  ADD COLUMN category_ml_id TEXT,
+  ADD COLUMN category_ml_path JSONB DEFAULT '[]',
+  ADD COLUMN updated_from_ml_at TIMESTAMPTZ;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_products_tenant_ml_item_id
+  ON public.products (tenant_id, ml_item_id);


### PR DESCRIPTION
## Summary
- handle `seller_sku` when deriving Mercado Livre SKU
- add missing product columns for ML sync
- document new ML product fields

## Testing
- `npx vitest run tests/actions/importFromML.test.ts`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b719a1e64883298e0b1e326cd6e5c5