### PR TITLE
feat: store ml category info on products

### DIFF
--- a/supabase/functions/ml-sync-v2/actions/importFromML.ts
+++ b/supabase/functions/ml-sync-v2/actions/importFromML.ts
@@ -120,7 +120,8 @@ export async function importFromML(
         }
 
         let categoryName = '';
-        let categoryPath: Array<{ id: string; name: string }> = [];
+        let categoryPathArray: Array<{ id: string; name: string }> = [];
+        let categoryPath = '';
         if (itemDetail.category_id) {
           try {
             const catResponse = await fetch(
@@ -130,7 +131,10 @@ export async function importFromML(
             if (catResponse.ok) {
               const catData = await catResponse.json();
               categoryName = catData.name;
-              categoryPath = catData.path_from_root || [];
+              categoryPathArray = catData.path_from_root || [];
+              categoryPath = categoryPathArray
+                .map((c: { name: string }) => c.name)
+                .join(' > ');
             }
           } catch (error) {
             console.log(
@@ -148,7 +152,7 @@ export async function importFromML(
               tenant_id: tenantId,
               ml_category_id: itemDetail.category_id,
               ml_category_name: categoryName,
-              ml_path_from_root: categoryPath,
+              ml_path_from_root: categoryPathArray,
               auto_mapped: true,
             })
             .select()

--- a/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
@@ -57,6 +57,7 @@ export async function resyncProduct(
     }
 
     let categoryData = null as any;
+    let categoryPath = '';
     if (itemData.category_id) {
       try {
         const catResponse = await fetch(
@@ -65,6 +66,9 @@ export async function resyncProduct(
         );
         if (catResponse.ok) {
           categoryData = await catResponse.json();
+          categoryPath = (categoryData.path_from_root || [])
+            .map((c: any) => c.name)
+            .join(' > ');
         }
       } catch (e) {
         console.warn('Could not fetch category:', e);
@@ -146,6 +150,11 @@ export async function resyncProduct(
       updated_at: new Date().toISOString(),
       updated_from_ml_at: new Date().toISOString(),
     };
+
+    if (categoryData) {
+      updateData.category_ml_id = categoryData.id;
+      updateData.category_ml_path = categoryPath;
+    }
 
     if (shouldUpdateName) updateData.name = itemData.title;
     if (shouldUpdateCost) updateData.cost_unit = itemData.price;

--- a/tests/actions/importFromML.test.ts
+++ b/tests/actions/importFromML.test.ts
@@ -110,7 +110,7 @@ describe('importFromML action', () => {
     const inserted = productsTable.upsert.mock.calls[0][0];
     expect(inserted.sku).toBe('SCF123');
     expect(inserted.sku_source).toBe('mercado_livre');
-    expect(inserted.category_ml_path).toEqual([{ id: 'CAT1', name: 'Root' }]);
+    expect(inserted.category_ml_path).toBe('Root');
   });
 
   it('uses seller_sku as sku when seller_custom_field is missing', async () => {

--- a/tests/actions/resyncProduct.test.ts
+++ b/tests/actions/resyncProduct.test.ts
@@ -20,11 +20,16 @@ describe('resyncProduct action', () => {
       seller_sku: '',
       variations: [],
       pictures: [],
+      category_id: 'CAT1'
     } as any;
 
     global.fetch = vi.fn((url: RequestInfo) => {
-      if (url.toString().includes('/description')) {
+      const urlStr = url.toString();
+      if (urlStr.includes('/description')) {
         return Promise.resolve({ ok: true, json: async () => ({ plain_text: '' }) } as any);
+      }
+      if (urlStr.includes('/categories/CAT1')) {
+        return Promise.resolve({ ok: true, json: async () => ({ id: 'CAT1', path_from_root: [{ name: 'Root' }] }) } as any);
       }
       return Promise.resolve({ ok: true, json: async () => itemData } as any);
     });
@@ -67,6 +72,8 @@ describe('resyncProduct action', () => {
     const updateArg = productsTable.update.mock.calls[0][0];
     expect(updateArg.cost_unit).toBe(itemData.price);
     expect(updateArg.name).toBe(itemData.title);
+    expect(updateArg.category_ml_id).toBe('CAT1');
+    expect(updateArg.category_ml_path).toBe('Root');
   });
 
   it('should not override existing cost_unit', async () => {


### PR DESCRIPTION
## 🎯 Descrição
- save Mercado Livre category id and path during imports, resync and webhooks
- update tests for category path handling

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [x] Testes adicionados/atualizados
- [ ] Documentação atualizada
- [ ] Edge Function deployável
- [ ] Logs de debug implementados

## 🧪 Testes
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b7536716b883298537972dd5857979