### PR TITLE
feat: show selling price on product detail

### DIFF
--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -9,6 +9,7 @@ export interface ProductType {
   cost_unit: number;
   packaging_cost: number;
   tax_rate: number;
+  price?: number;
   source: 'manual' | 'mercado_livre' | 'shopee';
   origin?: 'mercado_livre' | 'manual' | 'import';
   ml_item_id?: string | null;


### PR DESCRIPTION
## Summary
- retrieve product selling price from ML mapping or local record
- display selling price in product details with ML origin tooltip
- type support for optional price field

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b857027e648329ace87e6606aaf70a