### PR TITLE
feat: verify ml webhook signature

### DIFF
--- a/supabase/functions/ml-webhook/verifySignature.test.ts
+++ b/supabase/functions/ml-webhook/verifySignature.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { verifySignature } from './verifySignature';
+
+const body = JSON.stringify({ foo: 'bar' });
+const secret = 'secret';
+
+async function sign() {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const digest = await crypto.subtle.sign('HMAC', key, encoder.encode(body));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+describe('verifySignature', () => {
+  it('validates correct signature', async () => {
+    const sig = await sign();
+    const valid = await verifySignature(body, `sha256=${sig}`, secret);
+    expect(valid).toBe(true);
+  });
+
+  it('rejects invalid signature', async () => {
+    const sig = await sign();
+    const valid = await verifySignature(body, `sha256=bad${sig}`, secret);
+    expect(valid).toBe(false);
+  });
+
+  it('rejects when signature missing', async () => {
+    const valid = await verifySignature(body, null, secret);
+    expect(valid).toBe(false);
+  });
+});

--- a/supabase/functions/ml-webhook/verifySignature.ts
+++ b/supabase/functions/ml-webhook/verifySignature.ts
@@ -1,0 +1,23 @@
+export async function verifySignature(
+  body: string,
+  signature: string | null,
+  secret: string,
+): Promise<boolean> {
+  if (!signature || !secret) return false;
+  const [, received] = signature.split('=');
+  if (!received) return false;
+
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const digest = await crypto.subtle.sign('HMAC', key, encoder.encode(body));
+  const expected = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return received === expected;
+}

--- a/tests/functions/ml-webhook.test.ts
+++ b/tests/functions/ml-webhook.test.ts
@@ -20,12 +20,28 @@ describe('ml-webhook function', () => {
     });
 
     await expect(
-      callMLFunction('ml-webhook', 'process', {}, { headers: { 'X-Webhook-Signature': 'bad' } })
+      callMLFunction('ml-webhook', 'process', {}, { headers: { 'X-Hub-Signature': 'bad' } })
     ).rejects.toThrow('Invalid webhook signature');
 
     expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledWith('ml-webhook', {
       body: { action: 'process' },
-      headers: { Authorization: 'Bearer token', 'X-Webhook-Signature': 'bad' },
+      headers: { Authorization: 'Bearer token', 'X-Hub-Signature': 'bad' },
+    });
+  });
+
+  it('throws error when signature is missing', async () => {
+    mockSupabaseClient.functions.invoke.mockResolvedValue({
+      data: null,
+      error: { message: 'Invalid webhook signature' },
+    });
+
+    await expect(
+      callMLFunction('ml-webhook', 'process', {}, { headers: {} })
+    ).rejects.toThrow('Invalid webhook signature');
+
+    expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledWith('ml-webhook', {
+      body: { action: 'process' },
+      headers: { Authorization: 'Bearer token' },
     });
   });
 });


### PR DESCRIPTION
## Summary
- verify Mercado Livre webhook payloads using X-Hub-Signature HMAC
- type Supabase client and webhook payload interfaces
- add tests for signature validation and missing/invalid cases

## Testing
- `npx vitest run supabase/functions/ml-webhook/verifySignature.test.ts`
- `npx vitest run tests/functions/ml-webhook.test.ts`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68bf560d5b2c83299602bb3d891f1a36