### PR TITLE
refactor: standardize ml_sync_log table usage

### DIFF
--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -88,11 +88,11 @@ export default function ProductDetail() {
 
   // ML sync logs query
   const { data: syncLogs = [] } = useQuery<MLSyncLog[]>({
-    queryKey: ['ml_sync_logs', tenantId, id],
+    queryKey: ['ml_sync_log', tenantId, id],
     queryFn: async () => {
       if (!id) return [];
       const { data, error } = await supabase
-        .from('ml_sync_logs')
+        .from('ml_sync_log')
         .select('*')
         .eq('product_id', id)
         .order('created_at', { ascending: false })

--- a/supabase/functions/ml-sync-v2/actions/syncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/syncProduct.ts
@@ -326,7 +326,7 @@ async function logSyncOperation(
 ) {
   try {
     await supabase
-      .from('ml_sync_logs')
+      .from('ml_sync_log')
       .insert({
         tenant_id: tenantId,
         entity_type: 'product',

--- a/supabase/migrations/20250906001800_5e6ad416-2cb1-4ecd-8448-ef91c591ea62.sql
+++ b/supabase/migrations/20250906001800_5e6ad416-2cb1-4ecd-8448-ef91c591ea62.sql
@@ -1,0 +1,22 @@
+-- Migration to consolidate ml_sync_logs into ml_sync_log
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'ml_sync_logs'
+  ) THEN
+    INSERT INTO public.ml_sync_log (
+      id, tenant_id, operation_type, entity_type, entity_id,
+      ml_entity_id, status, request_data, response_data,
+      error_details, execution_time_ms, created_at
+    )
+    SELECT id, tenant_id, operation_type, entity_type, entity_id,
+           ml_entity_id, status, request_data, response_data,
+           error_details, execution_time_ms, created_at
+    FROM public.ml_sync_logs
+    ON CONFLICT (id) DO NOTHING;
+
+    DROP TABLE public.ml_sync_logs;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## 🎯 Descrição
- padroniza o uso da tabela `ml_sync_log`
- adiciona migração para mover dados de `ml_sync_logs`

## ✅ Checklist
- [x] Funcionalidade básica implementada
- [ ] Testes adicionados/atualizados
- [ ] Documentação atualizada
- [ ] Edge Function deployável
- [ ] Logs de debug implementados

## 🧪 Testes
- `npm test` *(falhou)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68bf5c05da608329af667ec4feabc7d5