### PR TITLE
chore: add migration for decrypted ML tokens view

### DIFF
--- a/supabase/migrations/20250904220947_3e252164-a52b-41a6-a987-93e56ef389c8.sql
+++ b/supabase/migrations/20250904220947_3e252164-a52b-41a6-a987-93e56ef389c8.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE VIEW public.ml_auth_tokens_decrypted AS
+SELECT
+  id,
+  tenant_id,
+  CASE WHEN access_token IS NOT NULL
+       THEN pgp_sym_decrypt(decode(access_token, 'base64'),
+            coalesce(current_setting('app.ml_encryption_key', true), 'changeme'))::text
+  END AS access_token,
+  CASE WHEN refresh_token IS NOT NULL
+       THEN pgp_sym_decrypt(decode(refresh_token, 'base64'),
+            coalesce(current_setting('app.ml_encryption_key', true), 'changeme'))::text
+  END AS refresh_token,
+  token_type, expires_at, scope, user_id_ml, ml_nickname,
+  created_at, updated_at
+FROM public.ml_auth_tokens;


### PR DESCRIPTION
## Summary
- add SQL migration that creates `ml_auth_tokens_decrypted` view for decrypted ML tokens

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ba0d5feb1c8329a4aee8ed1a235fbf