### PR TITLE
feat: handle ml auth disconnect

### DIFF
--- a/supabase/functions/ml-auth/index.ts
+++ b/supabase/functions/ml-auth/index.ts
@@ -86,7 +86,7 @@ serve(async (req) => {
     const tenantId = profile.tenant_id;
     console.log('Successfully retrieved tenant_id:', tenantId);
 
-    // Tentar ler body JSON, mas permitir se estiver vazio
+    // Tentar ler body JSON
     let body: z.infer<typeof mlAuthSchema>;
     try {
       const bodyText = await req.text();
@@ -94,7 +94,7 @@ serve(async (req) => {
       body = mlAuthSchema.parse(json);
     } catch (error) {
       console.error('Error parsing request body:', error);
-      body = mlAuthSchema.parse({});
+      return errorResponse('Invalid request body', 400);
     }
 
     switch (body.action) {

--- a/supabase/functions/ml-webhook/updateProductFromItem.test.ts
+++ b/supabase/functions/ml-webhook/updateProductFromItem.test.ts
@@ -134,4 +134,11 @@ describe('updateProductFromItem', () => {
     expect(updateArg.sku_source).toBe('mercado_livre');
     expect(updateArg.ml_variation_id).toBe('67890');
   });
+
+  it('throws when product mapping is missing (disconnected)', async () => {
+    mappingQuery.single.mockResolvedValueOnce({ data: null, error: { message: 'not found' } });
+    await expect(
+      updateProductFromItem(supabase, 'tenant1', { id: 'MLX' }, 'token')
+    ).rejects.toThrow('Product mapping not found');
+  });
 });

--- a/supabase/functions/shared/schemas.ts
+++ b/supabase/functions/shared/schemas.ts
@@ -33,7 +33,7 @@ export const assistantUpdateSchema = z.object({
 
 export const mlAuthSchema = z.object({
   action: z
-    .enum(['start_auth', 'handle_callback', 'refresh_token', 'get_status'])
+    .enum(['start_auth', 'handle_callback', 'refresh_token', 'disconnect', 'get_status'])
     .default('get_status'),
   code: z.string().optional(),
   state: z.string().optional(),


### PR DESCRIPTION
## Summary
- allow disconnect action in ml auth schema
- return 400 for invalid ml auth requests
- test product update when mapping disconnected

## Testing
- `npm test -- --run` *(fails: Test Files 3 failed | 18 passed)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68bf533fa6448329aafd1a4755753e87