### PR TITLE
fix: restore variation SKU fallback

### DIFF
--- a/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
@@ -101,7 +101,8 @@ export async function resyncProduct(
     const variation =
       productMapping.ml_variation_id
         ? itemData.variations?.find(
-            (v: any) => v.id === productMapping.ml_variation_id
+            // Normalize IDs as Supabase returns strings and ML API returns numbers
+            (v: any) => String(v.id) === String(productMapping.ml_variation_id)
           )
         : itemData.variations?.[0];
     const mlSku =
@@ -140,7 +141,7 @@ export async function resyncProduct(
       ml_seller_sku: mlSku,
       ml_available_quantity: itemData.available_quantity || 0,
       ml_sold_quantity: itemData.sold_quantity || 0,
-      ml_variation_id: variation?.id || null,
+      ml_variation_id: variation ? String(variation.id) : null,
       ml_pictures: itemData.pictures || [],
       updated_at: new Date().toISOString(),
       updated_from_ml_at: new Date().toISOString(),

--- a/supabase/functions/ml-sync-v2/actions/syncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/syncProduct.ts
@@ -123,8 +123,10 @@ export async function syncSingleProduct(
               const variation =
                 existingMapping?.ml_variation_id
                   ? itemData.variations?.find(
+                      // Normalize IDs because ML API returns numbers and Supabase stores strings
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      (v: any) => v.id === existingMapping.ml_variation_id
+                      (v: any) =>
+                        String(v.id) === String(existingMapping.ml_variation_id)
                     )
                   : itemData.variations?.[0];
               const mlSku =

--- a/supabase/functions/ml-webhook/updateProductFromItem.test.ts
+++ b/supabase/functions/ml-webhook/updateProductFromItem.test.ts
@@ -105,7 +105,7 @@ describe('updateProductFromItem', () => {
 
   it('uses variation seller_sku when item-level sku missing', async () => {
     mappingQuery.single.mockResolvedValueOnce({
-      data: { product_id: 'prod-2', ml_variation_id: 'VAR2' },
+      data: { product_id: 'prod-2', ml_variation_id: '67890' },
       error: null,
     });
     const itemData = {
@@ -113,7 +113,8 @@ describe('updateProductFromItem', () => {
       attributes: [],
       pictures: [],
       available_quantity: 1,
-      variations: [{ id: 'VAR2', seller_sku: 'VSKU2' }],
+      // ML returns numeric variation IDs
+      variations: [{ id: 67890, seller_sku: 'VSKU2' }],
     };
 
     await updateProductFromItem(supabase, 'tenant1', itemData, 'token');
@@ -121,6 +122,6 @@ describe('updateProductFromItem', () => {
     const updateArg = productsQuery.update.mock.calls[0][0];
     expect(updateArg.sku).toBe('VSKU2');
     expect(updateArg.sku_source).toBe('mercado_livre');
-    expect(updateArg.ml_variation_id).toBe('VAR2');
+    expect(updateArg.ml_variation_id).toBe('67890');
   });
 });

--- a/supabase/functions/ml-webhook/updateProductFromItem.ts
+++ b/supabase/functions/ml-webhook/updateProductFromItem.ts
@@ -36,8 +36,9 @@ export async function updateProductFromItem(
   const variation =
     mapping?.ml_variation_id
       ? itemData.variations?.find(
+          // Normalize IDs because ML API returns numbers and Supabase stores strings
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (v: any) => v.id === mapping.ml_variation_id
+          (v: any) => String(v.id) === String(mapping.ml_variation_id)
         )
       : itemData.variations?.[0];
   const mlSku =
@@ -63,7 +64,7 @@ export async function updateProductFromItem(
     ml_pictures: itemData.pictures || [],
     ml_available_quantity: itemData.available_quantity || 0,
     ml_seller_sku: mlSku,
-    ml_variation_id: variation?.id || null,
+    ml_variation_id: variation ? String(variation.id) : null,
     updated_at: new Date().toISOString(),
     updated_from_ml_at: new Date().toISOString(),
   };

--- a/tests/actions/resyncProduct.test.ts
+++ b/tests/actions/resyncProduct.test.ts
@@ -196,7 +196,8 @@ describe('resyncProduct action', () => {
       available_quantity: 0,
       sold_quantity: 0,
       pictures: [],
-      variations: [{ id: 'VAR1', seller_sku: 'VSKU1' }],
+      // ML API returns numeric IDs, ensure comparison works when mapping stores string
+      variations: [{ id: 12345, seller_sku: 'VSKU1' }],
     } as any;
 
     global.fetch = vi.fn((url: RequestInfo) => {
@@ -217,7 +218,8 @@ describe('resyncProduct action', () => {
       single: vi.fn().mockResolvedValue({
         data: {
           ml_item_id: 'MLA5',
-          ml_variation_id: 'VAR1',
+          // Supabase stores variation IDs as text
+          ml_variation_id: '12345',
           products: { id: 'prod5', cost_unit: 0 },
         },
         error: null,
@@ -247,7 +249,7 @@ describe('resyncProduct action', () => {
     const updateArg = productsTable.update.mock.calls[0][0];
     expect(updateArg.sku).toBe('VSKU1');
     expect(updateArg.sku_source).toBe('mercado_livre');
-    expect(updateArg.ml_variation_id).toBe('VAR1');
+    expect(updateArg.ml_variation_id).toBe('12345');
   });
 
   it('should normalize weight units to grams', async () => {


### PR DESCRIPTION
## Summary
- handle SKU lookup on mapped ML variations
- cover variation SKU fallback in resync and webhook tests
- normalize variation ID comparison between string stored IDs and numeric API IDs

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b725babd44832982b8de81a5db2ae0