### PR TITLE
fix: preserve ML sku source on edit

### DIFF
--- a/src/components/forms/ProductModalForm.tsx
+++ b/src/components/forms/ProductModalForm.tsx
@@ -133,7 +133,12 @@ export function ProductModalForm({ product, onSuccess, onSubmitForm }: ProductMo
 
     const dataToSubmit = {
       ...formData,
-      sku_source: formData.sku ? "internal" : "none",
+      sku_source:
+        product?.sku_source === "mercado_livre"
+          ? product.sku_source
+          : formData.sku
+            ? "internal"
+            : "none",
       category_id:
         formData.category_id === "none" || formData.category_id === ""
           ? null


### PR DESCRIPTION
## Summary
- ensure `sku_source` stays `mercado_livre` when editing imported products
- only set `sku_source` to `internal` for manual SKUs

## Testing
- `npm run lint`
- `npm run type-check`
- `npx vitest run` *(fails: ML write flag > allows syncProduct when enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68b74089b3b883298eeea3dcd40249af