### PR TITLE
refactor: rename handleCors to applyCors

### DIFF
--- a/supabase/functions/assistants/index.ts
+++ b/supabase/functions/assistants/index.ts
@@ -3,7 +3,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { assistantCreateSchema, assistantUpdateSchema } from '../shared/schemas.ts';
 import { setupLogger } from '../shared/logger.ts';
-import { corsHeaders, handleCors } from '../shared/cors.ts';
+import { corsHeaders, applyCors } from '../shared/cors.ts';
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
@@ -17,7 +17,7 @@ serve(async (req) => {
   console.log('URL:', req.url);
   console.log('Headers:', Object.fromEntries(req.headers.entries()));
 
-  const corsResponse = handleCors(req);
+  const corsResponse = applyCors(req);
   if (corsResponse) {
     console.log('Handling OPTIONS request');
     return corsResponse;

--- a/supabase/functions/generate-ad-chat/index.ts
+++ b/supabase/functions/generate-ad-chat/index.ts
@@ -3,10 +3,10 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.53.0';
 import { generateAdChatSchema } from '../shared/schemas.ts';
 import { setupLogger } from '../shared/logger.ts';
-import { corsHeaders, handleCors } from '../shared/cors.ts';
+import { corsHeaders, applyCors } from '../shared/cors.ts';
 
 serve(async (req) => {
-  const corsResponse = handleCors(req);
+  const corsResponse = applyCors(req);
   if (corsResponse) return corsResponse;
 
   setupLogger(req.headers);

--- a/supabase/functions/generate-ad/index.ts
+++ b/supabase/functions/generate-ad/index.ts
@@ -2,10 +2,10 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { generateAdSchema } from '../shared/schemas.ts';
 import { setupLogger } from '../shared/logger.ts';
-import { corsHeaders, handleCors } from '../shared/cors.ts';
+import { corsHeaders, applyCors } from '../shared/cors.ts';
 
 serve(async (req) => {
-  const corsResponse = handleCors(req);
+  const corsResponse = applyCors(req);
   if (corsResponse) return corsResponse;
 
   try {

--- a/supabase/functions/ml-auth/index.ts
+++ b/supabase/functions/ml-auth/index.ts
@@ -3,7 +3,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { mlAuthSchema } from '../shared/schemas.ts';
 import type { z } from 'zod';
 import { setupLogger } from '../shared/logger.ts';
-import { corsHeaders, handleCors } from '../shared/cors.ts';
+import { corsHeaders, applyCors } from '../shared/cors.ts';
 
 // PKCE Helper Functions - Compatível com Deno
 async function generateRandomString(length: number): Promise<string> {
@@ -32,7 +32,7 @@ async function generatePKCE(): Promise<{ codeVerifier: string; codeChallenge: st
 }
 
 serve(async (req) => {
-  const corsResponse = handleCors(req);
+  const corsResponse = applyCors(req);
   if (corsResponse) return corsResponse;
 
   try {

--- a/supabase/functions/ml-security-monitor/index.ts
+++ b/supabase/functions/ml-security-monitor/index.ts
@@ -1,12 +1,12 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0'
 import { setupLogger } from '../shared/logger.ts';
-import { corsHeaders, handleCors } from '../shared/cors.ts';
+import { corsHeaders, applyCors } from '../shared/cors.ts';
 
 console.log('ML Security Monitor initialized');
 
 serve(async (req) => {
-  const corsResponse = handleCors(req);
+  const corsResponse = applyCors(req);
   if (corsResponse) return corsResponse;
 
   setupLogger(req.headers);

--- a/supabase/functions/ml-sync-v2/index.ts
+++ b/supabase/functions/ml-sync-v2/index.ts
@@ -5,7 +5,7 @@ import {
   ActionContext,
   errorResponse,
 } from './types.ts';
-import { corsHeaders, handleCors } from '../shared/cors.ts';
+import { corsHeaders, applyCors } from '../shared/cors.ts';
 import { mlSyncRequestSchema } from '../shared/schemas.ts';
 import { getStatus } from './actions/getStatus.ts';
 import { syncProduct } from './actions/syncProduct.ts';
@@ -30,7 +30,7 @@ const actions: Record<SyncRequest['action'], Handler> = {
 };
 
 serve(async (req) => {
-  const corsResponse = handleCors(req);
+  const corsResponse = applyCors(req);
   if (corsResponse) return corsResponse;
 
   try {

--- a/supabase/functions/ml-token-renewal/index.ts
+++ b/supabase/functions/ml-token-renewal/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0'
 import { setupLogger } from '../shared/logger.ts';
-import { corsHeaders, handleCors } from '../shared/cors.ts';
+import { corsHeaders, applyCors } from '../shared/cors.ts';
 
 console.log('ML Token Renewal Service initialized');
 
@@ -40,7 +40,7 @@ async function refreshWithRetry(refreshToken: string, mlClientId: string, mlClie
 }
 
 serve(async (req) => {
-  const corsResponse = handleCors(req);
+  const corsResponse = applyCors(req);
   if (corsResponse) return corsResponse;
 
   setupLogger(req.headers);

--- a/supabase/functions/ml-webhook/index.ts
+++ b/supabase/functions/ml-webhook/index.ts
@@ -4,12 +4,12 @@ import { updateProductFromItem } from './updateProductFromItem.ts';
 import { mlWebhookSchema } from '../shared/schemas.ts';
 import type { z } from 'zod';
 import { setupLogger } from '../shared/logger.ts';
-import { corsHeaders, handleCors } from '../shared/cors.ts';
+import { corsHeaders, applyCors } from '../shared/cors.ts';
 
 type MLWebhookPayload = z.infer<typeof mlWebhookSchema>;
 
 serve(async (req) => {
-  const corsResponse = handleCors(req);
+  const corsResponse = applyCors(req);
   if (corsResponse) return corsResponse;
 
   setupLogger(req.headers);

--- a/supabase/functions/shared/cors.ts
+++ b/supabase/functions/shared/cors.ts
@@ -7,7 +7,7 @@ export const corsHeaders = {
   'Access-Control-Max-Age': '86400',
 };
 
-export function handleCors(req: Request): Response | null {
+export function applyCors(req: Request): Response | null {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
     return new Response(null, {

--- a/supabase/functions/shared/ml-service.ts
+++ b/supabase/functions/shared/ml-service.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // Shared ML Service Layer - Implementa princípios SOLID e DRY
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import { corsHeaders, handleCors } from './cors.ts'
+import { corsHeaders, applyCors } from './cors.ts'
 
 // Types e Interfaces
 export interface MLAuthData {
@@ -282,7 +282,7 @@ export async function withAuth(
   request: Request,
   handler: (authData: { tenantId: string; userId: string }) => Promise<Response>
 ): Promise<Response> {
-  const corsResponse = handleCors(request);
+  const corsResponse = applyCors(request);
   if (corsResponse) return corsResponse;
 
   const supabaseUrl = Deno.env.get('SUPABASE_URL')!;


### PR DESCRIPTION
## Summary
- rename `handleCors` helper to `applyCors`
- update all edge functions to use `applyCors`

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `supabase functions deploy assistants` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d148bf208329a8965106912157b7