### PR TITLE
feat: add ML write flag and guard write operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ VITE_SUPABASE_ANON_KEY=supabase-anon-key
 
 # Integração Mercado Livre
 VITE_ML_CLIENT_ID=seu-client-id-ml
+ML_WRITE_ENABLED=false

--- a/src/api/ml/write-enabled.ts
+++ b/src/api/ml/write-enabled.ts
@@ -1,0 +1,25 @@
+const getCookieValue = (cookieHeader: string | null, name: string): string | null => {
+  if (!cookieHeader) return null;
+  const match = cookieHeader
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${name}=`));
+  return match ? decodeURIComponent(match.split('=')[1]) : null;
+};
+
+export default async function handler(req: Request): Promise<Response> {
+  const token = getCookieValue(req.headers.get('cookie'), 'sb-access-token');
+
+  if (!token) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const enabled = (process.env.ML_WRITE_ENABLED ?? 'false') === 'true';
+  return new Response(
+    JSON.stringify({ enabled }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      status: 200,
+    }
+  );
+}

--- a/src/components/ml/MLProductList.tsx
+++ b/src/components/ml/MLProductList.tsx
@@ -12,7 +12,7 @@ import { MLProductRow } from "./MLProductRow";
 export function MLProductList() {
   const { data, isLoading } = useMLProducts();
   const products = data?.pages.flat() ?? [];
-  const { sync } = useMLIntegration();
+  const { sync, writeEnabled } = useMLIntegration();
   const { syncProduct, syncBatch, importFromML } = sync;
   
   const [selectedProducts, setSelectedProducts] = useState<string[]>([]);
@@ -80,7 +80,7 @@ export function MLProductList() {
               Importar do ML
             </Button>
 
-            {selectedProducts.length > 0 && (
+            {writeEnabled && selectedProducts.length > 0 && (
               <Button
                 onClick={handleSyncBatch}
                 disabled={syncBatch.isPending || syncProduct.isPending}
@@ -138,6 +138,7 @@ export function MLProductList() {
                       syncProduct.isPending &&
                       syncProduct.variables === product.id
                     }
+                    writeEnabled={writeEnabled}
                   />
                 ))}
               </TableBody>

--- a/src/components/ml/MLProductRow.tsx
+++ b/src/components/ml/MLProductRow.tsx
@@ -16,6 +16,7 @@ interface MLProductRowProps {
   onSync: (productId: string) => void;
   isProcessing: boolean;
   isLoading: boolean;
+  writeEnabled: boolean;
 }
 
 function MLProductRowComponent({
@@ -25,6 +26,7 @@ function MLProductRowComponent({
   onSync,
   isProcessing,
   isLoading,
+  writeEnabled,
 }: MLProductRowProps) {
   const handleSelectChange = useCallback(
     (checked: boolean) => {
@@ -92,26 +94,28 @@ function MLProductRowComponent({
       </TableCell>
       <TableCell>
         <div className="flex gap-2">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleSyncClick}
-                  disabled={isProcessing}
-                  aria-label="Enviar ao Mercado Livre"
-                >
-                  {isLoading ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <RefreshCw className="size-4" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Enviar ao Mercado Livre</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          {writeEnabled && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSyncClick}
+                    disabled={isProcessing}
+                    aria-label="Enviar ao Mercado Livre"
+                  >
+                    {isLoading ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <RefreshCw className="size-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Enviar ao Mercado Livre</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
         </div>
       </TableCell>
     </TableRow>

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -24,7 +24,7 @@ export default function Products() {
   const { data: products = [], isLoading } = useProductsWithCategories();
   const { data: mlProductsData } = useMLProducts();
   const mlProducts = mlProductsData?.pages.flat() ?? [];
-  const { sync, syncStatusQuery } = useMLIntegration();
+  const { sync, syncStatusQuery, writeEnabled } = useMLIntegration();
   const { importFromML } = sync;
   const { resyncProduct } = useMLProductResync();
   const deleteMutation = useDeleteProduct();
@@ -238,13 +238,15 @@ export default function Products() {
       icon: <Edit className="size-4" />,
       onClick: (product) => handleEdit(product),
     },
-    {
-      label: "Anunciar no ML",
-      icon: <Tag className="size-4" />,
-      onClick: (product) => handleAdvertiseOnML(product),
-      variant: "default",
-      disabled: (product) => product.source !== 'manual',
-    },
+    ...(writeEnabled
+      ? [{
+          label: "Anunciar no ML",
+          icon: <Tag className="size-4" />,
+          onClick: (product: ProductWithCategory) => handleAdvertiseOnML(product),
+          variant: "default",
+          disabled: (product: ProductWithCategory) => product.source !== 'manual',
+        }]
+      : []),
     {
       label: "Ver no ML",
       icon: <Package className="size-4" />,

--- a/supabase/.env.example
+++ b/supabase/.env.example
@@ -7,3 +7,4 @@ ML_CLIENT_SECRET=seu-client-secret-ml
 # URLs utilizadas pela aplicação
 ML_REDIRECT_URL=http://localhost:5173/integrations/mercadolivre/callback
 ML_WEBHOOK_SECRET=defina-um-segredo
+ML_WRITE_ENABLED=false

--- a/supabase/functions/ml-sync-v2/actions/createAd.ts
+++ b/supabase/functions/ml-sync-v2/actions/createAd.ts
@@ -1,4 +1,5 @@
 import { ActionContext, CreateAdRequest, errorResponse, corsHeaders } from '../types.ts';
+import { isMLWriteEnabled } from '../../shared/write-guard.ts';
 
 export async function createAd(
   req: CreateAdRequest,
@@ -6,6 +7,10 @@ export async function createAd(
 ): Promise<Response> {
   if (!req.ad_data) {
     return errorResponse('Ad data required', 400);
+  }
+
+  if (!isMLWriteEnabled()) {
+    return errorResponse('ML write operations disabled', 403);
   }
 
   await supabase

--- a/supabase/functions/ml-sync-v2/actions/syncBatch.ts
+++ b/supabase/functions/ml-sync-v2/actions/syncBatch.ts
@@ -1,5 +1,6 @@
 import { ActionContext, SyncBatchRequest, errorResponse, corsHeaders } from '../types.ts';
 import { syncSingleProduct } from './syncProduct.ts';
+import { isMLWriteEnabled } from '../../shared/write-guard.ts';
 
 export async function syncBatch(
   req: SyncBatchRequest,
@@ -7,6 +8,10 @@ export async function syncBatch(
 ): Promise<Response> {
   if (!req.product_ids || !Array.isArray(req.product_ids)) {
     return errorResponse('Product IDs array required', 400);
+  }
+
+  if (!isMLWriteEnabled()) {
+    return errorResponse('ML write operations disabled', 403);
   }
 
     const startTime = Date.now();

--- a/supabase/functions/ml-sync-v2/actions/syncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/syncProduct.ts
@@ -1,4 +1,5 @@
 import { ActionContext, SyncProductRequest, errorResponse, corsHeaders } from '../types.ts';
+import { isMLWriteEnabled } from '../../shared/write-guard.ts';
 import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const DEFAULT_IMAGE_PLACEHOLDER =
@@ -389,6 +390,10 @@ export async function syncProduct(
 ): Promise<Response> {
   if (!req.product_id) {
     return errorResponse('Product ID required', 400);
+  }
+
+  if (!isMLWriteEnabled()) {
+    return errorResponse('ML write operations disabled', 403);
   }
 
   try {

--- a/supabase/functions/shared/write-guard.ts
+++ b/supabase/functions/shared/write-guard.ts
@@ -1,0 +1,6 @@
+export function isMLWriteEnabled(): boolean {
+  const denoFlag = typeof Deno !== 'undefined' ? Deno.env.get('ML_WRITE_ENABLED') : undefined;
+  const nodeFlag = typeof process !== 'undefined' ? process.env.ML_WRITE_ENABLED : undefined;
+  const value = denoFlag ?? nodeFlag ?? 'false';
+  return value === 'true';
+}

--- a/tests/actions/mlWriteFlag.test.ts
+++ b/tests/actions/mlWriteFlag.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as syncModule from '../../supabase/functions/ml-sync-v2/actions/syncProduct.ts';
+import { createAd } from '../../supabase/functions/ml-sync-v2/actions/createAd.ts';
+
+const baseContext = { supabase: {} as any, tenantId: 'tenant1', mlToken: 'token' } as any;
+
+afterEach(() => {
+  delete process.env.ML_WRITE_ENABLED;
+  vi.restoreAllMocks();
+});
+
+describe('ML write flag', () => {
+  it('blocks syncProduct when disabled', async () => {
+    process.env.ML_WRITE_ENABLED = 'false';
+    const response = await syncModule.syncProduct(
+      { action: 'sync_product', product_id: 'prod1' },
+      baseContext
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it('allows syncProduct when enabled', async () => {
+    process.env.ML_WRITE_ENABLED = 'true';
+    const spy = vi
+      .spyOn(syncModule, 'syncSingleProduct')
+      .mockResolvedValue({ success: true });
+
+    const response = await syncModule.syncProduct(
+      { action: 'sync_product', product_id: 'prod1' },
+      baseContext
+    );
+
+    expect(spy).toHaveBeenCalled();
+    expect(response.status).toBe(200);
+  });
+
+  it('blocks createAd when disabled', async () => {
+    process.env.ML_WRITE_ENABLED = 'false';
+    const supabase = { from: vi.fn().mockReturnThis(), insert: vi.fn() } as any;
+    const response = await createAd(
+      { action: 'create_ad', ad_data: {} },
+      { supabase, tenantId: 'tenant1' } as any
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it('allows createAd when enabled', async () => {
+    process.env.ML_WRITE_ENABLED = 'true';
+    const insert = vi.fn().mockResolvedValue({});
+    const supabase = { from: vi.fn().mockReturnValue({ insert }) } as any;
+    const response = await createAd(
+      { action: 'create_ad', ad_data: {} },
+      { supabase, tenantId: 'tenant1' } as any
+    );
+    expect(insert).toHaveBeenCalled();
+    expect(response.status).toBe(200);
+  });
+});

--- a/tests/components/MLProductList.test.tsx
+++ b/tests/components/MLProductList.test.tsx
@@ -34,6 +34,7 @@ describe('MLProductList', () => {
         syncBatch: { mutate: vi.fn(), isPending: false },
         importFromML: { mutate: vi.fn(), isPending: false },
       },
+      writeEnabled: true,
     });
 
     render(<MLProductList />);
@@ -69,6 +70,7 @@ describe('MLProductList', () => {
         syncBatch: { mutate: vi.fn(), isPending: false },
         importFromML: { mutate: vi.fn(), isPending: false },
       },
+      writeEnabled: true,
     });
 
     render(<MLProductList />);
@@ -100,6 +102,7 @@ describe('MLProductList', () => {
         syncBatch: { mutate: vi.fn(), isPending: false },
         importFromML: { mutate: importMutate, isPending: false },
       },
+      writeEnabled: true,
     });
 
     render(<MLProductList />);


### PR DESCRIPTION
## Summary
- add ML_WRITE_ENABLED env flag with default disabled
- enforce write guard in syncProduct, syncBatch and createAd
- expose write flag to frontend and hide write actions when disabled

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b730c9a7388329b4234ffd97a394d2