### PR TITLE
refactor: use crypto.randomUUID for oauth state

### DIFF
--- a/supabase/functions/ml-auth/index.ts
+++ b/supabase/functions/ml-auth/index.ts
@@ -106,7 +106,7 @@ serve(async (req) => {
           // Gerar PKCE
           const { codeVerifier, codeChallenge } = await generatePKCE();
           const redirectUri = Deno.env.get('ML_REDIRECT_URL') || 'https://peepers-hub.lovable.app/integrations/mercado-livre/callback';
-          const state = `${tenantId}_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+          const state = `${tenantId}_${Date.now()}_${crypto.randomUUID()}`;
 
           // Armazenar PKCE na base de dados
           const { error: pkceError } = await supabase

--- a/tests/functions/ml-auth.test.ts
+++ b/tests/functions/ml-auth.test.ts
@@ -14,14 +14,15 @@ describe('ml-auth service', () => {
   });
 
   it('starts auth flow and returns url', async () => {
+    const state = 'tenant123_1712345678901_550e8400-e29b-41d4-a716-446655440000';
     mockSupabaseClient.functions.invoke.mockResolvedValue({
-      data: { auth_url: 'https://auth.url', state: 'state123' },
+      data: { auth_url: 'https://auth.url', state },
       error: null,
     });
 
     const result = await MLService.startAuth();
 
-    expect(result).toEqual({ auth_url: 'https://auth.url', state: 'state123' });
+    expect(result).toEqual({ auth_url: 'https://auth.url', state });
     expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledWith('ml-auth', {
       body: { action: 'start_auth' },
       headers: { Authorization: 'Bearer token' },
@@ -29,12 +30,13 @@ describe('ml-auth service', () => {
   });
 
   it('handles callback with provided code and state', async () => {
+    const state = 'tenant123_1712345678901_550e8400-e29b-41d4-a716-446655440000';
     mockSupabaseClient.functions.invoke.mockResolvedValue({ data: null, error: null });
 
-    await MLService.handleCallback('code123', 'state456');
+    await MLService.handleCallback('code123', state);
 
     expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledWith('ml-auth', {
-      body: { action: 'handle_callback', code: 'code123', state: 'state456' },
+      body: { action: 'handle_callback', code: 'code123', state },
       headers: { Authorization: 'Bearer token' },
     });
   });


### PR DESCRIPTION
## Summary
- replace Math.random usage in ml-auth function with crypto.randomUUID
- update ml-auth tests to match new state format

## Testing
- `npm test` *(fails: AssertionError in importFromML and other suites)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68bf6202634483298ffe8d949c0c28fa