### PR TITLE
fix: derive internal sku source for manual skus

### DIFF
--- a/src/components/forms/ProductModalForm.tsx
+++ b/src/components/forms/ProductModalForm.tsx
@@ -133,6 +133,7 @@ export function ProductModalForm({ product, onSuccess, onSubmitForm }: ProductMo
 
     const dataToSubmit = {
       ...formData,
+      sku_source: formData.sku ? "internal" : "none",
       category_id:
         formData.category_id === "none" || formData.category_id === ""
           ? null


### PR DESCRIPTION
## Summary
- derive `sku_source` as `internal` when a manual SKU is provided before submitting

## Testing
- `npm run lint`
- `npm run type-check`
- `npx vitest run` *(fails: tests/actions/mlWriteFlag.test.ts > ML write flag > allows syncProduct when enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68b73da412d483298c7593c208b7ee02