### PR TITLE
refactor: add types for ML webhook update

### DIFF
--- a/supabase/functions/ml-webhook/index.ts
+++ b/supabase/functions/ml-webhook/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2.45.4";
-import { updateProductFromItem } from './updateProductFromItem.ts';
+import { updateProductFromItem, type ItemData } from './updateProductFromItem.ts';
 import { mlWebhookSchema } from '../shared/schemas.ts';
 import { setupLogger } from '../shared/logger.ts';
 import { corsHeaders, handleCors } from '../shared/cors.ts';
@@ -207,7 +207,7 @@ async function processItemWebhook(
       throw new Error(`Failed to fetch item: ${itemResponse.status}`);
     }
 
-    const itemData = await itemResponse.json();
+    const itemData: ItemData = await itemResponse.json();
 
     const updatedFields = await updateProductFromItem(
       supabase,


### PR DESCRIPTION
## Summary
- define SupabaseClient and ML item data interfaces for webhook update
- replace any with new types and adjust function usage
- update updateProductFromItem tests with typed mocks

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: defaults cost_unit to zero when sale terms are missing, updates cost_unit when parsed value differs from stored value, uses sale term cost when provided, sets sku to null when ML does not provide, uses variation seller_sku when item-level sku is missing, should normalize weight units to grams, starts auth flow and returns url, refresh token, throws error when signature is invalid, throws error when signature is missing, deve atualizar produto com sucesso)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8f9203a883298ed0fb9dc9060c79