### PR TITLE
feat: handle ML SKU editing and display

### DIFF
--- a/src/components/forms/ProductModalForm.tsx
+++ b/src/components/forms/ProductModalForm.tsx
@@ -179,6 +179,8 @@ export function ProductModalForm({ product, onSuccess, onSubmitForm }: ProductMo
 
   const isLoading = createMutation.isPending || updateMutation.isPending;
   const custoTotal = formData.cost_unit + formData.packaging_cost;
+  const isMLProduct =
+    product?.source === "mercado_livre" || product?.origin === "mercado_livre";
 
   return (
     <div className="space-y-6">
@@ -345,19 +347,30 @@ export function ProductModalForm({ product, onSuccess, onSubmitForm }: ProductMo
         onToggle={optionalFields.toggle}
       >
         <div className="space-y-4">
-          <div>
-            <Label htmlFor="sku" className="text-sm font-medium">
-              SKU
-            </Label>
-            <Input
-              id="sku"
-              value={formData.sku}
-              onChange={(e) => handleInputChange("sku", e.target.value)}
-              placeholder="Ex: SM-G991B"
-              className="mt-1"
-              disabled={isLoading}
-            />
-          </div>
+          {isMLProduct ? (
+            <div>
+              <Label htmlFor="sku" className="text-sm font-medium">
+                SKU
+              </Label>
+              <p className="mt-1 text-sm text-muted-foreground">
+                SKU deve ser definido no Mercado Livre.
+              </p>
+            </div>
+          ) : (
+            <div>
+              <Label htmlFor="sku" className="text-sm font-medium">
+                SKU
+              </Label>
+              <Input
+                id="sku"
+                value={formData.sku}
+                onChange={(e) => handleInputChange("sku", e.target.value)}
+                placeholder="Ex: SM-G991B"
+                className="mt-1"
+                disabled={isLoading}
+              />
+            </div>
+          )}
           <div>
             <Label htmlFor="description" className="text-sm font-medium">
               Descrição

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -15,6 +15,12 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Separator } from "@/components/ui/separator";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { formatarMoeda } from "@/utils/pricing";
@@ -121,7 +127,9 @@ export default function ProductDetail() {
     : [];
 
   const mlProduct = mlProducts.find(ml => ml.id === product.id);
-  const hasIncompleteData = product.source === 'mercado_livre' && (!product.description || !product.sku || !product.brand);
+  const hasIncompleteData =
+    product.source === 'mercado_livre' &&
+    (!product.description || !product.ml_seller_sku || !product.brand);
 
   const formatWeight = (w: number) => {
     if (w >= 1000) {
@@ -236,14 +244,37 @@ export default function ProductDetail() {
                 </div>
                 <div>
                   <label className="text-sm font-medium text-muted-foreground">SKU</label>
-                  <p>{product.sku || <span className="text-muted-foreground">Não informado</span>}</p>
-                  
-                  {/* Mostrar SKU do ML se for diferente */}
-                  {product.source === 'mercado_livre' && product.ml_seller_sku && product.ml_seller_sku !== product.sku && (
-                    <>
-                      <label className="text-sm font-medium text-muted-foreground">SKU Original ML</label>
-                      <p className="text-sm text-muted-foreground">{product.ml_seller_sku}</p>
-                    </>
+                  {product.source === 'mercado_livre' ? (
+                    product.ml_seller_sku ? (
+                      <div className="flex items-center gap-2">
+                        <p>{product.ml_seller_sku}</p>
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Badge variant="outline">SKU Original ML</Badge>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              SKU definido originalmente no Mercado Livre
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      </div>
+                    ) : (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="text-muted-foreground">—</span>
+                          </TooltipTrigger>
+                          <TooltipContent>Defina o SKU no ML</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )
+                  ) : (
+                    <p>
+                      {product.sku || (
+                        <span className="text-muted-foreground">Não informado</span>
+                      )}
+                    </p>
                   )}
                 </div>
               </div>

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -4,6 +4,12 @@ import { Button } from "@/components/ui/button";
 import { DataVisualization } from "@/components/ui/data-visualization";
 import type { DataColumn, DataAction } from "@/components/ui/data-visualization";
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { formatarMoeda } from "@/utils/pricing";
 import { useProductsWithCategories, useDeleteProduct } from "@/hooks/useProducts";
 import type { ProductWithCategory } from "@/types/products";
@@ -35,7 +41,9 @@ export default function Products() {
       key: "name",
       header: "Nome",
       render: (item) => {
-        const hasIncompleteData = item.source === 'mercado_livre' && (!item.description || !item.sku || !item.brand);
+        const hasIncompleteData =
+          item.source === 'mercado_livre' &&
+          (!item.description || !item.ml_seller_sku || !item.brand);
         
         return (
           <div className="flex items-center gap-2">
@@ -65,10 +73,39 @@ export default function Products() {
                   </Button>
                 </>
               )}
-              {item.sku && (
-                <Badge variant="outline" className="text-xs">
-                  {item.sku}
-                </Badge>
+              {item.source === 'mercado_livre' ? (
+                item.ml_seller_sku ? (
+                  <div className="flex items-center gap-1">
+                    <span className="font-mono text-xs">{item.ml_seller_sku}</span>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge variant="outline" className="text-xs">
+                            SKU Original ML
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          SKU definido originalmente no Mercado Livre
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                ) : (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="text-muted-foreground">—</span>
+                      </TooltipTrigger>
+                      <TooltipContent>Defina o SKU no ML</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )
+              ) : (
+                item.sku && (
+                  <Badge variant="outline" className="text-xs">
+                    {item.sku}
+                  </Badge>
+                )
               )}
             </div>
           </div>

--- a/tests/components/ProductModalForm.test.tsx
+++ b/tests/components/ProductModalForm.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ProductModalForm } from '@/components/forms/ProductModalForm';
+import { testUtils } from '../setup';
+import type { ProductWithCategory } from '@/types/products';
+
+vi.mock('@/hooks/useCategories', () => ({
+  useCategories: () => ({ data: [] }),
+}));
+
+vi.mock('@/hooks/useProducts', () => ({
+  useCreateProduct: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateProduct: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/hooks/useCollapsibleSection', () => ({
+  useCollapsibleSection: () => ({ isOpen: true, toggle: vi.fn() }),
+}));
+
+describe('ProductModalForm', () => {
+  const noop = () => {};
+
+  it('esconde campo SKU para produtos do Mercado Livre', () => {
+    const product = testUtils.createMockProduct({
+      source: 'mercado_livre',
+    }) as ProductWithCategory;
+
+    render(
+      <ProductModalForm
+        product={product}
+        onSuccess={noop}
+        onSubmitForm={noop}
+      />
+    );
+
+    expect(screen.queryByLabelText(/SKU/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/SKU deve ser definido no Mercado Livre/i)
+    ).toBeInTheDocument();
+  });
+
+  it('exibe campo SKU para produtos manuais', () => {
+    const product = testUtils.createMockProduct({ source: 'manual' }) as ProductWithCategory;
+
+    render(
+      <ProductModalForm
+        product={product}
+        onSuccess={noop}
+        onSubmitForm={noop}
+      />
+    );
+
+    expect(screen.getByLabelText(/SKU/i)).toBeInTheDocument();
+  });
+});

--- a/tests/pages/Products.test.tsx
+++ b/tests/pages/Products.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, type Mock, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Products from '@/pages/Products';
+import { MemoryRouter } from 'react-router-dom';
+import { testUtils } from '../setup';
+import { useProductsWithCategories } from '@/hooks/useProducts';
+
+vi.mock('@/hooks/useMLProducts', () => ({
+  useMLProducts: () => ({ data: { pages: [] } }),
+}));
+
+vi.mock('@/hooks/useMLIntegration', () => ({
+  useMLIntegration: () => ({
+    sync: {
+      syncProduct: { mutate: vi.fn(), isPending: false },
+      syncBatch: { mutate: vi.fn(), isPending: false },
+      importFromML: { mutate: vi.fn(), isPending: false },
+    },
+    writeEnabled: true,
+    syncStatusQuery: { data: null },
+  }),
+}));
+
+vi.mock('@/hooks/useMLProductResync', () => ({
+  useMLProductResync: () => ({ resyncProduct: { mutate: vi.fn(), isPending: false } }),
+}));
+
+vi.mock('@/hooks/useProducts', () => ({
+  useProductsWithCategories: vi.fn(),
+  useDeleteProduct: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useGlobalModal', () => ({
+  useGlobalModal: () => ({ showFormModal: vi.fn(), showConfirmModal: vi.fn() }),
+}));
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('Products page', () => {
+  it('exibe SKU do ML com badge e sem SKU interno', () => {
+    const products = [
+      testUtils.createMockProduct({
+        id: '1',
+        name: 'Produto ML',
+        source: 'mercado_livre',
+        ml_seller_sku: 'ML-SKU-1',
+        sku: 'INTERNAL',
+        brand: 'Marca',
+      }),
+    ];
+
+    (useProductsWithCategories as Mock).mockReturnValue({
+      data: products,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <Products />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('ML-SKU-1')).toBeInTheDocument();
+    expect(screen.getByText('SKU Original ML')).toBeInTheDocument();
+    expect(screen.queryByText('INTERNAL')).not.toBeInTheDocument();
+  });
+
+  it('mostra traço e tooltip quando SKU do ML ausente', async () => {
+    const products = [
+      testUtils.createMockProduct({
+        id: '1',
+        name: 'Produto ML',
+        source: 'mercado_livre',
+        ml_seller_sku: undefined,
+        sku: undefined,
+        brand: 'Marca',
+      }),
+    ];
+
+    (useProductsWithCategories as Mock).mockReturnValue({
+      data: products,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <Products />
+      </MemoryRouter>
+    );
+
+    const dash = screen.getByText('—');
+    const user = userEvent.setup();
+    await user.hover(dash);
+    const tooltips = await screen.findAllByText('Defina o SKU no ML');
+    expect(tooltips.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- hide SKU input for Mercado Livre products and show informational message
- display ML seller SKU with badge and tooltips across product views
- add tests to cover ML SKU visibility and behavior

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run` *(fails: tests/actions/mlWriteFlag.test.ts > allows syncProduct when enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68b74262e13c8329b5572bf8868dda5c