### PR TITLE
chore: add bundle analysis and enforce size budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,6 @@ jobs:
       run: npm run build
 
     - name: Bundle Analysis
-      run: npm run build:analyze
-      continue-on-error: true
+      run: |
+        npm run build:analyze
+        node scripts/verifyBundleSize.mjs

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky",
-    "align:ml": "node scripts/align-ml-data.mjs"
+    "align:ml": "node scripts/align-ml-data.mjs",
+    "build:analyze": "vite build && npx source-map-explorer 'dist/assets/*.js'"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/verifyBundleSize.mjs
+++ b/scripts/verifyBundleSize.mjs
@@ -1,0 +1,26 @@
+import { readdir, stat } from 'fs/promises';
+import path from 'path';
+
+const limit = 250 * 1024; // 250 KiB
+const assetsDir = path.resolve('dist', 'assets');
+
+const entries = await readdir(assetsDir);
+let hasError = false;
+for (const file of entries) {
+  if (!file.endsWith('.js')) continue;
+  const filePath = path.join(assetsDir, file);
+  const { size } = await stat(filePath);
+  const sizeKb = size / 1024;
+  if (size > limit) {
+    console.error(`\u274c ${file} is ${sizeKb.toFixed(2)} KiB (limit: ${limit / 1024} KiB)`);
+    hasError = true;
+  } else {
+    console.log(`\u2705 ${file} is ${sizeKb.toFixed(2)} KiB`);
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+} else {
+  console.log('All bundles within size limit');
+}


### PR DESCRIPTION
## Summary
- add build:analyze script using source-map-explorer
- enforce 250 KiB bundle size budget in CI

## Testing
- `npm test` *(fails: allows syncProduct when enabled)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b78f438e2483299f6841c21fab5f66