### PR TITLE
refactor: use structured logger for edge functions

### DIFF
--- a/supabase/functions/ml-security-monitor/index.ts
+++ b/supabase/functions/ml-security-monitor/index.ts
@@ -1,11 +1,12 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0'
-import { setupLogger } from '../shared/logger.ts';
+import { setupLogger, logger } from '../shared/logger.ts';
 import { corsHeaders, handleCors } from '../shared/cors.ts';
 
-console.log('ML Security Monitor initialized');
+logger.info('ML Security Monitor initialized');
 
 serve(async (req) => {
+  const requestId = crypto.randomUUID();
   const corsResponse = handleCors(req);
   if (corsResponse) return corsResponse;
 
@@ -17,7 +18,7 @@ serve(async (req) => {
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
   try {
-    console.log('Starting ML security and health monitoring...');
+    logger.info('Starting ML security and health monitoring', { requestId, action: 'security-scan' });
     
     const securityReport = {
       timestamp: new Date().toISOString(),
@@ -131,7 +132,7 @@ serve(async (req) => {
     // 6. Alert on critical issues
     const criticalIssues = securityReport.issues.filter(issue => issue.severity === 'high');
     if (criticalIssues.length > 0) {
-      console.warn('CRITICAL SECURITY ISSUES DETECTED:', criticalIssues);
+      logger.warn('CRITICAL SECURITY ISSUES DETECTED', { requestId, issues: criticalIssues, action: 'security-scan' });
       
       // In a real implementation, you would send alerts via email/Slack/etc
       await supabase.from('ml_sync_log').insert({
@@ -146,7 +147,7 @@ serve(async (req) => {
       });
     }
 
-    console.log(`Security scan completed: ${securityReport.issues.length} issues found`);
+    logger.info('Security scan completed', { requestId, issuesFound: securityReport.issues.length, action: 'security-scan' });
 
     return new Response(
       JSON.stringify({
@@ -161,7 +162,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Fatal error in security monitoring:', error);
+    logger.error('Fatal error in security monitoring', error as Error, { requestId, action: 'security-scan' });
     
     return new Response(
       JSON.stringify({ 

--- a/supabase/functions/ml-token-renewal/index.ts
+++ b/supabase/functions/ml-token-renewal/index.ts
@@ -1,11 +1,11 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0'
-import { setupLogger } from '../shared/logger.ts';
+import { setupLogger, logger } from '../shared/logger.ts';
 import { corsHeaders, handleCors } from '../shared/cors.ts';
 
-console.log('ML Token Renewal Service initialized');
+logger.info('ML Token Renewal Service initialized');
 
-async function refreshWithRetry(refreshToken: string, mlClientId: string, mlClientSecret: string) {
+async function refreshWithRetry(refreshToken: string, mlClientId: string, mlClientSecret: string, requestId: string) {
   const maxRetries = 3;
   const baseDelay = 500; // ms
 
@@ -33,13 +33,14 @@ async function refreshWithRetry(refreshToken: string, mlClientId: string, mlClie
     } catch (error) {
       if (attempt === maxRetries - 1) throw error;
       const delay = baseDelay * Math.pow(2, attempt);
-      console.log(`Retrying token refresh in ${delay}ms due to error:`, error);
+      logger.warn('Retrying token refresh', { delay, error, action: 'refresh-token', requestId });
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
 }
 
 serve(async (req) => {
+  const requestId = crypto.randomUUID();
   const corsResponse = handleCors(req);
   if (corsResponse) return corsResponse;
 
@@ -53,7 +54,7 @@ serve(async (req) => {
   const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
   try {
-    console.log('Starting automatic token renewal process...');
+    logger.info('Starting automatic token renewal process', { requestId, action: 'token-renewal' });
     
     // Find tokens that expire in less than 2 hours
     const twoHoursFromNow = new Date();
@@ -67,11 +68,11 @@ serve(async (req) => {
       .not('refresh_token', 'is', null); // Has refresh token
 
     if (queryError) {
-      console.error('Error querying expiring tokens:', queryError);
+      logger.error('Error querying expiring tokens', undefined, { requestId, action: 'token-renewal', error: queryError });
       throw queryError;
     }
 
-    console.log(`Found ${expiringSoonTokens?.length || 0} tokens expiring soon`);
+    logger.info('Found tokens expiring soon', { requestId, count: expiringSoonTokens?.length || 0, action: 'token-renewal' });
 
     let renewedCount = 0;
     let failedCount = 0;
@@ -79,10 +80,10 @@ serve(async (req) => {
     // Process each token
     for (const token of expiringSoonTokens || []) {
       try {
-        console.log(`Renewing token for tenant: ${token.tenant_id}`);
+        logger.info('Renewing token for tenant', { requestId, tenantId: token.tenant_id, action: 'token-renewal' });
 
         // Refresh token with retry/backoff
-        const tokenData = await refreshWithRetry(token.refresh_token, mlClientId, mlClientSecret);
+        const tokenData = await refreshWithRetry(token.refresh_token, mlClientId, mlClientSecret, requestId);
         const expiresAt = new Date();
         expiresAt.setSeconds(expiresAt.getSeconds() + tokenData.expires_in);
 
@@ -98,7 +99,7 @@ serve(async (req) => {
           .eq('id', token.id);
 
         if (updateError) {
-          console.error(`Failed to update token in DB for tenant ${token.tenant_id}:`, updateError);
+          logger.error('Failed to update token in DB', undefined, { requestId, tenantId: token.tenant_id, action: 'token-renewal', error: updateError });
           failedCount++;
           continue;
         }
@@ -117,10 +118,10 @@ serve(async (req) => {
         });
 
         renewedCount++;
-        console.log(`Successfully renewed token for tenant: ${token.tenant_id}`);
+        logger.info('Successfully renewed token for tenant', { requestId, tenantId: token.tenant_id, action: 'token-renewal' });
 
       } catch (error) {
-        console.error(`Unexpected error renewing token for tenant ${token.tenant_id}:`, error);
+        logger.error('Unexpected error renewing token', error as Error, { requestId, tenantId: token.tenant_id, action: 'token-renewal' });
         
         // Log unexpected errors
         await supabase.from('ml_sync_log').insert({
@@ -140,7 +141,7 @@ serve(async (req) => {
     }
 
     // Summary log
-    console.log(`Token renewal completed: ${renewedCount} renewed, ${failedCount} failed`);
+    logger.info('Token renewal completed', { requestId, renewed: renewedCount, failed: failedCount, action: 'token-renewal' });
 
     return new Response(
       JSON.stringify({
@@ -156,7 +157,7 @@ serve(async (req) => {
     );
 
   } catch (error) {
-    console.error('Fatal error in token renewal process:', error);
+    logger.error('Fatal error in token renewal process', error as Error, { requestId, action: 'token-renewal' });
     
     return new Response(
       JSON.stringify({ 

--- a/supabase/functions/ml-webhook/index.ts
+++ b/supabase/functions/ml-webhook/index.ts
@@ -2,7 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2.45.4";
 import { updateProductFromItem, type ItemData } from './updateProductFromItem.ts';
 import { mlWebhookSchema } from '../shared/schemas.ts';
-import { setupLogger } from '../shared/logger.ts';
+import { setupLogger, logger } from '../shared/logger.ts';
 import { corsHeaders, handleCors } from '../shared/cors.ts';
 import { verifySignature } from './verifySignature.ts';
 
@@ -17,6 +17,7 @@ interface MLWebhookPayload {
 }
 
 serve(async (req) => {
+  const requestId = crypto.randomUUID();
   const corsResponse = handleCors(req);
   if (corsResponse) return corsResponse;
 
@@ -27,7 +28,7 @@ serve(async (req) => {
     const secret = Deno.env.get('MELI_WEBHOOK_SECRET')!;
     const isValid = await verifySignature(rawBody, signature, secret);
     if (!isValid) {
-      console.error('Invalid ML webhook signature');
+      logger.error('Invalid ML webhook signature', undefined, { requestId, action: 'verify-signature' });
       return new Response('Invalid webhook signature', {
         status: 401,
         headers: corsHeaders,
@@ -35,7 +36,7 @@ serve(async (req) => {
     }
 
     const payload = mlWebhookSchema.parse(JSON.parse(rawBody));
-    console.log('Received ML webhook:', payload);
+    logger.info('Received ML webhook', { requestId, action: 'parse-webhook', topic: payload.topic });
 
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
     const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
@@ -47,7 +48,7 @@ serve(async (req) => {
       .rpc('get_tenant_by_ml_user_id', { p_user_id_ml: payload.user_id });
 
     if (tenantError || !tenantData) {
-      console.error('Tenant not found for ML user:', payload.user_id);
+      logger.error('Tenant not found for ML user', undefined, { requestId, action: 'lookup-tenant', userId: payload.user_id });
       return new Response('Tenant not found', { status: 404 });
     }
 
@@ -67,22 +68,22 @@ serve(async (req) => {
       });
 
     if (logError) {
-      console.error('Failed to log webhook event:', logError);
+      logger.error('Failed to log webhook event', undefined, { requestId, tenantId, action: 'log-webhook', error: logError });
     }
 
     // Process webhook based on topic
     let result: { updatedFields?: string[]; error?: Error } | undefined;
     switch (payload.topic) {
       case 'orders_v2':
-        result = await processOrderWebhook(supabase, tenantId, payload);
+        result = await processOrderWebhook(supabase, tenantId, payload, requestId);
         break;
 
       case 'items':
-        result = await processItemWebhook(supabase, tenantId, payload);
+        result = await processItemWebhook(supabase, tenantId, payload, requestId);
         break;
 
       default:
-        console.log('Unhandled webhook topic:', payload.topic);
+        logger.warn('Unhandled webhook topic', { requestId, tenantId, action: 'handle-webhook', topic: payload.topic });
     }
 
     // Mark webhook as processed with results
@@ -105,7 +106,7 @@ serve(async (req) => {
     });
 
   } catch (error) {
-    console.error('ML Webhook Error:', error);
+    logger.error('ML Webhook Error', error as Error, { requestId, action: 'webhook-handler' });
     
     return new Response(
       JSON.stringify({ error: error.message }),
@@ -120,9 +121,10 @@ serve(async (req) => {
 async function processOrderWebhook(
   supabase: SupabaseClient,
   tenantId: string,
-  payload: MLWebhookPayload
+  payload: MLWebhookPayload,
+  requestId: string
 ): Promise<{ error?: Error }> {
-  console.log('Processing order webhook for tenant:', tenantId);
+  logger.info('Processing order webhook for tenant', { requestId, tenantId, action: 'process-order' });
 
   try {
     // Get ML auth token for this tenant
@@ -171,7 +173,7 @@ async function processOrderWebhook(
     return {};
 
   } catch (error) {
-    console.error('Error processing order webhook:', error);
+    logger.error('Error processing order webhook', error as Error, { requestId, tenantId, action: 'process-order' });
     return { error: error as Error };
   }
 }
@@ -179,9 +181,10 @@ async function processOrderWebhook(
 async function processItemWebhook(
   supabase: SupabaseClient,
   tenantId: string,
-  payload: MLWebhookPayload
+  payload: MLWebhookPayload,
+  requestId: string
 ): Promise<{ updatedFields?: string[]; error?: Error }> {
-  console.log('Processing item webhook for tenant:', tenantId);
+  logger.info('Processing item webhook for tenant', { requestId, tenantId, action: 'process-item' });
 
   try {
     // Get ML auth token
@@ -231,7 +234,7 @@ async function processItemWebhook(
     return { updatedFields };
 
   } catch (error) {
-    console.error('Error processing item webhook:', error);
+    logger.error('Error processing item webhook', error as Error, { requestId, tenantId, action: 'process-item' });
     return { error: error as Error };
   }
 }

--- a/supabase/functions/ml-webhook/updateProductFromItem.ts
+++ b/supabase/functions/ml-webhook/updateProductFromItem.ts
@@ -1,3 +1,5 @@
+import { logger } from '../shared/logger.ts';
+
 export interface PostgrestResponse<T> {
   data: T | null;
   error: unknown;
@@ -72,7 +74,7 @@ export async function updateProductFromItem(
       description = descData.plain_text || '';
     }
   } catch (e) {
-    console.warn('Could not fetch description:', e);
+    logger.warn('Could not fetch description', { tenantId, error: e });
   }
 
   let categoryPath = '';
@@ -89,7 +91,7 @@ export async function updateProductFromItem(
           .join(' > ');
       }
     } catch (e) {
-      console.warn('Could not fetch category:', e);
+      logger.warn('Could not fetch category', { tenantId, error: e });
     }
   }
 

--- a/supabase/functions/shared/ml-service.ts
+++ b/supabase/functions/shared/ml-service.ts
@@ -2,6 +2,7 @@
 // Shared ML Service Layer - Implementa princípios SOLID e DRY
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders, handleCors } from './cors.ts'
+import { logger } from './logger.ts'
 
 // Types e Interfaces
 export interface MLAuthData {
@@ -67,7 +68,7 @@ export class MLService {
       .single();
 
     if (error || !tokenData) {
-      console.error('ML token not found or expired:', error);
+      logger.error('ML token not found or expired', undefined, { error });
       return null;
     }
 
@@ -81,7 +82,7 @@ export class MLService {
     });
 
     if (error) {
-      console.warn('Rate limit check failed:', error);
+      logger.warn('Rate limit check failed', { error });
       return true; // Allow operation if check fails
     }
 
@@ -115,7 +116,7 @@ export class MLService {
         execution_time_ms: executionTimeMs
       });
     } catch (error) {
-      console.error('Failed to log operation:', error);
+      logger.error('Failed to log operation', undefined, { error });
     }
   }
 
@@ -245,7 +246,7 @@ export class MLService {
 
   // Error handler padronizado
   handleError(error: any, operation: string): Response {
-    console.error(`Error in ${operation}:`, error);
+    logger.error(`Error in ${operation}`, error as Error);
 
     const errorResponse = {
       error: error.message || 'Internal server error',


### PR DESCRIPTION
## Summary
- use shared logger with request-based context for ML webhook handler
- apply structured logging to security monitor and token renewal services
- expose logger in shared ML service utilities

## Testing
- `npm test` *(fails: expected undefined to be true)*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c072be6e6883298020f38d70fba2b7