### PR TITLE
fix: validate ml auth status response

### DIFF
--- a/src/types/ml/auth.ts
+++ b/src/types/ml/auth.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const mlAuthStatusResponseSchema = z.object({
+  connected: z.boolean().optional().default(false),
+  user_id_ml: z.number().optional(),
+  ml_nickname: z.string().optional(),
+  expires_at: z.string().optional().nullable(),
+});
+
+export type MLAuthStatusResponse = z.infer<typeof mlAuthStatusResponseSchema>;

--- a/tests/services/ml-service.test.ts
+++ b/tests/services/ml-service.test.ts
@@ -54,6 +54,15 @@ describe('MLService', () => {
       expect(status.isConnected).toBe(false);
       expect(status.error).toBe('Network error while checking auth status');
     });
+
+    it('deve tratar resposta inválida do backend', async () => {
+      vi.mocked(callMLFunction).mockResolvedValue({ connected: 'yes' });
+
+      const status = await MLService.getAuthStatus();
+
+      expect(status.isConnected).toBe(false);
+      expect(status.error).toBe('Invalid auth status response');
+    });
   });
 
   describe('Sync Operations', () => {


### PR DESCRIPTION
## 🎯 Descrição
- valida resposta da função `ml-auth` com Zod
- melhora tratamento de erros em `MLService.getAuthStatus`
- cobre cenário inválido nos testes do serviço

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [x] Testes adicionados/atualizados
- [ ] Documentação atualizada
- [ ] Edge Function deployável
- [ ] Logs de debug implementados

## 🧪 Testes
- `npx vitest run tests/services/ml-service.test.ts`
- `npm run lint` *(falha: Unexpected any e outras regras)*
- `npm run type-check`

## 📋 Próximos Passos
- Revisar e corrigir pendências de lint
- Investigar falhas em outras suítes de testes


------
https://chatgpt.com/codex/tasks/task_e_68beff995208832984576f827cd525c9