### PR TITLE
refactor: standardize ml_sync_log table usage

### DIFF
--- a/supabase/functions/ml-sync-v2/actions/syncProduct.ts
+++ b/supabase/functions/ml-sync-v2/actions/syncProduct.ts
@@ -329,11 +329,12 @@ async function logSyncOperation(
       .from('ml_sync_log')
       .insert({
         tenant_id: tenantId,
+        operation_type: 'sync_product',
         entity_type: 'product',
         entity_id: productId,
-        operation: 'sync',
         status: success ? 'success' : 'error',
-        message,
+        response_data: success ? { message } : null,
+        error_details: success ? null : { message },
         created_at: new Date().toISOString()
       });
   } catch (error) {


### PR DESCRIPTION
## Summary
- align ml_sync_log insert with new schema using operation_type and structured data

## Testing
- `npm test` *(fails: spy not called, etc.)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68bf5fabe7208329a31ee679f4ad117a