### PR TITLE
fix: allow null auth metadata values

### DIFF
--- a/src/services/ml-service.ts
+++ b/src/services/ml-service.ts
@@ -77,9 +77,9 @@ export class MLService {
       const data = mlAuthStatusResponseSchema.parse(raw);
       return {
         isConnected: data.connected,
-        user_id_ml: data.user_id_ml,
-        ml_nickname: data.ml_nickname,
-        expires_at: data.expires_at || undefined,
+        user_id_ml: data.user_id_ml ?? undefined,
+        ml_nickname: data.ml_nickname ?? undefined,
+        expires_at: data.expires_at ?? undefined,
       };
     } catch (error) {
       console.error('ML Auth Status Exception:', error);

--- a/src/types/ml/auth.ts
+++ b/src/types/ml/auth.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const mlAuthStatusResponseSchema = z.object({
   connected: z.boolean().optional().default(false),
-  user_id_ml: z.number().optional(),
-  ml_nickname: z.string().optional(),
+  user_id_ml: z.number().nullable().optional(),
+  ml_nickname: z.string().nullable().optional(),
   expires_at: z.string().optional().nullable(),
 });
 

--- a/tests/services/ml-service.test.ts
+++ b/tests/services/ml-service.test.ts
@@ -37,6 +37,20 @@ describe('MLService', () => {
       expect(callMLFunction).toHaveBeenCalledWith('ml-auth', 'get_status', {}, {});
     });
 
+    it('deve aceitar metadados nulos quando conectado', async () => {
+      vi.mocked(callMLFunction).mockResolvedValue({
+        connected: true,
+        user_id_ml: null,
+        ml_nickname: null,
+      });
+
+      const status = await MLService.getAuthStatus();
+
+      expect(status.isConnected).toBe(true);
+      expect(status.user_id_ml).toBeUndefined();
+      expect(status.ml_nickname).toBeUndefined();
+    });
+
     it('deve retornar desconectado quando há erro', async () => {
       vi.mocked(callMLFunction).mockRejectedValue(new Error('Token expired'));
 


### PR DESCRIPTION
## Summary
- allow null user metadata values in ML auth status schema
- normalize null ML auth metadata to undefined
- test ML auth handling when metadata is null

## Testing
- `npx vitest run tests/services/ml-service.test.ts`
- `npx eslint src/types/ml/auth.ts src/services/ml-service.ts tests/services/ml-service.test.ts`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68bf042bb5a0832998f476d0700cf70b