### PR TITLE
fix: add allowed methods to ML CORS headers

### DIFF
--- a/supabase/functions/ml-auth/index.ts
+++ b/supabase/functions/ml-auth/index.ts
@@ -7,6 +7,7 @@ import { setupLogger } from '../shared/logger.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
 // PKCE Helper Functions - Compatível com Deno

--- a/supabase/functions/ml-sync-v2/types.ts
+++ b/supabase/functions/ml-sync-v2/types.ts
@@ -68,6 +68,7 @@ export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
 export const errorResponse = (message: string, status: number) =>


### PR DESCRIPTION
## 🎯 Descrição
- add `Access-Control-Allow-Methods` header to `ml-auth` and `ml-sync-v2` edge functions

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [ ] Testes adicionados/atualizados
- [ ] Documentação atualizada
- [ ] Edge Function deployável
- [ ] Logs de debug implementados

## 🧪 Testes
- `npm test -- --run`
- `npm run lint`
- `npm run type-check`

## 📋 Próximos Passos
- resolver falhas de testes e lint
- deploy das edge functions com token de acesso Supabase


------
https://chatgpt.com/codex/tasks/task_e_68b9a1115e408329b49562ddee9568cc