### PR TITLE
fix: derive ML product cost from sale terms

### DIFF
--- a/supabase/functions/ml-sync-v2/actions/importFromML.ts
+++ b/supabase/functions/ml-sync-v2/actions/importFromML.ts
@@ -273,9 +273,9 @@ export async function importFromML(
           null;
         const skuSource = mlSku ? 'mercado_livre' : 'none';
 
-        const cost =
-          parseCost(itemDetail.sale_terms || []) ??
-          (itemDetail.price ?? 0) * 0.7;
+        // Cost is parsed from ML sale terms when provided; otherwise use zero
+        // The previous heuristic of price * 0.7 has been removed to prevent mispricing
+        const cost = parseCost(itemDetail.sale_terms || []) ?? 0;
 
         const { data: newProduct, error: productError } = await supabase
           .from('products')

--- a/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
@@ -121,9 +121,9 @@ export async function resyncProduct(
       null;
     const skuSource = mlSku ? 'mercado_livre' : 'none';
 
-    const cost =
-      parseCost(itemData.sale_terms || []) ??
-      (itemData.price ?? 0) * 0.7;
+    // Cost is derived from ML sale terms when available, otherwise defaults to zero
+    // Previous fallback using 70% of item price was removed to avoid ambiguity
+    const cost = parseCost(itemData.sale_terms || []) ?? 0;
 
     const shouldUpdateName = !productMapping.products?.name;
 

--- a/tests/actions/resyncProduct.test.ts
+++ b/tests/actions/resyncProduct.test.ts
@@ -9,7 +9,7 @@ afterEach(() => {
 });
 
 describe('resyncProduct action', () => {
-  it('should map item price to cost_unit when local value is missing or zero', async () => {
+  it('defaults cost_unit to zero when sale terms are missing', async () => {
     const itemData = {
       id: 'MLA1',
       title: 'Test Item',
@@ -70,13 +70,13 @@ describe('resyncProduct action', () => {
 
     expect(productsTable.update).toHaveBeenCalled();
     const updateArg = productsTable.update.mock.calls[0][0];
-    expect(updateArg.cost_unit).toBe(itemData.price * 0.7);
+    expect(updateArg.cost_unit).toBe(0);
     expect(updateArg.name).toBe(itemData.title);
     expect(updateArg.category_ml_id).toBe('CAT1');
     expect(updateArg.category_ml_path).toBe('Root');
   });
 
-  it('updates cost_unit when fallback differs from stored value', async () => {
+  it('updates cost_unit when parsed value differs from stored value', async () => {
     const itemData = {
       id: 'MLA2',
       title: 'Another Item',
@@ -132,11 +132,11 @@ describe('resyncProduct action', () => {
 
     expect(productsTable.update).toHaveBeenCalled();
     const updateArg = productsTable.update.mock.calls[0][0];
-    expect(updateArg.cost_unit).toBeCloseTo(itemData.price * 0.7);
+    expect(updateArg.cost_unit).toBe(0);
     expect(updateArg.name).toBeUndefined();
   });
 
-  it('replaces fallback cost when sale terms provide real cost', async () => {
+  it('uses sale term cost when provided', async () => {
     const itemData = {
       id: 'MLA6',
       title: 'Item With Real Cost',


### PR DESCRIPTION
## Summary
- derive item cost from ML sale terms or default to zero
- remove old price-based cost heuristic in product resync/import
- update product resync tests for new cost logic

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b8a3ff71e083299b31fa1bd9aadc7f