### PR TITLE
feat: retrieve cost from ML sale terms

### DIFF
--- a/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
@@ -5,7 +5,7 @@ import {
   errorResponse,
   corsHeaders,
 } from '../types.ts';
-import { parseWeight, weightToGrams } from './importFromML.ts';
+import { parseWeight, weightToGrams, parseCost } from './importFromML.ts';
 
 export async function resyncProduct(
   req: ResyncProductRequest,
@@ -121,6 +121,8 @@ export async function resyncProduct(
       null;
     const skuSource = mlSku ? 'mercado_livre' : 'none';
 
+    const cost = parseCost(itemData.sale_terms || []);
+
     const shouldUpdateName = !productMapping.products?.name;
     const localCost = productMapping.products?.cost_unit;
     const shouldUpdateCost =
@@ -157,7 +159,7 @@ export async function resyncProduct(
     }
 
     if (shouldUpdateName) updateData.name = itemData.title;
-    if (shouldUpdateCost) updateData.cost_unit = itemData.price;
+    if (shouldUpdateCost) updateData.cost_unit = cost;
     if (shouldUpdatePrice) updateData.price = itemData.price;
 
     const { error: updateError } = await supabase


### PR DESCRIPTION
## 🎯 Descrição
- fetch product cost from Mercado Livre sale terms during import
- use fetched cost during product resync

## ✅ Checklist
- [ ] Funcionalidade básica implementada
- [ ] Testes adicionados/atualizados
- [ ] Documentação atualizada
- [ ] Edge Function deployável
- [ ] Logs de debug implementados

## 🧪 Testes
- `npm test` *(falhou: Failed to resolve import "i18next" from "src/lib/i18n.ts" )*
- `npm run lint` *(falhou: Cannot find package 'eslint-plugin-jsx-a11y')*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b833a3013083298f008077e9888484