### PR TITLE
fix: derive internal sku source for manual skus

### DIFF
--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -56,6 +56,12 @@ export const productSchema = z.object({
   category_ml_id: z.string().optional(),
   category_ml_path: z.string().optional(),
   updated_from_ml_at: z.string().optional(),
-});
+
+// Derive sku_source = 'internal' when a manual SKU is provided
+}).transform((data) => ({
+  ...data,
+  sku_source: data.sku ? 'internal' : data.sku_source,
+}));
 
 export type ProductFormData = z.infer<typeof productSchema>;
+

--- a/supabase/migrations/20250902160000_5278d46a-b265-4deb-bcee-17ee0291a3f4.sql
+++ b/supabase/migrations/20250902160000_5278d46a-b265-4deb-bcee-17ee0291a3f4.sql
@@ -12,6 +12,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS ux_products_account_ml
 ON public.products (tenant_id, ml_item_id)
 WHERE origin = 'mercado_livre';
 
+-- Backfill sku_source for existing manual SKUs
+UPDATE public.products
+SET sku_source = 'internal'
+WHERE sku IS NOT NULL AND (sku_source IS NULL OR sku_source = 'none');
+
 -- Trigger to enforce SKU integrity
 CREATE OR REPLACE FUNCTION public.enforce_ml_sku_integrity()
 RETURNS trigger AS $$

--- a/tests/contracts/zod-schemas.test.ts
+++ b/tests/contracts/zod-schemas.test.ts
@@ -54,7 +54,8 @@ describe('Zod schema contract tests', () => {
       created_at: '2024-01-01T00:00:00Z',
       updated_at: '2024-01-01T00:00:00Z',
     };
-    expect(() => productSchema.parse(data)).not.toThrow();
+    const parsed = productSchema.parse(data);
+    expect(parsed.sku_source).toBe('internal');
   });
 
   it('parses commission response', () => {


### PR DESCRIPTION
## Summary
- derive `sku_source` as `internal` when a manual SKU is provided
- backfill existing products with manual SKUs before enforcing trigger
- add test covering sku source derivation

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68b739e168d083299f91b24590657d63