### PR TITLE
fix: use global logger for deno

### DIFF
--- a/supabase/functions/shared/logger.ts
+++ b/supabase/functions/shared/logger.ts
@@ -1,5 +1,4 @@
 import pino from 'https://esm.sh/pino@8';
-import { AsyncLocalStorage } from 'https://deno.land/std@0.168.0/node/async_hooks.ts';
 
 const originalConsole = globalThis.console;
 
@@ -34,10 +33,10 @@ const baseLogger = pino(
   stream,
 );
 
-const loggerStore = new AsyncLocalStorage<pino.Logger>();
+let currentLogger: pino.Logger = baseLogger;
 
 function getLogger(): pino.Logger {
-  return loggerStore.getStore() ?? baseLogger;
+  return currentLogger;
 }
 
 globalThis.console = {
@@ -51,7 +50,7 @@ globalThis.console = {
 export function setupLogger(headers: Headers) {
   const correlationId = headers.get('x-correlation-id') ?? crypto.randomUUID();
   const logger = baseLogger.child({ correlationId });
-  loggerStore.enterWith(logger);
+  currentLogger = logger;
   return logger;
 }
 


### PR DESCRIPTION
## Summary
- replace AsyncLocalStorage with global request logger for Deno

## Testing
- `npm test` *(fails: ZodError and AssertionError)*
- `npm run lint` *(fails: numerous lint errors)*
- `npm run type-check`
- `npx supabase functions deploy ml-auth` *(fails: Access token not provided)*
- `npx supabase functions deploy ml-sync-v2` *(fails: Access token not provided)*
- `curl -i -X OPTIONS https://ngkhzbzynkhgezkqykeb.supabase.co/functions/v1/ml-auth`
- `curl -i -X OPTIONS https://ngkhzbzynkhgezkqykeb.supabase.co/functions/v1/ml-sync-v2`


------
https://chatgpt.com/codex/tasks/task_e_68b9a7e4faa88329a22a3cb160bfaa24