### PR TITLE
fix: expand allowed methods in CORS headers

### DIFF
--- a/supabase/functions/ml-auth/index.ts
+++ b/supabase/functions/ml-auth/index.ts
@@ -7,6 +7,7 @@ import { setupLogger } from '../shared/logger.ts';
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
 };
 
 // PKCE Helper Functions - Compatível com Deno
@@ -38,7 +39,7 @@ async function generatePKCE(): Promise<{ codeVerifier: string; codeChallenge: st
 serve(async (req) => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
+    return new Response(null, { headers: corsHeaders, status: 200 });
   }
 
   try {

--- a/supabase/functions/ml-sync-v2/index.ts
+++ b/supabase/functions/ml-sync-v2/index.ts
@@ -31,7 +31,7 @@ const actions: Record<SyncRequest['action'], Handler> = {
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
+    return new Response(null, { headers: corsHeaders, status: 200 });
   }
 
   try {

--- a/supabase/functions/ml-sync-v2/types.ts
+++ b/supabase/functions/ml-sync-v2/types.ts
@@ -66,6 +66,7 @@ export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
 };
 
 export const errorResponse = (message: string, status: number) =>

--- a/supabase/functions/shared/ml-service.ts
+++ b/supabase/functions/shared/ml-service.ts
@@ -245,7 +245,7 @@ export class MLService {
   // Error handler padronizado
   handleError(error: any, operation: string): Response {
     console.error(`Error in ${operation}:`, error);
-    
+
     const errorResponse = {
       error: error.message || 'Internal server error',
       operation,
@@ -256,11 +256,7 @@ export class MLService {
 
     return new Response(JSON.stringify(errorResponse), {
       status: statusCode,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-      }
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
     });
   }
 
@@ -268,11 +264,7 @@ export class MLService {
   createResponse(data: any, status: number = 200): Response {
     return new Response(JSON.stringify(data), {
       status,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-      }
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
     });
   }
 
@@ -288,11 +280,12 @@ export class MLService {
 export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
 };
 
 export function handleCORS(request: Request): Response | null {
   if (request.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
+    return new Response(null, { headers: corsHeaders, status: 200 });
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- allow GET/POST/OPTIONS in CORS responses for ML edge functions
- reuse shared cors headers and return explicit 200 for preflight requests

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b9b233bacc8329846d80f020450515