### PR TITLE
chore: enable strict TS checks and add typecheck CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       run: npm ci
 
     - name: Type check
-      run: npm run type-check
+      run: npm run typecheck
 
     - name: Lint
       run: npm run lint

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint . --cache",
     "lint:fix": "eslint . --fix --cache",
     "type-check": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:watch": "vitest watch",
     "test:ui": "vitest --ui",

--- a/src/types/marketplaces.ts
+++ b/src/types/marketplaces.ts
@@ -32,7 +32,7 @@ export const marketplaceSchema = z.object({
   platform_id: z.string().uuid().optional().nullable(),
   marketplace_type: z.enum(['platform', 'modality']).default('modality'),
   category_restrictions: z.array(z.string()).optional().default([]),
-  marketplace_metadata: z.record(z.any()).optional(),
+  marketplace_metadata: z.record(z.unknown()).optional(),
 });
 
 export type MarketplaceFormData = z.infer<typeof marketplaceSchema>;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,10 +15,11 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": false,
+    "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
     "noFallthroughCasesInSwitch": false,
 
     "baseUrl": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,12 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "noImplicitAny": false,
+    "strict": true,
+    "noImplicitAny": true,
     "noUnusedParameters": false,
     "skipLibCheck": true,
     "allowJs": true,
     "noUnusedLocals": false,
-    "strictNullChecks": false
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
## Summary
- enable strict TypeScript flags
- add typecheck script and run in CI
- replace remaining z.any with z.unknown

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run` *(fails: tests/actions/mlWriteFlag.test.ts > allows syncProduct when enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68b784e785cc8329ab420d9d98cfba45