### PR TITLE
refactor: centralize CORS handling across edge functions

### DIFF
--- a/supabase/functions/assistants/index.ts
+++ b/supabase/functions/assistants/index.ts
@@ -3,12 +3,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { assistantCreateSchema, assistantUpdateSchema } from '../shared/schemas.ts';
 import { setupLogger } from '../shared/logger.ts';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, PUT, DELETE, OPTIONS',
-};
+import { corsHeaders, handleCors } from '../shared/cors.ts';
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
@@ -22,13 +17,10 @@ serve(async (req) => {
   console.log('URL:', req.url);
   console.log('Headers:', Object.fromEntries(req.headers.entries()));
 
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
+  const corsResponse = handleCors(req);
+  if (corsResponse) {
     console.log('Handling OPTIONS request');
-    return new Response(null, { 
-      status: 200,
-      headers: corsHeaders 
-    });
+    return corsResponse;
   }
 
   try {

--- a/supabase/functions/generate-ad-chat/index.ts
+++ b/supabase/functions/generate-ad-chat/index.ts
@@ -3,16 +3,11 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 import { generateAdChatSchema } from '../shared/schemas.ts';
 import { setupLogger } from '../shared/logger.ts';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { corsHeaders, handleCors } from '../shared/cors.ts';
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
+  const corsResponse = handleCors(req);
+  if (corsResponse) return corsResponse;
 
   setupLogger(req.headers);
   try {

--- a/supabase/functions/generate-ad/index.ts
+++ b/supabase/functions/generate-ad/index.ts
@@ -2,17 +2,11 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { generateAdSchema } from '../shared/schemas.ts';
 import { setupLogger } from '../shared/logger.ts';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { corsHeaders, handleCors } from '../shared/cors.ts';
 
 serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
+  const corsResponse = handleCors(req);
+  if (corsResponse) return corsResponse;
 
   try {
     setupLogger(req.headers);

--- a/supabase/functions/ml-auth/index.ts
+++ b/supabase/functions/ml-auth/index.ts
@@ -3,12 +3,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { mlAuthSchema } from '../shared/schemas.ts';
 import type { z } from 'zod';
 import { setupLogger } from '../shared/logger.ts';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-};
+import { corsHeaders, handleCors } from '../shared/cors.ts';
 
 // PKCE Helper Functions - Compatível com Deno
 async function generateRandomString(length: number): Promise<string> {
@@ -37,10 +32,8 @@ async function generatePKCE(): Promise<{ codeVerifier: string; codeChallenge: st
 }
 
 serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders, status: 200 });
-  }
+  const corsResponse = handleCors(req);
+  if (corsResponse) return corsResponse;
 
   try {
     setupLogger(req.headers);

--- a/supabase/functions/ml-security-monitor/index.ts
+++ b/supabase/functions/ml-security-monitor/index.ts
@@ -1,19 +1,13 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0'
 import { setupLogger } from '../shared/logger.ts';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { corsHeaders, handleCors } from '../shared/cors.ts';
 
 console.log('ML Security Monitor initialized');
 
 serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
+  const corsResponse = handleCors(req);
+  if (corsResponse) return corsResponse;
 
   setupLogger(req.headers);
   const supabaseUrl = Deno.env.get('SUPABASE_URL')!;

--- a/supabase/functions/ml-sync-v2/actions/createAd.ts
+++ b/supabase/functions/ml-sync-v2/actions/createAd.ts
@@ -1,4 +1,5 @@
-import { ActionContext, CreateAdRequest, errorResponse, corsHeaders } from '../types.ts';
+import { ActionContext, CreateAdRequest, errorResponse } from '../types.ts';
+import { corsHeaders } from '../../shared/cors.ts';
 import { isMLWriteEnabled } from '../../shared/write-guard.ts';
 
 export async function createAd(

--- a/supabase/functions/ml-sync-v2/actions/getProducts.ts
+++ b/supabase/functions/ml-sync-v2/actions/getProducts.ts
@@ -1,4 +1,5 @@
-import { ActionContext, GetProductsRequest, errorResponse, corsHeaders } from '../types.ts';
+import { ActionContext, GetProductsRequest, errorResponse } from '../types.ts';
+import { corsHeaders } from '../../shared/cors.ts';
 
 interface ProductMapping {
   products: {

--- a/supabase/functions/ml-sync-v2/actions/getStatus.ts
+++ b/supabase/functions/ml-sync-v2/actions/getStatus.ts
@@ -1,4 +1,5 @@
-import { ActionContext, GetStatusRequest, errorResponse, corsHeaders } from '../types.ts';
+import { ActionContext, GetStatusRequest, errorResponse } from '../types.ts';
+import { corsHeaders } from '../../shared/cors.ts';
 
 export async function getStatus(
   _req: GetStatusRequest,

--- a/supabase/functions/ml-sync-v2/actions/importFromML.ts
+++ b/supabase/functions/ml-sync-v2/actions/importFromML.ts
@@ -2,8 +2,8 @@ import {
   ActionContext,
   ImportFromMLRequest,
   errorResponse,
-  corsHeaders,
 } from '../types.ts';
+import { corsHeaders } from '../../shared/cors.ts';
 import { resyncProduct } from './resyncProduct.ts';
 
 interface MLAttribute {

--- a/supabase/functions/ml-sync-v2/actions/linkProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/linkProduct.ts
@@ -1,4 +1,5 @@
-import { ActionContext, LinkProductRequest, errorResponse, corsHeaders } from '../types.ts';
+import { ActionContext, LinkProductRequest, errorResponse } from '../types.ts';
+import { corsHeaders } from '../../shared/cors.ts';
 
 export async function linkProduct(
   req: LinkProductRequest,

--- a/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/resyncProduct.ts
@@ -3,8 +3,8 @@ import {
   ActionContext,
   ResyncProductRequest,
   errorResponse,
-  corsHeaders,
 } from '../types.ts';
+import { corsHeaders } from '../../shared/cors.ts';
 import { parseWeight, weightToGrams, parseCost } from './importFromML.ts';
 
 export async function resyncProduct(

--- a/supabase/functions/ml-sync-v2/actions/syncBatch.ts
+++ b/supabase/functions/ml-sync-v2/actions/syncBatch.ts
@@ -1,4 +1,5 @@
-import { ActionContext, SyncBatchRequest, errorResponse, corsHeaders } from '../types.ts';
+import { ActionContext, SyncBatchRequest, errorResponse } from '../types.ts';
+import { corsHeaders } from '../../shared/cors.ts';
 import { syncSingleProduct } from './syncProduct.ts';
 import { isMLWriteEnabled } from '../../shared/write-guard.ts';
 

--- a/supabase/functions/ml-sync-v2/actions/syncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/syncProduct.ts
@@ -1,4 +1,5 @@
-import { ActionContext, SyncProductRequest, errorResponse, corsHeaders } from '../types.ts';
+import { ActionContext, SyncProductRequest, errorResponse } from '../types.ts';
+import { corsHeaders } from '../../shared/cors.ts';
 import { isMLWriteEnabled } from '../../shared/write-guard.ts';
 import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
 

--- a/supabase/functions/ml-sync-v2/index.ts
+++ b/supabase/functions/ml-sync-v2/index.ts
@@ -3,9 +3,9 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import {
   SyncRequest,
   ActionContext,
-  corsHeaders,
   errorResponse,
 } from './types.ts';
+import { corsHeaders, handleCors } from '../shared/cors.ts';
 import { mlSyncRequestSchema } from '../shared/schemas.ts';
 import { getStatus } from './actions/getStatus.ts';
 import { syncProduct } from './actions/syncProduct.ts';
@@ -30,9 +30,8 @@ const actions: Record<SyncRequest['action'], Handler> = {
 };
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders, status: 200 });
-  }
+  const corsResponse = handleCors(req);
+  if (corsResponse) return corsResponse;
 
   try {
     setupLogger(req.headers);

--- a/supabase/functions/ml-sync-v2/types.ts
+++ b/supabase/functions/ml-sync-v2/types.ts
@@ -1,3 +1,5 @@
+import { corsHeaders } from '../shared/cors.ts';
+
 interface QueryBuilder {
   select: (columns?: string) => QueryBuilder;
   update: (values: Record<string, unknown>) => QueryBuilder; 
@@ -61,13 +63,6 @@ export interface ActionContext {
   mlToken: string;
   jwt: string;
 }
-
-export const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers':
-    'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-};
 
 export const errorResponse = (message: string, status: number) =>
   new Response(JSON.stringify({ error: message }), {

--- a/supabase/functions/ml-token-renewal/index.ts
+++ b/supabase/functions/ml-token-renewal/index.ts
@@ -1,11 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0'
 import { setupLogger } from '../shared/logger.ts';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+import { corsHeaders, handleCors } from '../shared/cors.ts';
 
 console.log('ML Token Renewal Service initialized');
 
@@ -44,10 +40,8 @@ async function refreshWithRetry(refreshToken: string, mlClientId: string, mlClie
 }
 
 serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
+  const corsResponse = handleCors(req);
+  if (corsResponse) return corsResponse;
 
   setupLogger(req.headers);
   const supabaseUrl = Deno.env.get('SUPABASE_URL')!;

--- a/supabase/functions/ml-webhook/index.ts
+++ b/supabase/functions/ml-webhook/index.ts
@@ -4,19 +4,13 @@ import { updateProductFromItem } from './updateProductFromItem.ts';
 import { mlWebhookSchema } from '../shared/schemas.ts';
 import type { z } from 'zod';
 import { setupLogger } from '../shared/logger.ts';
+import { corsHeaders, handleCors } from '../shared/cors.ts';
 
 type MLWebhookPayload = z.infer<typeof mlWebhookSchema>;
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
-
 serve(async (req) => {
-  // Handle CORS preflight requests
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
+  const corsResponse = handleCors(req);
+  if (corsResponse) return corsResponse;
 
   setupLogger(req.headers);
   try {

--- a/supabase/functions/shared/cors.ts
+++ b/supabase/functions/shared/cors.ts
@@ -1,0 +1,11 @@
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+};
+
+export function handleCors(req: Request): Response | undefined {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+}

--- a/supabase/functions/shared/ml-service.ts
+++ b/supabase/functions/shared/ml-service.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // Shared ML Service Layer - Implementa princípios SOLID e DRY
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders, handleCors } from './cors.ts'
 
 // Types e Interfaces
 export interface MLAuthData {
@@ -276,26 +277,12 @@ export class MLService {
   }
 }
 
-// Middleware de CORS
-export const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-};
-
-export function handleCORS(request: Request): Response | null {
-  if (request.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders, status: 200 });
-  }
-  return null;
-}
-
 // Middleware de autenticação
 export async function withAuth(
   request: Request,
   handler: (authData: { tenantId: string; userId: string }) => Promise<Response>
 ): Promise<Response> {
-  const corsResponse = handleCORS(request);
+  const corsResponse = handleCors(request);
   if (corsResponse) return corsResponse;
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL')!;


### PR DESCRIPTION
## Summary
- add shared CORS helpers with `handleCors` utility
- refactor edge functions to reuse common headers

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b6fde2f08329b0fac30c72d64303