### PR TITLE
feat: enhance ML product schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "prepare": "husky"
+    "prepare": "husky",
+    "align:ml": "node scripts/align-ml-data.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/align-ml-data.mjs
+++ b/scripts/align-ml-data.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY env vars');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey, { auth: { persistSession: false }});
+
+async function fetchCategoryPath(categoryId) {
+  const res = await fetch(`https://api.mercadolibre.com/categories/${categoryId}`);
+  if (!res.ok) return { id: categoryId, name: null, path: null };
+  const json = await res.json();
+  const path = json.path_from_root?.map(c => c.name).join(' > ');
+  return { id: json.id, name: json.name, path };
+}
+
+async function syncProduct(product) {
+  if (!product.ml_item_id) return;
+  const res = await fetch(`https://api.mercadolibre.com/items/${product.ml_item_id}`);
+  if (!res.ok) {
+    console.warn(`Item ${product.ml_item_id} not found`);
+    return;
+  }
+  const item = await res.json();
+  const sku = item.seller_custom_field || null;
+  const skuSource = sku ? 'mercado_livre' : 'none';
+  const category = await fetchCategoryPath(item.category_id);
+
+  if (category.name) {
+    await supabase.from('ml_categories').upsert({
+      id: category.id,
+      name: category.name,
+      path_from_root: category.path,
+    });
+  }
+
+  await supabase.from('products').update({
+    sku,
+    sku_source: skuSource,
+    category_ml_id: category.id,
+    category_ml_path: category.path,
+    updated_from_ml_at: new Date().toISOString(),
+  }).eq('id', product.id);
+}
+
+async function run() {
+  const { data, error } = await supabase
+    .from('products')
+    .select('id, ml_item_id')
+    .eq('origin', 'mercado_livre');
+
+  if (error) throw error;
+  for (const product of data) {
+    await syncProduct(product);
+  }
+
+  console.log('Alignment complete');
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -824,14 +824,20 @@ export type Database = {
           ml_seller_sku: string | null
           ml_sold_quantity: number | null
           ml_stock_quantity: number | null
-          ml_variation_id: string | null
-          ml_variations: Json | null
-          model: string | null
-          name: string
-          packaging_cost: number | null
-          sku: string | null
-          source: string
-          tax_rate: number | null
+            ml_variation_id: string | null
+            ml_variations: Json | null
+            ml_item_id: string | null
+            origin: Database["public"]["Enums"]["product_origin"] | null
+            sku_source: Database["public"]["Enums"]["sku_source"] | null
+            category_ml_id: string | null
+            category_ml_path: string | null
+            updated_from_ml_at: string | null
+            model: string | null
+            name: string
+            packaging_cost: number | null
+            sku: string | null
+            source: string
+            tax_rate: number | null
           tenant_id: string | null
           updated_at: string
           warranty: string | null
@@ -851,14 +857,20 @@ export type Database = {
           ml_seller_sku?: string | null
           ml_sold_quantity?: number | null
           ml_stock_quantity?: number | null
-          ml_variation_id?: string | null
-          ml_variations?: Json | null
-          model?: string | null
-          name: string
-          packaging_cost?: number | null
-          sku?: string | null
-          source?: string
-          tax_rate?: number | null
+            ml_variation_id?: string | null
+            ml_variations?: Json | null
+            ml_item_id?: string | null
+            origin?: Database["public"]["Enums"]["product_origin"] | null
+            sku_source?: Database["public"]["Enums"]["sku_source"] | null
+            category_ml_id?: string | null
+            category_ml_path?: string | null
+            updated_from_ml_at?: string | null
+            model?: string | null
+            name: string
+            packaging_cost?: number | null
+            sku?: string | null
+            source?: string
+            tax_rate?: number | null
           tenant_id?: string | null
           updated_at?: string
           warranty?: string | null
@@ -878,14 +890,20 @@ export type Database = {
           ml_seller_sku?: string | null
           ml_sold_quantity?: number | null
           ml_stock_quantity?: number | null
-          ml_variation_id?: string | null
-          ml_variations?: Json | null
-          model?: string | null
-          name?: string
-          packaging_cost?: number | null
-          sku?: string | null
-          source?: string
-          tax_rate?: number | null
+            ml_variation_id?: string | null
+            ml_variations?: Json | null
+            ml_item_id?: string | null
+            origin?: Database["public"]["Enums"]["product_origin"] | null
+            sku_source?: Database["public"]["Enums"]["sku_source"] | null
+            category_ml_id?: string | null
+            category_ml_path?: string | null
+            updated_from_ml_at?: string | null
+            model?: string | null
+            name?: string
+            packaging_cost?: number | null
+            sku?: string | null
+            source?: string
+            tax_rate?: number | null
           tenant_id?: string | null
           updated_at?: string
           warranty?: string | null
@@ -1476,6 +1494,8 @@ export type Database = {
         | "error"
         | "conflict"
         | "pending"
+      product_origin: "mercado_livre" | "manual" | "import"
+      sku_source: "mercado_livre" | "internal" | "none"
       user_role: "super_admin" | "admin" | "user"
     }
     CompositeTypes: {

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -10,6 +10,12 @@ export interface ProductType {
   packaging_cost: number;
   tax_rate: number;
   source: 'manual' | 'mercado_livre' | 'shopee';
+  origin?: 'mercado_livre' | 'manual' | 'import';
+  ml_item_id?: string | null;
+  sku_source?: 'mercado_livre' | 'internal' | 'none';
+  category_ml_id?: string | null;
+  category_ml_path?: string | null;
+  updated_from_ml_at?: string | null;
   created_at: string;
   updated_at: string;
   // Novos campos ML
@@ -44,6 +50,12 @@ export const productSchema = z.object({
   packaging_cost: z.number().min(0, "Custo de embalagem deve ser positivo").default(0),
   tax_rate: z.number().min(0, "Taxa de imposto deve ser positiva").max(100, "Taxa não pode exceder 100%").default(0),
   source: z.enum(['manual', 'mercado_livre', 'shopee']).default('manual'),
+  origin: z.enum(['mercado_livre', 'manual', 'import']).default('manual'),
+  sku_source: z.enum(['mercado_livre', 'internal', 'none']).default('none'),
+  ml_item_id: z.string().optional(),
+  category_ml_id: z.string().optional(),
+  category_ml_path: z.string().optional(),
+  updated_from_ml_at: z.string().optional(),
 });
 
 export type ProductFormData = z.infer<typeof productSchema>;

--- a/supabase/migrations/20250902160000_5278d46a-b265-4deb-bcee-17ee0291a3f4.sql
+++ b/supabase/migrations/20250902160000_5278d46a-b265-4deb-bcee-17ee0291a3f4.sql
@@ -1,0 +1,46 @@
+-- Add ML integration columns and constraints to products table
+ALTER TABLE public.products
+ADD COLUMN IF NOT EXISTS origin text CHECK (origin IN ('mercado_livre','manual','import')) DEFAULT 'manual',
+ADD COLUMN IF NOT EXISTS ml_item_id text,
+ADD COLUMN IF NOT EXISTS sku_source text CHECK (sku_source IN ('mercado_livre','internal','none')) DEFAULT 'none',
+ADD COLUMN IF NOT EXISTS category_ml_id text,
+ADD COLUMN IF NOT EXISTS category_ml_path text,
+ADD COLUMN IF NOT EXISTS updated_from_ml_at timestamp with time zone;
+
+-- Unique index for Mercado Livre items per account
+CREATE UNIQUE INDEX IF NOT EXISTS ux_products_account_ml
+ON public.products (tenant_id, ml_item_id)
+WHERE origin = 'mercado_livre';
+
+-- Trigger to enforce SKU integrity
+CREATE OR REPLACE FUNCTION public.enforce_ml_sku_integrity()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.sku_source = 'mercado_livre' THEN
+        IF NEW.ml_item_id IS NULL THEN
+            RAISE EXCEPTION 'ml_item_id must be set when sku_source = mercado_livre';
+        END IF;
+        IF NEW.sku IS NULL THEN
+            RAISE EXCEPTION 'sku must be set when sku_source = mercado_livre';
+        END IF;
+    ELSIF NEW.sku_source = 'none' THEN
+        IF NEW.sku IS NOT NULL THEN
+            RAISE EXCEPTION 'sku must be null when sku_source = none';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS enforce_ml_sku_integrity ON public.products;
+CREATE TRIGGER enforce_ml_sku_integrity
+BEFORE INSERT OR UPDATE ON public.products
+FOR EACH ROW EXECUTE FUNCTION public.enforce_ml_sku_integrity();
+
+-- Ensure ml_categories table exists
+CREATE TABLE IF NOT EXISTS public.ml_categories (
+  id text PRIMARY KEY,
+  name text NOT NULL,
+  path_from_root text,
+  updated_at timestamp with time zone DEFAULT now()
+);


### PR DESCRIPTION
## 🎯 Descrição
- add ML product columns and integrity trigger
- create one-off script to align SKUs and categories
- update shared types and Supabase enums

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [ ] Testes adicionados/atualizados
- [ ] Documentação atualizada

## 🧪 Testes
- `npm run lint`
- `npm run type-check`
- `npm test` *(falhando: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68b73727af208329a937e2a41505a066