### PR TITLE
chore: enforce zero eslint warnings

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged
+npm run lint
 npm test -- --run --passWithNoTests

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",
-    "lint": "eslint . --cache",
+    "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix --cache",
     "type-check": "tsc --noEmit",
     "typecheck": "tsc --noEmit",

--- a/src/components/ml/MLProductList.tsx
+++ b/src/components/ml/MLProductList.tsx
@@ -6,12 +6,12 @@ import { Package, Play, Loader2 } from "@/components/ui/icons";
 import { useMLIntegration } from "@/hooks/useMLIntegration";
 import { useMLProducts } from "@/hooks/useMLProducts";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { MLProductRow } from "./MLProductRow";
 
 export function MLProductList() {
   const { data, isLoading } = useMLProducts();
-  const products = data?.pages.flat() ?? [];
+  const products = useMemo(() => data?.pages.flat() ?? [], [data]);
   const { sync, writeEnabled } = useMLIntegration();
   const { syncProduct, syncBatch, importFromML } = sync;
   

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -131,6 +131,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       clearTimeout(safetyTimeout)
       subscription.unsubscribe()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []) // CORREÇÃO CRÍTICA: Remover [logger] para evitar loop infinito
 
   const signIn = async (email: string, password: string) => {


### PR DESCRIPTION
## 🎯 Descrição
- impede avisos do ESLint com `--max-warnings=0`
- executa `npm run lint` no pre-commit
- corrige avisos existentes nas rotinas de produtos e auth

## ✅ Checklist
- [x] Lint sem avisos (`npm run lint`)
- [ ] Testes passando (`npm test`) – `tests/actions/mlWriteFlag.test.ts > ML write flag > allows syncProduct when enabled`
- [x] Typecheck (`npm run typecheck`)


------
https://chatgpt.com/codex/tasks/task_e_68b825db44c08329ad6d089d390aafc1